### PR TITLE
Labels are throwing off the validator, removing them

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -11,7 +11,6 @@ const SCHEMA_MATRIX = Joi.object()
     // All others are marked as invalid
     .unknown(false)
     // Add documentation
-    .label('Job Matrix')
     .options({
         language: {
             object: {
@@ -28,7 +27,6 @@ const SCHEMA_ENVIRONMENT = Joi.object()
     // All others are marked as invalid
     .unknown(false)
     // Add documentation
-    .label('Environment')
     .options({
         language: {
             object: {
@@ -44,7 +42,6 @@ const SCHEMA_STEPS = Joi.object()
     // All others are marked as invalid
     .unknown(false)
     // Add documentation
-    .label('Steps')
     .options({
         language: {
             object: {
@@ -52,8 +49,7 @@ const SCHEMA_STEPS = Joi.object()
             }
         }
     });
-const SCHEMA_IMAGE = Joi.string()
-    .label('Container Image');
+const SCHEMA_IMAGE = Joi.string();
 const SCHEMA_JOB = Joi.object()
     .keys({
         steps: SCHEMA_STEPS,
@@ -61,8 +57,7 @@ const SCHEMA_JOB = Joi.object()
         matrix: SCHEMA_MATRIX,
         image: SCHEMA_IMAGE
     })
-    .default({})
-    .label('Job');
+    .default({});
 
 /**
  * Various components of a Job

--- a/config/workflow.js
+++ b/config/workflow.js
@@ -7,8 +7,7 @@ const SCHEMA_WORKFLOW = Joi.array()
     // List of jobs
     .items(Joi.string().regex(Regex.JOB_NAME))
     // You cannot trigger the same job twice
-    .unique()
-    .label('Workflow');
+    .unique();
 
 /**
  * The definition of the Workflow pieces


### PR DESCRIPTION
For complex structures like the config, label isn't helping. It's saying Job is broken instead of "main"

With labels:
```js
const Joi = require('joi');
const stepSchema = Joi.string().alphanum().label('Step');
const stepsSchema = Joi.object().keys({
    init: stepSchema,
    test: stepSchema,
    publish: stepSchema
}).label('List of Steps');

const example = {
    init: 'foo',
    test: 'BAD-THINGS_HERE!!!',
    publish: 'bar'
};
Joi.validate(example, stepsSchema).error.toString();
// 'ValidationError: child "Step" fails because ["Step" must only contain alpha-numeric characters]'
```

Without labels:
```js
const Joi = require('joi');
const stepSchema = Joi.string().alphanum();
const stepsSchema = Joi.object().keys({
    init: stepSchema,
    test: stepSchema,
    publish: stepSchema
});

const example = {
    init: 'foo',
    test: 'BAD-THINGS_HERE!!!',
    publish: 'bar'
};
Joi.validate(example, stepsSchema).error.toString();
// 'ValidationError: child "test" fails because ["test" must only contain alpha-numeric characters]'
```