### PR TITLE
Switching to a new screwdriver.yaml and validator format

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -5,22 +5,35 @@ const Regex = require('../config/regex');
 const Job = require('../config/job');
 const Workflow = require('../config/workflow');
 
+const SCHEMA_JOB_COMMAND = Joi.object()
+    .keys({
+        name: Joi.string(),
+        command: Joi.string()
+    })
+    .unknown(false)
+    .label('Named command to execute');
+
+const SCHEMA_JOB_COMMANDS = Joi.array()
+    .items(SCHEMA_JOB_COMMAND)
+    .min(1)
+    .label('List of named commands to execute');
+
 const SCHEMA_JOB_PERMUTATION = Joi.object()
     .keys({
         image: Job.image,
-        steps: Job.steps,
+        commands: SCHEMA_JOB_COMMANDS,
         environment: Job.environment
     }).label('Job permutation');
 
-const SCHEMA_JOB_PERMUATIONS = Joi.array(SCHEMA_JOB_PERMUTATION)
+const SCHEMA_JOB_PERMUTATIONS = Joi.array().items(SCHEMA_JOB_PERMUTATION)
     .label('List of job permutations');
 
 const SCHEMA_JOBS = Joi.object()
     .keys({
-        main: SCHEMA_JOB_PERMUATIONS.required()
+        main: SCHEMA_JOB_PERMUTATIONS.required()
     })
     // Jobs can only be named with A-Z,a-z,0-9,-,_
-    .pattern(Regex.JOB_NAME, SCHEMA_JOB_PERMUATIONS)
+    .pattern(Regex.JOB_NAME, SCHEMA_JOB_PERMUTATIONS)
     // All others are marked as invalid
     .unknown(false)
     .label('List of available job configurations');

--- a/config/job.js
+++ b/config/job.js
@@ -35,12 +35,15 @@ const SCHEMA_ENVIRONMENT = Joi.object()
             }
         }
     });
-const SCHEMA_STEPS = Joi.object()
+const SCHEMA_STEP_STRING = Joi.string();
+const SCHEMA_STEP_OBJECT = Joi.object()
     // Steps can only be named with A-Z,a-z,0-9,-,_
     // Steps only contain strings (the command to execute)
     .pattern(Regex.STEP_NAME, Joi.string())
     // All others are marked as invalid
     .unknown(false)
+    // And there can be only one command per step
+    .length(1)
     // Add documentation
     .options({
         language: {
@@ -49,6 +52,8 @@ const SCHEMA_STEPS = Joi.object()
             }
         }
     });
+const SCHEMA_STEP = Joi.alternatives().try(SCHEMA_STEP_STRING, SCHEMA_STEP_OBJECT);
+const SCHEMA_STEPS = Joi.array().items(SCHEMA_STEP).min(1);
 const SCHEMA_IMAGE = Joi.string();
 const SCHEMA_JOB = Joi.object()
     .keys({
@@ -66,6 +71,7 @@ const SCHEMA_JOB = Joi.object()
 module.exports = {
     matrix: SCHEMA_MATRIX,
     steps: SCHEMA_STEPS,
+    step: SCHEMA_STEP,
     environment: SCHEMA_ENVIRONMENT,
     image: SCHEMA_IMAGE,
     job: SCHEMA_JOB

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/test/data/config.base.config.yaml
+++ b/test/data/config.base.config.yaml
@@ -13,13 +13,13 @@ jobs:
                 - 6
         image: node:{{NODE_VERSION}}
         steps:
-            init: npm install
-            test: npm test
+            - init: npm install
+            - test: npm test
 
     publish:
         image: node:4
         steps:
-            publish: npm publish
+            - publish: npm publish
 
 workflow:
     - publish

--- a/test/data/config.base.jobs.yaml
+++ b/test/data/config.base.jobs.yaml
@@ -8,10 +8,10 @@ main:
             - 6
     image: node:{{NODE_VERSION}}
     steps:
-        init: npm install
-        test: npm test
+        - init: npm install
+        - test: npm test
 
 publish:
     image: node:4
     steps:
-        publish: npm publish
+        - publish: npm publish

--- a/test/data/config.base.shared.yaml
+++ b/test/data/config.base.shared.yaml
@@ -7,6 +7,6 @@ matrix:
         - 6
 image: node:{{NODE_VERSION}}
 steps:
-    init: npm install
-    test: npm test
-    publish: npm publish
+    - init: npm install
+    - test: npm test
+    - publish: npm publish

--- a/test/data/config.job.job.yaml
+++ b/test/data/config.job.job.yaml
@@ -7,6 +7,6 @@ matrix:
         - 6
 image: node:{{NODE_VERSION}}
 steps:
-    init: npm install
-    test: npm test
-    publish: npm publish
+    - init: npm install
+    - test: npm test
+    - publish: npm publish

--- a/test/data/config.job.steps.yaml
+++ b/test/data/config.job.steps.yaml
@@ -1,3 +1,3 @@
-init: npm install
-test: npm test
-publish: npm publish
+- init: npm install
+- test: npm test
+- npm publish

--- a/test/data/validator.output.yaml
+++ b/test/data/validator.output.yaml
@@ -1,31 +1,41 @@
 jobs:
   main:
   - image: node:4
-    steps:
-      install: npm install
-      test: npm test
-      build: npm run build
+    commands:
+      - name: install
+        command: npm install
+      - name: test
+        command: npm test
+      - name: build
+        command: npm run build
     environment:
       NODE_VERSION: 4
   - image: node:5
-    steps:
-      install: npm install
-      test: npm test
-      build: npm run build
+    commands:
+    - name: install
+      command: npm install
+    - name: test
+      command: npm test
+    - name: build
+      command: npm run build
     environment:
       NODE_VERSION: 5
   - image: node:6
-    steps:
-      install: npm install
-      test: npm test
-      build: npm run build
+    commands:
+    - name: install
+      command: npm install
+    - name: test
+      command: npm test
+    - name: build
+      command: npm run build
     environment:
       NODE_VERSION: 6
 
   publish:
   - image: node:4
-    steps:
-      install: npm publish
+    commands:
+    - name: install
+      command: npm publish
     environment: {}
 
 workflow:


### PR DESCRIPTION
This has a new format for the validator (to be json valid):

```json
{"name": "install", "command": "npm install"}
```

It also changes the screwdriver.yaml with a new step format:
```yaml
steps:
  - npm install
  - install: npm install
```