### PR TITLE
[3] Revert "add getFileRef schema for scm.getFile() to take in prRef"

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -36,12 +36,6 @@ const GET_FILE = Joi.object().keys({
     ref: Joi.string().optional()
 }).required();
 
-const GET_FILE_REF = Joi.object().keys({
-    token,
-    path: Joi.string().required(),
-    ref: Joi.string().required()
-}).required();
-
 const DECORATE_URL = Joi.object().keys({
     scmUri,
     token
@@ -95,14 +89,6 @@ module.exports = {
      * @type {Joi}
      */
     getFile: GET_FILE,
-
-    /**
-     * Properties for Scm Base that will be passed for the getFile method when there is no scmUri
-     *
-     * @property getFileRef
-     * @type {Joi}
-     */
-    getFileRef: GET_FILE_REF,
 
     /**
      * Properties for Scm Base that will be passed for the decorateUrl method

--- a/test/data/scm.getFile.yaml
+++ b/test/data/scm.getFile.yaml
@@ -1,4 +1,4 @@
 scmUri: github.com:12345678:master
 token: thisisatokenthingy
 path: screwdriver.yaml
-ref: git@github.com:screwdriver-cd-test/functional-git.git#pull/453/merge
+ref: 46f1a0bd5592a2f9244ca321b129902a06b53e03

--- a/test/data/scm.getFileRef.yaml
+++ b/test/data/scm.getFileRef.yaml
@@ -1,3 +1,0 @@
-token: thisisatokenthingy
-path: screwdriver.yaml
-ref: git@github.com:screwdriver-cd-test/functional-git.git#pull/453/merge

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -45,16 +45,6 @@ describe('scm test', () => {
         });
     });
 
-    describe('getFileRef', () => {
-        it('validates', () => {
-            assert.isNull(validate('scm.getFileRef.yaml', scm.getFileRef).error);
-        });
-
-        it('fails', () => {
-            assert.isNotNull(validate('empty.yaml', scm.getFileRef).error);
-        });
-    });
-
     describe('decorateUrl', () => {
         it('validates', () => {
             assert.isNull(validate('scm.decorateUrl.yaml', scm.decorateUrl).error);


### PR DESCRIPTION
Not using this anymore. Should be merged after https://github.com/screwdriver-cd/scm-base/pull/19