### PR TITLE
[1] Add "archive" attribute to job model

### DIFF
--- a/models/job.js
+++ b/models/job.js
@@ -34,7 +34,13 @@ const MODEL = {
         ])
         .description('Current state of the Job')
         .example('ENABLED')
-        .default('ENABLED')
+        .default('ENABLED'),
+
+    archived: Joi
+        .boolean()
+        .description('Flag if the job is archived')
+        .example(true)
+        .default(false)
 };
 
 module.exports = {
@@ -55,7 +61,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'pipelineId', 'name', 'state'
     ], [
-        'description', 'permutations'
+        'description', 'permutations', 'archived'
     ])).label('Get Job'),
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "12.0.0",
+  "version": "12.1.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/test/data/job.get.yaml
+++ b/test/data/job.get.yaml
@@ -4,3 +4,4 @@ name: main
 description: build and test the code
 pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 state: ENABLED
+archived: false


### PR DESCRIPTION
This PR adds an archive attribute to the job model. The purpose of this additional field is to flag a specific job as active or archived. Related to screwdriver-cd/screwdriver#188

Jobs that are associated with open PRs workflow jobs are considered to be active. 

Jobs that are associated with closed/merged PRs or are jobs used outside of the workflow are considered to be archived.



