### PR TITLE
Add event uuid to scm parseHook schema

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -68,6 +68,10 @@ const SCHEMA_HOOK = Joi.object().keys({
         .required()
         .label('Type of the event'),
 
+    hookId: Joi.string()
+        .required()
+        .label('Uuid of the event'),
+
     action: Joi.alternatives()
         .when('type', { is: 'pr', then: Joi.valid(['opened', 'closed', 'synchronized']) })
         .when('type', { is: 'repo', then: Joi.valid('push') })

--- a/test/data/scm.hook.yaml
+++ b/test/data/scm.hook.yaml
@@ -1,5 +1,6 @@
 # SCM Hook example
 type: pr
+hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 action: opened
 prNum: 123
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master


### PR DESCRIPTION
- Add event uuid to parseHook schema
- It will be needed in API when we switch to parseHook for getting all event data
- https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/webhooks/github.js#L339