### PR TITLE
Add container to job schema

### DIFF
--- a/models/job.js
+++ b/models/job.js
@@ -14,6 +14,11 @@ const MODEL = {
         .description('Name of the Job')
         .example('main'),
 
+    container: Joi
+        .string()
+        .description('Container this build is running in')
+        .example('node:4'),
+
     description: Joi
         .string().max(100)
         .description('Description of the Job')
@@ -52,7 +57,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'pipelineId', 'name', 'state'
     ], [
-        'description'
+        'description', 'container'
     ])).label('Get Job'),
 
     /**
@@ -61,9 +66,10 @@ module.exports = {
      * @property update
      * @type {Joi}
      */
-    update: Joi.object(mutate(MODEL, [
-        'state'
-    ], [])).label('Update Job'),
+    update: Joi.object(mutate(MODEL, [], [
+        'state',
+        'container'
+    ])).label('Update Job'),
 
     /**
      * List of fields that determine a unique row

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/test/data/job.update.yaml
+++ b/test/data/job.update.yaml
@@ -1,1 +1,2 @@
 state: 'ENABLED'
+container: node:6

--- a/test/data/job.yaml
+++ b/test/data/job.yaml
@@ -3,3 +3,4 @@ id: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 name: component
 pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 state: ENABLED
+container: node:6


### PR DESCRIPTION
Job schema should have container so when we create builds, we can look up this information 