### PR TITLE
Define multiple rangeKeys

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -208,11 +208,13 @@ module.exports = {
 
     /**
      * Primary column to sort queries by.
-     * This defines queries to optionally sort a query result set by build number
+     * This defines queries to optionally sort a query result set by build number.
+     * Each range key matches up with an element in the indexes property
      *
-     * @type {String}
+     * @property rangeKeys
+     * @type {Array}
      */
-    rangeKey: 'number',
+    rangeKeys: ['number', null],
 
     /**
      * List of all fields in the model

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "11.2.0",
+  "version": "12.0.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/test/models/index.test.js
+++ b/test/models/index.test.js
@@ -32,6 +32,6 @@ describe('model commmons', () => {
     it('selected models have rangeKeys defined', () => {
         const buildModel = models.build;
 
-        assert.strictEqual(buildModel.rangeKey, 'number');
+        assert.deepEqual(buildModel.rangeKeys, ['number', null]);
     });
 });


### PR DESCRIPTION
This PR addresses the case where we need to have multiple range keys -- or fewer range keys than indices. We cannot decorate the `indexes` property, since the `rangeKey` property is specific to only one datastore (dynamodb).

Blocked by #51 
Solves https://github.com/screwdriver-cd/screwdriver/issues/187