### PR TITLE
Adding JobName to start (this is really only temporary)

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -5,6 +5,7 @@ const buildId = Joi.reach(models.build.base, 'id').required();
 const SCHEMA_START = Joi.object().keys({
     buildId,
     jobId: Joi.reach(models.job.base, 'id').required(),
+    jobName: Joi.reach(models.job.base, 'name').required(),
     pipelineId: Joi.reach(models.pipeline.base, 'id').required(),
     container: Joi.reach(models.build.base, 'container').required(),
     scmUrl: Joi.reach(models.pipeline.base, 'scmUrl').required()

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -1,5 +1,6 @@
 buildId: 8843d7f92416211de9ebb963ff4ce28125932878
 jobId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
+jobName: main
 pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 container: node:4
 scmUrl: git@github.com:screwdriver-cd/data-model.git#master


### PR DESCRIPTION
This is only temporary until we migrate to just passing `buildId`.