### PR TITLE
feat(470): Add template validation

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -3,6 +3,7 @@
 const base = require('./base');
 const job = require('./job');
 const regex = require('./regex');
+const template = require('./template');
 const workflow = require('./workflow');
 
-module.exports = { base, job, regex, workflow };
+module.exports = { base, job, regex, template, workflow };

--- a/config/regex.js
+++ b/config/regex.js
@@ -5,6 +5,10 @@
  * @type {Object}
  */
 module.exports = {
+    // Templates can only be named with A-Z,a-z,0-9,-,_,/
+    TEMPLATE_NAME: /^[\w/-]+$/,
+    // Version can only have up to 2 decimals, like 1.2.3
+    VERSION: /^(\d+\.)?(\d+\.)?(\d+)$/,
     // Steps can only be named with A-Z,a-z,0-9,-,_
     STEP_NAME: /^[\w-]+$/,
     // Jobs can only be named with A-Z,a-z,0-9,-,_

--- a/config/template.js
+++ b/config/template.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const Joi = require('joi');
+const Job = require('./job');
+const Regex = require('./regex');
+
+const TEMPLATE_NAME = Joi
+            .string()
+            .regex(Regex.TEMPLATE_NAME)
+            .description('Name of the Template')
+            .example('node/npm-install');
+
+const TEMPLATE_VERSION = Joi
+            .string()
+            .regex(Regex.VERSION)
+            .description('Version of the Template')
+            .example('1.2.3');
+
+const TEMPLATE_DESCRIPTION = Joi
+            .string()
+            .description('Description of the Template')
+            .example('Installs npm modules');
+
+const TEMPLATE_MAINTAINER = Joi
+            .string()
+            .email()
+            .description('Maintainer of the Template')
+            .example('foo@bar.com');
+
+const SCHEMA_TEMPLATE = Joi.object()
+    .keys({
+        name: TEMPLATE_NAME,
+        version: TEMPLATE_VERSION,
+        description: TEMPLATE_DESCRIPTION,
+        maintainer: TEMPLATE_MAINTAINER,
+        config: Job.job
+    })
+    .requiredKeys('name', 'version', 'description', 'maintainer', 'config.steps');
+
+/**
+ * The definition of the Template pieces
+ * @type {Object}
+ */
+module.exports = {
+    template: SCHEMA_TEMPLATE
+};

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -4,6 +4,26 @@ const assert = require('chai').assert;
 const config = require('../../').config;
 
 describe('config regex', () => {
+    describe('templates', () => {
+        it('checks good template names', () => {
+            assert.isTrue(config.regex.TEMPLATE_NAME.test('node/npm-install'));
+        });
+
+        it('fails on bad template names', () => {
+            assert.isFalse(config.regex.TEMPLATE_NAME.test('run all the things'));
+        });
+    });
+
+    describe('versions', () => {
+        it('checks good versions', () => {
+            assert.isTrue(config.regex.VERSION.test('12.1.2'));
+        });
+
+        it('fails on bad versions', () => {
+            assert.isFalse(config.regex.VERSION.test('1.0.1.0.1'));
+        });
+    });
+
     describe('steps', () => {
         it('checks good step names', () => {
             assert.isTrue(config.regex.STEP_NAME.test('foo-BAR_15'));

--- a/test/config/template.test.js
+++ b/test/config/template.test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const assert = require('chai').assert;
+const config = require('../../').config;
+const validate = require('../helper').validate;
+
+describe('config template', () => {
+    describe('template', () => {
+        it('validates safely', () => {
+            assert.isNull(validate('config.template.yaml', config.template.template).error);
+        });
+    });
+});

--- a/test/data/config.template.yaml
+++ b/test/data/config.template.yaml
@@ -1,0 +1,14 @@
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+config:
+  image: node:6
+  steps:
+    - install: npm install 
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN


### PR DESCRIPTION
We will need to add schemas for what is expected/valid in a ```template.yaml```

Expected/required fields in a `template.yaml`:
- name (eg: chef/cookbook, chef/pipeline-upload, chef/pipeline-assembly, etc.)
- description
- version
- maintainer/point of contact
- config
     - steps

Related to https://github.com/screwdriver-cd/screwdriver/issues/470

TODO (in another PR): add `lifespan` schema