### PR TITLE
Allow to store scmRepo object to pipeline

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -77,10 +77,10 @@ module.exports = {
      * @type {Joi}
      */
     create: Joi.object(mutate(MODEL, [
-        'scmUrl',
-        'scmRepo'
+        'scmUrl'
     ], [
-        'configUrl'
+        'configUrl',
+        'scmRepo'
     ])).label('Create Pipeline'),
 
     /**
@@ -89,7 +89,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['scmRepo.id'],
+    keys: ['scmUrl'],
 
     /**
      * List of all fields in the model

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -3,6 +3,7 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Regex = require('../config/regex');
 const Workflow = require('../config/workflow');
+const Scm = require('../core/scm');
 
 const MODEL = {
     id: Joi
@@ -19,6 +20,8 @@ const MODEL = {
         .string().regex(Regex.SCM_URL)
         .description('Source Code URL for Screwdriver configuration')
         .example('git@github.com:screwdriver-cd/optional-config.git#master'),
+
+    scmRepo: Scm.repo,
 
     createTime: Joi
         .string()
@@ -74,7 +77,8 @@ module.exports = {
      * @type {Joi}
      */
     create: Joi.object(mutate(MODEL, [
-        'scmUrl'
+        'scmUrl',
+        'scmRepo'
     ], [
         'configUrl'
     ])).label('Create Pipeline'),
@@ -85,7 +89,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['scmUrl'],
+    keys: ['scmRepo.id'],
 
     /**
      * List of all fields in the model

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "12.1.0",
+  "version": "13.0.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "13.0.0",
+  "version": "12.1.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/test/data/pipeline.create.yaml
+++ b/test/data/pipeline.create.yaml
@@ -1,3 +1,7 @@
 # Pipeline Create Example
 scmUrl: git@github.com:screwdriver-cd/data-model.git#master
 configUrl: git@github.com:screwdriver-cd/sample-config.git#master
+scmRepo:
+    id: github.com:123456:master
+    url: https://github.com/screwdriver-cd/data-model/tree/master
+    name: screwdriver-cd/data-model


### PR DESCRIPTION
This PR allows to store scmRepo object to a pipeline. 
(screwdriver-cd/screwdriver#194 and screwdriver-cd/screwdriver#160)