### PR TITLE
date to isoDate

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -40,15 +40,18 @@ const MODEL = {
         .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'),
 
     createTime: Joi
-        .date()
+        .string()
+        .isoDate()
         .description('When this build was created'),
 
     startTime: Joi
-        .date()
+        .string()
+        .isoDate()
         .description('When this build started on a build machine'),
 
     endTime: Joi
-        .date()
+        .string()
+        .isoDate()
         .description('When this build stopped running'),
 
     parameters: Joi

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -20,7 +20,8 @@ const MODEL = {
         .example('git@github.com:screwdriver-cd/optional-config.git#master'),
 
     createTime: Joi
-        .date()
+        .string()
+        .isoDate()
         .description('When this pipeline was created'),
 
     admins: Joi

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -4,4 +4,4 @@ jobId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 number: 15
 cause: Commit ccc493 was pushed to master
 status: SUCCESS
-createTime: 2017-04-20
+createTime: "2017-04-20"

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -6,9 +6,9 @@ number: 15.1
 container: node:4
 cause: Because I clicked it
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
-createTime: 2038-01-19 03:14:08
-startTime: 2038-01-19 03:15:08
-endTime: 2038-01-19 03:16:10
+createTime: "2038-01-19T03:14:08.131Z"
+startTime: "2038-01-19T03:15:08.131Z"
+endTime: "2038-01-19T03:16:10.131Z"
 parameters:
     desired: 123456
 meta:

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -1,6 +1,6 @@
 # Pipeline Get Example
 id: 2d991790bab1ac8576097ca87f170df73410b55c
 scmUrl: git@github.com:screwdriver-cd/data-model.git#master
-createTime: 2017-04-11
+createTime: "2017-04-11"
 admins:
     username: true

--- a/test/data/pipeline.yaml
+++ b/test/data/pipeline.yaml
@@ -2,4 +2,4 @@
 id: 2d991790bab1ac8576097ca87f170df73410b55c
 scmUrl: git@github.com:screwdriver-cd/data-model.git#master
 configUrl: git@github.com:screwdriver-cd/external-config.git#master
-createTime: 2017-04-19 14:55:11 UTC
+createTime: "2017-04-19T14:55:11" 


### PR DESCRIPTION
changed from .date() to .string().isoDate() so codegen will work and we ensure compliance with swagger spec for dateTime formatting. http://swagger.io/specification/ and definition of date-time standard. http://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14