### PR TITLE
fix(399): Datastore get should not require `id` anymore

### DIFF
--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -2,12 +2,9 @@
 
 const Joi = require('joi');
 const table = Joi.string().required();
-const id = Joi.number().integer().positive().required();
 const SCHEMA_ID = Joi.object().keys({
     table,
-    params: Joi.object().keys({
-        id
-    }).required()
+    params: Joi.object().min(1).required()
 });
 const SCHEMA_UPDATE = Joi.object().keys({
     table,

--- a/test/data/datastore.id.yaml
+++ b/test/data/datastore.id.yaml
@@ -1,3 +1,3 @@
 table: 'jobs'
 params:
-    id: 31242
+    foo: bar


### PR DESCRIPTION
This is because we should be able to lookup based on unique keys, not just the ID