### PR TITLE
Add schema to validate input for `getCheckoutCommand` in scm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 15.3.0
+
+Features:
+  * Add schema to validate input for `getCheckoutCommand` method in [scm-base](https://github.com/screwdriver-cd/scm-base)
+
 ## 15.2.0
 
 Features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "15.2.0",
+  "version": "15.3.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -10,6 +10,15 @@ const jobName = Joi.reach(models.job.base, 'name').optional();
 const username = Joi.reach(models.user.base, 'username').required();
 const checkoutUrl = Joi.reach(models.pipeline.create, 'checkoutUrl').required();
 
+const GET_CHECKOUT_COMMAND = Joi.object().keys({
+    branch: Joi.string().required(),
+    host: Joi.string().required(),
+    org: Joi.string().required(),
+    repo: Joi.string().required(),
+    sha: Joi.string().required(),
+    prRef: Joi.string().optional()
+}).required();
+
 const GET_PERMISSIONS = Joi.object().keys({
     scmUri,
     token
@@ -120,5 +129,13 @@ module.exports = {
      * @property parseUrl
      * @type {Joi}
      */
-    parseUrl: PARSE_URL
+    parseUrl: PARSE_URL,
+
+    /**
+     * Properties for Scm Base that will be passed for the getCheckoutCommand method
+     *
+     * @property getCheckoutCommand
+     * @type {Joi}
+     */
+    getCheckoutCommand: GET_CHECKOUT_COMMAND
 };

--- a/test/data/scm.getCheckoutCommand.yaml
+++ b/test/data/scm.getCheckoutCommand.yaml
@@ -1,0 +1,5 @@
+branch: master
+host: github.com
+org: screwdriver-cd
+repo: data-schema
+sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -84,4 +84,14 @@ describe('scm test', () => {
             assert.isNotNull(validate('empty.yaml', scm.parseUrl).error);
         });
     });
+
+    describe('getCheckoutCommand', () => {
+        it('validates', () => {
+            assert.isNull(validate('scm.getCheckoutCommand.yaml', scm.getCheckoutCommand).error);
+        });
+
+        it('fails', () => {
+            assert.isNotNull(validate('empty.yaml', scm.getCheckoutCommand).error);
+        });
+    });
 });


### PR DESCRIPTION
- We will generate checkout command in SCM plugin with `getCheckoutCommand` method
- This schema is used to validate the input for `getCheckoutCommand` method
Relates to https://github.com/screwdriver-cd/screwdriver/issues/312