### PR TITLE
Allow validator output to contain a list of errors.

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -42,7 +42,8 @@ const SCHEMA_JOBS = Joi.object()
 const SCHEMA_OUTPUT = Joi.object()
     .keys({
         jobs: SCHEMA_JOBS,
-        workflow: Workflow.workflow
+        workflow: Workflow.workflow,
+        errors: Joi.array().items(Joi.string()).optional()
     })
     .label('Execution information');
 

--- a/test/api/validator.test.js
+++ b/test/api/validator.test.js
@@ -15,5 +15,9 @@ describe('api validator', () => {
         it('validates basic output', () => {
             assert.isNull(validate('validator.output.yaml', api.validator.output).error);
         });
+
+        it('validates basic output with errors', () => {
+            assert.isNull(validate('validator.erroroutput.yaml', api.validator.output).error);
+        });
     });
 });

--- a/test/data/validator.erroroutput.yaml
+++ b/test/data/validator.erroroutput.yaml
@@ -1,0 +1,12 @@
+jobs:
+  main:
+  - image: alpine
+    commands:
+      - name: config-parse-error
+        command: echo "something went wrong"; exit 1
+
+workflow:
+- main
+
+errors:
+- something went wrong


### PR DESCRIPTION
Right now we have no way of surfacing parse errors from the API. This PR adds another key to the output `errors` to contain any parse errors. This will allow a future validator UI to more easily display these errors.