### PR TITLE
Make eventId an optional field when getting a build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 15.0.0
+## 15.0.1
 
-Breaking changes:
-  * `eventId` should be returned when a GET request is made on a build.
+Features:
+  * `eventId` can be returned when a GET request is made on a build.

--- a/models/build.js
+++ b/models/build.js
@@ -122,10 +122,10 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'eventId', 'jobId', 'number', 'cause', 'createTime', 'status'
+        'id', 'jobId', 'number', 'cause', 'createTime', 'status'
     ], [
         'container', 'parentBuildId', 'sha', 'startTime', 'endTime', 'meta', 'parameters', 'steps',
-        'commit'
+        'commit', 'eventId'
     ])).label('Get Build'),
 
     /**


### PR DESCRIPTION
In order to incrementally add events to the API, we need to make the `eventId` an optional field for build get.