### PR TITLE
Define tableName and indexes

### DIFF
--- a/model/build.js
+++ b/model/build.js
@@ -119,5 +119,21 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['jobId', 'number']
+    keys: ['jobId', 'number'],
+
+    /**
+     * Tablename to be used in the datastore
+     *
+     * @property tableName
+     * @type {String}
+     */
+    tableName: 'builds',
+
+    /**
+     * List of indexes to create in the datastore
+     *
+     * @property indexes
+     * @type {Array}
+     */
+    indexes: ['jobId', 'parentBuildId']
 };

--- a/model/job.js
+++ b/model/job.js
@@ -71,5 +71,21 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['pipelineId', 'name']
+    keys: ['pipelineId', 'name'],
+
+    /**
+     * Tablename to be used in the datastore
+     *
+     * @property tableName
+     * @type {String}
+     */
+    tableName: 'jobs',
+
+    /**
+     * List of indexes to create in the datastore
+     *
+     * @property indexes
+     * @type {Array}
+     */
+    indexes: ['pipelineId']
 };

--- a/model/pipeline.js
+++ b/model/pipeline.js
@@ -79,5 +79,21 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['scmUrl']
+    keys: ['scmUrl'],
+
+    /**
+     * Tablename to be used in the datastore
+     *
+     * @property tableName
+     * @type {String}
+     */
+    tableName: 'pipelines',
+
+    /**
+     * List of indexes to create in the datastore
+     *
+     * @property indexes
+     * @type {Array}
+     */
+    indexes: ['scmUrl']
 };

--- a/model/platform.js
+++ b/model/platform.js
@@ -94,5 +94,21 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['name', 'version']
+    keys: ['name', 'version'],
+
+    /**
+     * Tablename to be used in the datastore
+     *
+     * @property tableName
+     * @type {String}
+     */
+    tableName: 'platforms',
+
+    /**
+     * List of indexes to create in the datastore
+     *
+     * @property indexes
+     * @type {Array}
+     */
+    indexes: ['scmUrl', 'name']
 };

--- a/model/user.js
+++ b/model/user.js
@@ -39,5 +39,21 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['username']
+    keys: ['username'],
+
+    /**
+     * Tablename to be used in the datastore
+     *
+     * @property tableName
+     * @type {String}
+     */
+    tableName: 'users',
+
+    /**
+     * List of indexes to create in the datastore
+     *
+     * @property indexes
+     * @type {Array}
+     */
+    indexes: ['username']
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,25 @@
+'use strict';
+const assert = require('chai').assert;
+const models = require('../index');
+
+describe('commmons tests', () => {
+    const modelsToCheck = [
+        'pipeline',
+        'build',
+        'job',
+        'platform',
+        'user'
+    ];
+
+    it('selected models have tableName defined', () => {
+        modelsToCheck.forEach((model) => {
+            assert.isString(models[model].tableName);
+        });
+    });
+
+    it('selected models have indexes defined', () => {
+        modelsToCheck.forEach((model) => {
+            assert.isArray(models[model].indexes);
+        });
+    });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,4 +22,10 @@ describe('commmons tests', () => {
             assert.isArray(models[model].indexes);
         });
     });
+
+    it('selected models have keys defined', () => {
+        modelsToCheck.forEach((model) => {
+            assert.isArray(models[model].keys);
+        });
+    });
 });


### PR DESCRIPTION
This PR defines attributes in the data-schema that can be used for automated the creation of tables in a datastore

The models that we need to create tables for now all contain tableName and indexes to create 