### PR TITLE
Define sorting key for build model

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -207,6 +207,14 @@ module.exports = {
     keys: ['jobId', 'number'],
 
     /**
+     * Primary column to sort queries by.
+     * This defines queries to optionally sort a query result set by build number
+     *
+     * @type {String}
+     */
+    rangeKey: 'number',
+
+    /**
      * List of all fields in the model
      * @property allKeys
      * @type {Array}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/test/models/index.test.js
+++ b/test/models/index.test.js
@@ -28,4 +28,10 @@ describe('model commmons', () => {
             assert.isArray(models[model].allKeys);
         });
     });
+
+    it('selected models have rangeKeys defined', () => {
+        const buildModel = models.build;
+
+        assert.strictEqual(buildModel.rangeKey, 'number');
+    });
 });


### PR DESCRIPTION
Define a primary sorting key for the `build` model.

When you perform a query for a set of build models, they are in a non-specific order. This defines a column to sort the data by.