### PR TITLE
[1] Add checkout command output validation for scm plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 15.4.0
+
+Features:
+  * Add schema to validate output for `getCheckoutCommand` method in [scm-base](https://github.com/screwdriver-cd/scm-base)
+
 ## 15.3.0
 
 Features:

--- a/core/scm.js
+++ b/core/scm.js
@@ -45,6 +45,17 @@ const SCHEMA_REPO = Joi.object().keys({
         .example('https://github.com/screwdriver-cd/screwdriver/tree/master')
 }).label('SCM Repository');
 
+const SCHEMA_COMMAND = Joi.object().keys({
+    name: Joi.equal('sd-checkout-code')
+        .required()
+        .label('Command name')
+        .example('sd-checkout-code'),
+
+    command: Joi.string()
+        .required()
+        .label('Checkout command to run')
+}).label('SCM Command');
+
 const SCHEMA_COMMIT = Joi.object().keys({
     message: Joi.string()
         .required()
@@ -112,6 +123,7 @@ const SCHEMA_HOOK = Joi.object().keys({
 }).label('SCM Hook');
 
 module.exports = {
+    command: SCHEMA_COMMAND,
     commit: SCHEMA_COMMIT,
     repo: SCHEMA_REPO,
     user: SCHEMA_USER,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "15.3.0",
+  "version": "15.4.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,6 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "eslint-plugin-import": "^2.0.0",
     "jenkins-mocha": "^3.0.0",
     "js-yaml": "^3.6.1"
   },

--- a/test/core/scm.test.js
+++ b/test/core/scm.test.js
@@ -5,6 +5,16 @@ const core = require('../../').core;
 const validate = require('../helper').validate;
 
 describe('scm core', () => {
+    describe('command', () => {
+        it('validates the command', () => {
+            assert.isNull(validate('scm.command.yaml', core.scm.command).error);
+        });
+
+        it('fails the command', () => {
+            assert.isNotNull(validate('empty.yaml', core.scm.command).error);
+        });
+    });
+
     describe('commit', () => {
         it('validates the commit', () => {
             assert.isNull(validate('scm.commit.yaml', core.scm.commit).error);

--- a/test/data/scm.command.yaml
+++ b/test/data/scm.command.yaml
@@ -1,0 +1,3 @@
+# SCM Command Example
+name: sd-checkout-code
+command: "echo Cloning https://github.com/screwdriver-cd/guide, on branch branchName && git clone --quiet --progress --branch branchName https://github.com/screwdriver-cd/guide && cd guide && git reset --hard 12345 && echo Reset to 12345 && echo Setting user name and user email && git config user.name sd-buildbot && git config user.email dev-null@screwdriver.cd"


### PR DESCRIPTION
We will require scm-plugins to output `sd-checkout-code` as the name for a checkout command

Related to feedback in https://github.com/screwdriver-cd/models/pull/132