### PR TITLE
feat: Add notifications field to pipeline

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -35,11 +35,16 @@ const MODEL = {
 
     admins: Joi
         .object()
-        .description('Admins of this Pipeline')
+        .description('Admins of this pipeline')
         .example({ myself: true }),
 
     workflow: Workflow.workflow
-        .description('Current workflow of the pipeline')
+        .description('Current workflow of the pipeline'),
+
+    notificationEmail: Joi
+        .string().email()
+        .description('Email to send notifications to')
+        .example('screwdriver-cd@github.com')
 };
 
 module.exports = {
@@ -60,7 +65,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'scmUri', 'createTime', 'admins'
     ], [
-        'workflow', 'scmRepo'
+        'workflow', 'scmRepo', 'notificationEmail'
     ])).label('Get Pipeline'),
 
     /**

--- a/package.json
+++ b/package.json
@@ -24,8 +24,11 @@
     "Dao Lam <daolam112@gmail.com>",
     "Darren Matsumoto <aeneascorrupt@gmail.com>",
     "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
+    "Jerry Zhang <thejerryzhang@gmail.com>",
+    "Min Zhang <minzhang@andrew.cmu.edu>",
     "Noah Katzman <nkatzman@yahoo-inc.com>",
     "Peter Peterson <jedipetey@gmail.com>",
+    "Reetika Rastogi <r3rastogi@gmail.com>",
     "St. John Johnson <st.john.johnson@gmail.com",
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -11,3 +11,4 @@ scmRepo:
     name: screwdriver-cd/screwdriver
     branch: master
     url: https://github.com/screwdriver-cd/screwdriver/tree/master
+notificationEmail: screwdriver-cd@github.com

--- a/test/data/pipeline.yaml
+++ b/test/data/pipeline.yaml
@@ -6,3 +6,4 @@ scmRepo:
     name: screwdriver-cd/screwdriver
     branch: master
     url: https://github.com/screwdriver-cd/screwdriver/tree/master
+notificationEmail: screwdriver-cd@github.com


### PR DESCRIPTION
We want to allow users to be notified by email when their Screwdriver
job changes status. Thus, add an optional email notification field to
the pipeline model.