### PR TITLE
fix: add rangeKey for event

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -95,7 +95,7 @@ module.exports = {
      * @property rangeKeys
      * @type {Array}
      */
-    rangeKeys: ['createTime', null],
+    rangeKeys: ['createTime', 'createTime'],
 
     /**
      * Tablename to be used in the datastore

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -76,7 +76,7 @@ describe('model event', () => {
         it('defines the correct rangeKeys', () => {
             const expected = [
                 'createTime',
-                null
+                'createTime'
             ];
             const rangeKeys = models.event.rangeKeys;
 


### PR DESCRIPTION
- datastore-sequelize's `scan` method will set the `sortKey` for the index `type`, which is `null` now. This will cause error when querying the database.
- Change the sortKey to `createTime` 
 
https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L327