### PR TITLE
Make tokens optional for some scm commands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const models = require('../models');
 const scmUri = Joi.reach(models.pipeline.base, 'scmUri').required();
 const token = Joi.reach(models.user.base, 'token').required();
+const tokenOptional = Joi.reach(models.user.base, 'token').optional();
 const sha = Joi.reach(models.build.base, 'sha').required();
 const buildStatus = Joi.reach(models.build.base, 'status').required();
 const jobName = Joi.reach(models.job.base, 'name').optional();
@@ -17,7 +18,7 @@ const GET_PERMISSIONS = Joi.object().keys({
 
 const GET_COMMIT_SHA = Joi.object().keys({
     scmUri,
-    token
+    token: tokenOptional
 }).required();
 
 const UPDATE_COMMIT_STATUS = Joi.object().keys({
@@ -54,7 +55,7 @@ const DECORATE_AUTHOR = Joi.object().keys({
 
 const PARSE_URL = Joi.object().keys({
     checkoutUrl,
-    token
+    token: tokenOptional
 }).required();
 
 module.exports = {

--- a/test/data/scm.getCommitShaNoToken.yaml
+++ b/test/data/scm.getCommitShaNoToken.yaml
@@ -1,0 +1,1 @@
+scmUri: github.com:12345678:master

--- a/test/data/scm.parseUrlNoToken.yaml
+++ b/test/data/scm.parseUrlNoToken.yaml
@@ -1,0 +1,1 @@
+checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -20,6 +20,10 @@ describe('scm test', () => {
             assert.isNull(validate('scm.getCommitSha.yaml', scm.getCommitSha).error);
         });
 
+        it('validates with no token', () => {
+            assert.isNull(validate('scm.getCommitShaNoToken.yaml', scm.getCommitSha).error);
+        });
+
         it('fails', () => {
             assert.isNotNull(validate('empty.yaml', scm.getCommitSha).error);
         });
@@ -78,6 +82,10 @@ describe('scm test', () => {
     describe('parseUrl', () => {
         it('validates', () => {
             assert.isNull(validate('scm.parseUrl.yaml', scm.parseUrl).error);
+        });
+
+        it('validates with no token', () => {
+            assert.isNull(validate('scm.parseUrlNoToken.yaml', scm.parseUrl).error);
         });
 
         it('fails', () => {


### PR DESCRIPTION
Starting to address https://github.com/screwdriver-cd/screwdriver/issues/335, the `repo.get` for `parseUrl` shouldn't require a token, nor should `repo.getBranch`.
