### PR TITLE
Allow display name to be null

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -11,7 +11,8 @@ const SCHEMA_USER = Joi.object().keys({
         .example('https://github.com/stjohnjohnson'),
 
     name: Joi.string()
-        .required()
+        .optional()
+        .allow(null)
         .label('Display Name')
         .example('Dao Lam'),
 


### PR DESCRIPTION
- Display name can be null for github users
![image](https://cloud.githubusercontent.com/assets/20427140/19464727/9e6f4e14-94b3-11e6-80bc-4d74ef6fac99.png)
