### PR TITLE
Add update secret schema

### DIFF
--- a/models/secret.js
+++ b/models/secret.js
@@ -58,12 +58,12 @@ module.exports = {
     ], [])).label('Create Secret'),
 
     /**
-     * Properties for secret that will be passed during a DELETE request
+     * Properties for secret that will be passed during a UPDATE request
      *
-     * @property remove
+     * @property update
      * @type {Joi}
      */
-    remove: Joi.object(mutate(MODEL, ['id'], [])).label('Remove Secret'),
+    update: Joi.object(mutate(MODEL, [], ['value', 'allowInPR'])).label('Update Secret'),
 
     /**
      * List of fields that determine a unique row

--- a/test/data/secret.remove.yaml
+++ b/test/data/secret.remove.yaml
@@ -1,2 +1,0 @@
-# Secret DELETE Example
-id: 7babc233de26ab19ead1b9c278128d5c434910ee

--- a/test/data/secret.update.yaml
+++ b/test/data/secret.update.yaml
@@ -1,0 +1,3 @@
+# Secret UPDATE Example
+value: bar
+allowInPR: true

--- a/test/models/secret.test.js
+++ b/test/models/secret.test.js
@@ -30,13 +30,13 @@ describe('model secret', () => {
         });
     });
 
-    describe('remove', () => {
-        it('validates the remove', () => {
-            assert.isNull(validate('secret.remove.yaml', models.secret.remove).error);
+    describe('update', () => {
+        it('validates the update', () => {
+            assert.isNull(validate('secret.update.yaml', models.secret.update).error);
         });
 
-        it('fails the remove', () => {
-            assert.isNotNull(validate('empty.yaml', models.secret.remove).error);
+        it('fails the update', () => {
+            assert.isNotNull(validate('empty.yaml', models.secret.update).error);
         });
     });
 });


### PR DESCRIPTION
- Add `update` schema to secret to allow update on `value` or/and `allowInPR`
- Remove `remove` schema from secret since we are not using it

First PR in  [Issue #232](https://github.com/screwdriver-cd/screwdriver/issues/232)