### PR TITLE
Adding secrets to jobs and renaming the secret value

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -19,6 +19,11 @@ const SCHEMA_MATRIX = Joi.object()
             }
         }
     });
+// Secrets must be all uppercase
+const SCHEMA_SECRET = Joi.string().regex(Regex.ENV_NAME).max(25);
+const SCHEMA_SECRETS = Joi.array()
+    .items(SCHEMA_SECRET)
+    .min(0);
 const SCHEMA_ENVIRONMENT = Joi.object()
     // IEEE Std 1003.1-2001
     // Environment names contain uppercase letters, digits, and underscore
@@ -60,7 +65,8 @@ const SCHEMA_JOB = Joi.object()
         steps: SCHEMA_STEPS,
         environment: SCHEMA_ENVIRONMENT,
         matrix: SCHEMA_MATRIX,
-        image: SCHEMA_IMAGE
+        image: SCHEMA_IMAGE,
+        secrets: SCHEMA_SECRETS
     })
     .default({});
 
@@ -70,6 +76,8 @@ const SCHEMA_JOB = Joi.object()
  */
 module.exports = {
     matrix: SCHEMA_MATRIX,
+    secret: SCHEMA_SECRET,
+    secrets: SCHEMA_SECRETS,
     steps: SCHEMA_STEPS,
     step: SCHEMA_STEP,
     environment: SCHEMA_ENVIRONMENT,

--- a/models/secret.js
+++ b/models/secret.js
@@ -1,6 +1,7 @@
 'use strict';
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
+const Job = require('../config/job');
 
 const MODEL = {
     id: Joi
@@ -13,13 +14,11 @@ const MODEL = {
         .description('pipeline associated with the secret')
         .example('2d991790bab1ac8576097ca87f170df73410b55c'),
 
-    name: Joi
-        .string().regex(/^[A-Za-z0-9_-]+$/)
-        .max(25)
+    name: Job.secret
         .description('Name of the secret')
         .example('NPM_TOKEN'),
 
-    token: Joi
+    value: Joi
         .string()
         .description('value of the secret')
         .example('2d991790bab1ac8576097ca87f170df73410b55c'),
@@ -45,7 +44,7 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'pipelineId', 'name', 'token', 'allowInPR'
+        'id', 'pipelineId', 'name', 'value', 'allowInPR'
     ], [])).label('Get Secret'),
 
     /**
@@ -55,7 +54,7 @@ module.exports = {
      * @type {Joi}
      */
     create: Joi.object(mutate(MODEL, [
-        'pipelineId', 'name', 'token', 'allowInPR'
+        'pipelineId', 'name', 'value', 'allowInPR'
     ], [])).label('Create Secret'),
 
     /**
@@ -72,7 +71,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['pipleineId', 'name'],
+    keys: ['pipelineId', 'name'],
 
     /**
      * List of all fields in the model

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -22,6 +22,12 @@ describe('config job', () => {
         });
     });
 
+    describe('secrets', () => {
+        it('validates secrets', () => {
+            assert.isNull(validate('config.job.secrets.yaml', config.job.secrets).error);
+        });
+    });
+
     describe('environment', () => {
         it('validates environment', () => {
             assert.isNull(validate('config.job.environment.yaml', config.job.environment).error);

--- a/test/data/config.base.config.yaml
+++ b/test/data/config.base.config.yaml
@@ -20,6 +20,8 @@ jobs:
         image: node:4
         steps:
             - publish: npm publish
+        secrets:
+            - NPM_TOKEN
 
 workflow:
     - publish

--- a/test/data/config.base.jobs.yaml
+++ b/test/data/config.base.jobs.yaml
@@ -15,3 +15,5 @@ publish:
     image: node:4
     steps:
         - publish: npm publish
+    secrets:
+        - NPM_TOKEN

--- a/test/data/config.job.secrets.yaml
+++ b/test/data/config.job.secrets.yaml
@@ -1,0 +1,2 @@
+- NPM_TOKEN
+- GIT_KEY

--- a/test/data/secret.create.yaml
+++ b/test/data/secret.create.yaml
@@ -1,5 +1,5 @@
 # Secret create Example
 pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 name: NPM_TOKEN
-token: banana
+value: banana
 allowInPR: false

--- a/test/data/secret.get.yaml
+++ b/test/data/secret.get.yaml
@@ -2,5 +2,5 @@
 id: 7babc233de26ab19ead1b9c278128d5c434910ee
 pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 name: NPM_TOKEN
-token: banana
+value: banana
 allowInPR: true

--- a/test/data/secret.yaml
+++ b/test/data/secret.yaml
@@ -2,4 +2,4 @@
 id: 7babc233de26ab19ead1b9c278128d5c434910ee
 pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 name: NPM_TOKEN
-token: banana
+value: banana


### PR DESCRIPTION
This adds secrets to the job configuration.  Example:
```yaml
jobs:
  main:
    secrets:
      - NPM_TOKEN
```

Feature: https://github.com/screwdriver-cd/screwdriver/issues/148