### PR TITLE
[F1] New input schema for executor start (1st)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
     "eslint-plugin-import": "^1.12.0",
-    "jenkins-mocha": "^2.6.0",
+    "jenkins-mocha": "^3.0.0",
     "js-yaml": "^3.6.1"
   },
   "dependencies": {

--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -4,11 +4,11 @@ const models = require('../models');
 const buildId = Joi.reach(models.build.base, 'id').required();
 const SCHEMA_START = Joi.object().keys({
     buildId,
-    jobId: Joi.reach(models.job.base, 'id').required(),
-    jobName: Joi.reach(models.job.base, 'name').required(),
-    pipelineId: Joi.reach(models.pipeline.base, 'id').required(),
     container: Joi.reach(models.build.base, 'container').required(),
-    scmUrl: Joi.reach(models.pipeline.base, 'scmUrl').required()
+    apiUri: Joi.string().uri().required()
+        .label('API URI'),
+    token: Joi.string().required()
+        .label('Build JWT')
 }).required();
 const SCHEMA_STOP = Joi.object().keys({
     buildId

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -1,6 +1,4 @@
 buildId: 8843d7f92416211de9ebb963ff4ce28125932878
-jobId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
-jobName: main
-pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 container: node:4
-scmUrl: git@github.com:screwdriver-cd/data-model.git#master
+apiUri: http://localhost:8080
+token: eyJhbGciOiJIUziIsInR5cCI6IkpXVCJ9.eyJ1c2Vybam9obmpvaG5zb24iLCJzY29wZSI6WyJ1c2VyIl0sImlhdCI6MTQ3MDI2NjAwMywiZXhwIjoxNDcwMzA5MjAzfQ.CHaHW2-0wALpWaS4UTXQmSAn_ekMBml-ENEnGhw-9SE


### PR DESCRIPTION
[Feature](https://github.com/screwdriver-cd/screwdriver/issues/77)

Passing:
 - buildId - Build Identifier (to look up stuff)
 - container - Container to start in
 - apiUri - URI to hit our API
 - token - Token to be able to read/write from the API