### PR TITLE
Allow sort in the scan config

### DIFF
--- a/api/pagination.js
+++ b/api/pagination.js
@@ -11,7 +11,13 @@ const MODEL = {
         .number().integer().min(1)
         .max(50)
         .default(50)
-        .description('Count to paginate')
+        .description('Count to paginate'),
+
+    sort: Joi
+        .string().lowercase()
+        .valid(['ascending', 'descending'])
+        .default('descending')
+        .description('Sorting option')
 };
 
 /**

--- a/models/build.js
+++ b/models/build.js
@@ -36,8 +36,8 @@ const MODEL = {
 
     number: Joi
         .number().positive()
-        .description('Incrementing number of a Job')
-        .example(15),
+        .description('Timestamp of create time')
+        .example(1473900790309),
 
     container: Joi
         .string()

--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -15,13 +15,14 @@ const SCHEMA_DATA = Joi.object().keys({
         data: Joi.object().required()
     }).required()
 });
-const SCHEMA_PAGINATE = Joi.object().keys({
+const SCHEMA_SCAN = Joi.object().keys({
     table,
     params: Joi.object(),
     paginate: Joi.object().keys({
-        count: Joi.number().required(),
-        page: Joi.number().required()
-    }).required()
+        count: Joi.number().integer().positive().required(),
+        page: Joi.number().integer().positive().required()
+    }).required(),
+    sort: Joi.string().lowercase().valid(['ascending', 'descending']).default('descending')
 });
 
 module.exports = {
@@ -63,5 +64,5 @@ module.exports = {
      * @property create
      * @type {Joi}
      */
-    scan: SCHEMA_PAGINATE
+    scan: SCHEMA_SCAN
 };

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -1,7 +1,7 @@
 # Build Get Example
 id: 4b8d9b530d2e5e297b4f470d5b0a6e1310d29c5e
 jobId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
-number: 15
+number: 1473900790309
 cause: Commit ccc493 was pushed to master
 status: SUCCESS
 createTime: "2017-04-20"

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -2,7 +2,7 @@
 id: 8843d7f92416211de9ebb963ff4ce28125932878
 jobId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 parentBuildId: d8fd39d0bbdd2dcf322d8b11390a4c5825b11495
-number: 15.1
+number: 1473900790309.1
 container: node:4
 cause: Because I clicked it
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03

--- a/test/data/pagination.yaml
+++ b/test/data/pagination.yaml
@@ -1,2 +1,3 @@
 page: 3
 count: 30
+sort: 'ascending'


### PR DESCRIPTION
Add `sort` to the allowed keys. This prepares for the datastore change so that we can sort

Solves https://github.com/screwdriver-cd/screwdriver/issues/187