### PR TITLE
feat(470): add template schema to models

### DIFF
--- a/config/template.js
+++ b/config/template.js
@@ -42,5 +42,10 @@ const SCHEMA_TEMPLATE = Joi.object()
  * @type {Object}
  */
 module.exports = {
-    template: SCHEMA_TEMPLATE
+    template: SCHEMA_TEMPLATE,
+    name: TEMPLATE_NAME,
+    version: TEMPLATE_VERSION,
+    description: TEMPLATE_DESCRIPTION,
+    maintainer: TEMPLATE_MAINTAINER,
+    config: Job.job
 };

--- a/models/index.js
+++ b/models/index.js
@@ -6,5 +6,6 @@ const job = require('./job');
 const pipeline = require('./pipeline');
 const user = require('./user');
 const secret = require('./secret');
+const template = require('./template');
 
-module.exports = { build, event, job, pipeline, user, secret };
+module.exports = { build, event, job, pipeline, user, secret, template };

--- a/models/template.js
+++ b/models/template.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const Joi = require('joi');
+const mutate = require('../lib/mutate');
+const Template = require('../config/template');
+const scmUri = Joi.reach(require('./pipeline').base, 'scmUri');
+
+const MODEL = {
+    id: Joi
+        .number().integer().positive()
+        .description('Identifier of this template')
+        .example(123345),
+
+    labels: Joi
+        .array()
+        .items(Joi.string())
+        .description('Labels for template')
+        .example(['stable', 'latest', 'beta']),
+
+    config: Template.config,
+    name: Template.name,
+    version: Template.version,
+    description: Template.description,
+    maintainer: Template.maintainer,
+    scmUri
+};
+
+module.exports = {
+    /**
+     * All the available properties of Template
+     *
+     * @property base
+     * @type {Joi}
+     */
+    base: Joi.object(MODEL).label('Template'),
+
+    /**
+     * Properties for template that will come back during a GET request
+     *
+     * @property get
+     * @type {Joi}
+     */
+    get: Joi.object(mutate(MODEL, [
+        'id', 'labels', 'config', 'name', 'version', 'description', 'maintainer', 'scmUri'
+    ], [])).label('Get Template'),
+
+    /**
+     * Properties for template that will be passed during a CREATE request
+     *
+     * @property create
+     * @type {Joi}
+     */
+    create: Joi.object(mutate(MODEL, [
+        'config', 'name', 'version', 'description', 'maintainer'
+    ], ['labels'])).label('Create Template'),
+
+    /**
+     * Properties for template that will be passed during a UPDATE requeste
+     *
+     * @property update
+     * @type {Joi}
+     */
+    update: Joi.object(mutate(MODEL, [], ['labels']))
+        .label('Update Template'),
+
+    /**
+     * List of fields that determine a unique row
+     *
+     * @property keys
+     * @type {Array}
+     */
+    keys: ['name', 'version'],
+
+    /**
+     * List of all fields in the model
+     * @property allKeys
+     * @type {Array}
+     */
+    allKeys: Object.keys(MODEL),
+
+    /**
+     * List of indexes to create in the datastore
+     *
+     * @property indexes
+     * @type {Array}
+     */
+    indexes: ['name'],
+
+    /**
+     * Primary column to sort queries by.
+     * This defines queries to optionally sort a query result set by version.
+     * Each range key matches up with an element in the indexes property
+     *
+     * @property rangeKeys
+     * @type {Array}
+     */
+    rangeKeys: ['version'],
+
+    /**
+     * Tablename to be used in the datastore
+     *
+     * @property tableName
+     * @type {String}
+     */
+    tableName: 'templates'
+};

--- a/test/data/template.create.yaml
+++ b/test/data/template.create.yaml
@@ -1,0 +1,19 @@
+# Template CREATE Example
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+labels:
+    - stable
+    - test
+    - beta
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/data/template.get.yaml
+++ b/test/data/template.get.yaml
@@ -1,0 +1,21 @@
+# Template GET Example
+id: 123234135
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+scmUri: github.com:123:master
+labels:
+    - stable
+    - test
+    - beta
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/data/template.update.yaml
+++ b/test/data/template.update.yaml
@@ -1,0 +1,4 @@
+# Template UPDATE example
+labels:
+    - stable
+    - test

--- a/test/data/template.yaml
+++ b/test/data/template.yaml
@@ -1,0 +1,21 @@
+# Base Template Example
+id: 123234135
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+scmUri: github.com:123:master
+labels:
+    - stable
+    - test
+    - beta
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/models/template.test.js
+++ b/test/models/template.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const assert = require('chai').assert;
+const models = require('../../').models;
+const validate = require('../helper').validate;
+
+describe('model template', () => {
+    describe('base', () => {
+        it('validates the base', () => {
+            assert.isNull(validate('template.yaml', models.template.base).error);
+        });
+    });
+
+    describe('create', () => {
+        it('validates the create', () => {
+            assert.isNull(validate('template.create.yaml', models.template.create).error);
+        });
+
+        it('fails the create', () => {
+            assert.isNotNull(validate('empty.yaml', models.template.create).error);
+        });
+    });
+
+    describe('get', () => {
+        it('validates the get', () => {
+            assert.isNull(validate('template.get.yaml', models.template.get).error);
+        });
+
+        it('fails the get', () => {
+            assert.isNotNull(validate('empty.yaml', models.template.get).error);
+        });
+    });
+
+    describe('update', () => {
+        it('validates the update', () => {
+            assert.isNull(validate('template.update.yaml', models.template.update).error);
+        });
+
+        it('fails the update', () => {
+            assert.isNotNull(validate('empty.yaml', models.template.update).error);
+        });
+    });
+});


### PR DESCRIPTION
- Add template schema to models
- Highlight:
   -  `scmUri` is the template pipeline's scmUri
   - `name` and `version` define a unique record
   -   A record (e.g. test-template@1.3) can have multiple `labels`
   -  only `labels` can be updated for a record

Related to https://github.com/screwdriver-cd/screwdriver/issues/470