### PR TITLE
Optional ref parameter

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -26,7 +26,8 @@ const UPDATE_COMMIT_STATUS = Joi.object().keys({
 const GET_FILE = Joi.object().keys({
     scmUrl,
     token,
-    path: Joi.string().required()
+    path: Joi.string().required(),
+    ref: Joi.string().optional()
 }).required();
 
 module.exports = {

--- a/test/data/scm.getFile.yaml
+++ b/test/data/scm.getFile.yaml
@@ -1,3 +1,4 @@
-scmUrl: 'git@github.com:screwdriver-cd/hashr.git#master'
-token: 'thisisatokenthingy'
-path: 'screwdriver.yaml'
+scmUrl: git@github.com:screwdriver-cd/hashr.git#master
+token: thisisatokenthingy
+path: screwdriver.yaml
+ref: 46f1a0bd5592a2f9244ca321b129902a06b53e03

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -33,4 +33,14 @@ describe('scm test', () => {
             assert.isNotNull(validate('empty.yaml', scm.updateCommitStatus).error);
         });
     });
+
+    describe('getFile', () => {
+        it('validates', () => {
+            assert.isNull(validate('scm.getFile.yaml', scm.getFile).error);
+        });
+
+        it('fails', () => {
+            assert.isNotNull(validate('empty.yaml', scm.getFile).error);
+        });
+    });
 });


### PR DESCRIPTION
When reading a file from source-control it should be possible to pass a reference, i.e. commit, branch, or tag, that will be used for reading the file

