### PR TITLE
Fixing the pipeline model for scmRepo and removing configUrl

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -16,11 +16,6 @@ const MODEL = {
         .description('Source Code URL for the application')
         .example('git@github.com:screwdriver-cd/data-model.git#master'),
 
-    configUrl: Joi
-        .string().regex(Regex.SCM_URL)
-        .description('Source Code URL for Screwdriver configuration')
-        .example('git@github.com:screwdriver-cd/optional-config.git#master'),
-
     scmRepo: Scm.repo,
 
     createTime: Joi
@@ -55,7 +50,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'scmUrl', 'createTime', 'admins'
     ], [
-        'configUrl', 'workflow'
+        'workflow', 'scmRepo'
     ])).label('Get Pipeline'),
 
     /**
@@ -66,9 +61,7 @@ module.exports = {
      */
     update: Joi.object(mutate(MODEL, [
         'scmUrl'
-    ], [
-        'configUrl'
-    ])).label('Update Pipeline'),
+    ], [])).label('Update Pipeline'),
 
     /**
      * Properties for Pipeline that will be passed during a CREATE request
@@ -78,10 +71,7 @@ module.exports = {
      */
     create: Joi.object(mutate(MODEL, [
         'scmUrl'
-    ], [
-        'configUrl',
-        'scmRepo'
-    ])).label('Create Pipeline'),
+    ], [])).label('Create Pipeline'),
 
     /**
      * List of fields that determine a unique row

--- a/test/data/pipeline.create.yaml
+++ b/test/data/pipeline.create.yaml
@@ -1,7 +1,2 @@
 # Pipeline Create Example
 scmUrl: git@github.com:screwdriver-cd/data-model.git#master
-configUrl: git@github.com:screwdriver-cd/sample-config.git#master
-scmRepo:
-    id: github.com:123456:master
-    url: https://github.com/screwdriver-cd/data-model/tree/master
-    name: screwdriver-cd/data-model

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -7,3 +7,7 @@ admins:
 workflow:
     - main
     - publish
+scmRepo:
+    id: github.com:123456:master
+    url: https://github.com/screwdriver-cd/data-model/tree/master
+    name: screwdriver-cd/data-model

--- a/test/data/pipeline.update.yaml
+++ b/test/data/pipeline.update.yaml
@@ -1,3 +1,2 @@
 # Pipeline Update Example
 scmUrl: git@github.com:screwdriver-cd/data-model.git#master
-configUrl: git@github.com:screwdriver-cd/sample-config.git#master

--- a/test/data/pipeline.yaml
+++ b/test/data/pipeline.yaml
@@ -1,5 +1,8 @@
 # Pipeline Example
 id: 2d991790bab1ac8576097ca87f170df73410b55c
 scmUrl: git@github.com:screwdriver-cd/data-model.git#master
-configUrl: git@github.com:screwdriver-cd/external-config.git#master
-createTime: "2017-04-19T14:55:11" 
+createTime: "2017-04-19T14:55:11"
+scmRepo:
+    id: github.com:123456:master
+    url: https://github.com/screwdriver-cd/data-model/tree/master
+    name: screwdriver-cd/data-model


### PR DESCRIPTION
We have 0 code in our system for `configUrl` right now, so I'm removing it until we want to bring it back.

Additionally, we need to return `scmRepo` as part of the GET and we dont' want users to pass it to us during create, it's a auto-generated value.