### PR TITLE
feat: addWebhook method input

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -10,6 +10,17 @@ const jobName = Joi.reach(models.job.base, 'name').optional();
 const username = Joi.reach(models.user.base, 'username').required();
 const checkoutUrl = Joi.reach(models.pipeline.create, 'checkoutUrl').required();
 
+const ADD_WEBHOOK = Joi.object().keys({
+    scmUri,
+    token,
+    url: Joi.string().uri({
+        scheme: [
+            'http',
+            'https'
+        ]
+    })
+}).required();
+
 const GET_CHECKOUT_COMMAND = Joi.object().keys({
     branch: Joi.string().required(),
     host: Joi.string().required(),
@@ -67,6 +78,14 @@ const PARSE_URL = Joi.object().keys({
 }).required();
 
 module.exports = {
+    /**
+     * Properties for Scm Base that will be passed for the addWebhook method
+     *
+     * @property addWebhook
+     * @type {Joi}
+     */
+    addWebhook: ADD_WEBHOOK,
+
     /**
      * Properties for Scm Base that will be passed for the getPermissions method
      *

--- a/test/data/scm.addWebhook.yaml
+++ b/test/data/scm.addWebhook.yaml
@@ -1,0 +1,4 @@
+---
+scmUri: github.com:126987453:master
+token: thisisashinytoken
+url: https://screwdriver.cd/v4/some-endpoint

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -94,4 +94,14 @@ describe('scm test', () => {
             assert.isNotNull(validate('empty.yaml', scm.getCheckoutCommand).error);
         });
     });
+
+    describe('addWebhook', () => {
+        it('validates', () => {
+            assert.isNull(validate('scm.addWebhook.yaml', scm.addWebhook).error);
+        });
+
+        it('fails', () => {
+            assert.isNotNull(validate('empty.yaml', scm.addWebhook).error);
+        });
+    });
 });


### PR DESCRIPTION
Joi validation for `scm-base.addWebhook`, which will help enforce the input for the method.

Based on the implementations for [`scm-github`](https://github.com/screwdriver-cd/scm-github/pull/45) and [`scm-bitbucket`](https://github.com/screwdriver-cd/scm-bitbucket/pull/29), we determined that the most common interface between them contains:

* `scmUri` - the SCM URI of the repository
* `token` - the auth token to interact with the SCM service
* `url` - the webhook to notify when certain events occur

Related to screwdriver-cd/screwdriver#379