### PR TITLE
Add eventId to build schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## 15.0.0
+
+Breaking changes:
+  * `eventId` should be returned when a GET request is made on a build.

--- a/models/build.js
+++ b/models/build.js
@@ -26,9 +26,14 @@ const MODEL = {
         .description('Identifier of this build')
         .example('4b8d9b530d2e5e297b4f470d5b0a6e1310d29c5e'),
 
+    eventId: Joi
+        .string().hex().length(40)
+        .description('Identifier of the event')
+        .example('50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0'),
+
     jobId: Joi
         .string().hex().length(40)
-        .description('Identifier of the Job')
+        .description('Identifier of the job')
         .example('50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0'),
 
     parentBuildId: Joi
@@ -117,7 +122,7 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'jobId', 'number', 'cause', 'createTime', 'status'
+        'id', 'eventId', 'jobId', 'number', 'cause', 'createTime', 'status'
     ], [
         'container', 'parentBuildId', 'sha', 'startTime', 'endTime', 'meta', 'parameters', 'steps',
         'commit'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "14.2.0",
+  "version": "15.0.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -1,5 +1,6 @@
 # Build Get Example
 id: 4b8d9b530d2e5e297b4f470d5b0a6e1310d29c5e
+eventId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 jobId: 50dc14f719cdc2c9cb1fb0e49dd2acc4cf6189a0
 number: 1473900790309
 cause: Commit ccc493 was pushed to master


### PR DESCRIPTION
Builds should know which event they are associated with; updating build schema to include an `eventId` when a GET request is made 

Related to https://github.com/screwdriver-cd/screwdriver/issues/221