### PR TITLE
Remove event status

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -31,16 +31,6 @@ const MODEL = {
         .string().hex()
         .description('SHA this project was built on')
         .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'),
-    status: Joi
-        .string().valid([
-            'SUCCESS',
-            'FAILURE',
-            'ABORTED',
-            'RUNNING'
-        ])
-        .description('Current status of the event')
-        .example('SUCCESS')
-        .default('RUNNING'),
     type: Joi
         .string().valid([
             'pr',
@@ -76,7 +66,7 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'status', 'type', 'workflow'
+        'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type', 'workflow'
     ], [
         'causeMessage'
     ])).label('Get Event'),

--- a/test/data/event.get.full.yaml
+++ b/test/data/event.get.full.yaml
@@ -17,7 +17,6 @@ creator:
     avatar: https://avatars.githubusercontent.com/u/622065?v=3
 pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
-status: RUNNING
 type: pipeline
 workflow:
     - down

--- a/test/data/event.get.yaml
+++ b/test/data/event.get.yaml
@@ -16,7 +16,6 @@ creator:
     avatar: https://avatars.githubusercontent.com/u/622065?v=3
 pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
-status: RUNNING
 type: pipeline
 workflow:
     - down

--- a/test/data/event.yaml
+++ b/test/data/event.yaml
@@ -17,7 +17,6 @@ creator:
     avatar: https://avatars.githubusercontent.com/u/622065?v=3
 pipelineId: 2d991790bab1ac8576097ca87f170df73410b55c
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
-status: RUNNING
 type: pipeline
 workflow:
     - foo


### PR DESCRIPTION
Let's remove event status for now to simplify the logic of the API. 

We can infer the status of an event from the builds' status. 