### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+ci/
+.editorconfig
+eslint*
+CONTRIBUTING.md
+screwdriver.yaml
+test/
+features/

--- a/config/regex.js
+++ b/config/regex.js
@@ -15,7 +15,7 @@ module.exports = {
     ENV_NAME: /^[A-Z_][A-Z0-9_]*$/,
     // Repo checkout url. For example: https://github.com/screwdriver-cd/data-schema.git#branchName or git@github.com:screwdriver-cd/data-schema.git
     // eslint-disable-next-line max-len
-    CHECKOUT_URL: /^(?:(?:https?|git):\/\/)?(?:[^@]+@)?([^\/:]+)(?:\/|:)([^\/]+)\/([^.#]+)(?:\.git)?(#.+)?$/,
+    CHECKOUT_URL: /^(?:(?:https?|git):\/\/)?(?:[^@]+@)?([^/:]+)(?:\/|:)([^/]+)\/([^.#]+)(?:\.git)?(#.+)?$/,
     // scmUri. For example: github.com:abc-123:master or bitbucket.org:{123}:master
     SCM_URI: /^([^:]+):([^:]+):([^:]+)$/
 };


### PR DESCRIPTION
So we don't bundle extra files in our packages

Related to https://github.com/screwdriver-cd/screwdriver/issues/324
