### PR TITLE
Allow meta to be passed during update

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -158,7 +158,9 @@ module.exports = {
      */
     update: Joi.object(mutate(MODEL, [
         'status'
-    ], [])).label('Update Build'),
+    ], [
+        'meta'
+    ])).label('Update Build'),
 
     /**
      * Properties for Build that will be passed during a CREATE request

--- a/test/data/build.update.yaml
+++ b/test/data/build.update.yaml
@@ -1,2 +1,4 @@
 # Build Update Example
 status: ABORTED
+meta:
+    yes: no


### PR DESCRIPTION
This allows us to get rid of /webhooks/build and replace it with PUT /builds/:id