### PR TITLE
fix: model passes in webhookUrl for add webhooks

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -13,7 +13,7 @@ const checkoutUrl = Joi.reach(models.pipeline.create, 'checkoutUrl').required();
 const ADD_WEBHOOK = Joi.object().keys({
     scmUri,
     token,
-    url: Joi.string().uri({
+    webhookUrl: Joi.string().uri({
         scheme: [
             'http',
             'https'

--- a/test/data/scm.addWebhook.yaml
+++ b/test/data/scm.addWebhook.yaml
@@ -1,4 +1,4 @@
 ---
 scmUri: github.com:126987453:master
 token: thisisashinytoken
-url: https://screwdriver.cd/v4/some-endpoint
+webhookUrl: https://screwdriver.cd/v4/some-endpoint


### PR DESCRIPTION
This is a bug: https://github.com/screwdriver-cd/models/blob/master/lib/pipeline.js#L122

Related: https://github.com/screwdriver-cd/screwdriver/issues/379