### PR TITLE
feat(470): adding input & output schema for template validation API endpoint

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const pagination = require('./pagination');
-const validator = require('./validator');
-const loglines = require('./loglines');
 const auth = require('./auth');
+const loglines = require('./loglines');
+const pagination = require('./pagination');
+const templateValidator = require('./templateValidator');
+const validator = require('./validator');
 
-module.exports = { pagination, validator, loglines, auth };
+module.exports = { auth, loglines, pagination, templateValidator, validator };

--- a/api/templateValidator.js
+++ b/api/templateValidator.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const Joi = require('joi');
+
+// essentially a Joi.ValidationError.details object
+const TEMPLATE_ERROR = Joi.object()
+    .keys({
+        context: Joi.object()
+            .label('Functional context regarding the error'),
+        message: Joi.string()
+            .label('Description of a particular validation error'),
+        path: Joi.string()
+            .label('Dot-notation path to the field that caused the validation error'),
+        type: Joi.string()
+            .label('The the Joi-type that categorizes the error')
+    });
+
+const SCHEMA_OUTPUT = Joi.object()
+    .keys({
+        errors: Joi.array().items(TEMPLATE_ERROR),
+        // since a template could be parseable but invalid, the contents are unpredicatble
+        template: Joi.object()
+    })
+    .label('Template validation output');
+
+const SCHEMA_INPUT = Joi.object({
+    yaml: Joi.string().label('sd-template.yaml contents')
+}).label('Certify input to template validator');
+
+/**
+ * Input and output specification for validation
+ * @type {Object}
+ */
+module.exports = {
+    input: SCHEMA_INPUT,
+    output: SCHEMA_OUTPUT
+};

--- a/test/api/templateValidator.test.js
+++ b/test/api/templateValidator.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const assert = require('chai').assert;
+const api = require('../../').api;
+const validate = require('../helper').validate;
+
+describe('api validator', () => {
+    const inputSchema = api.templateValidator.input;
+    const outputSchema = api.templateValidator.output;
+
+    describe('input', () => {
+        it('accepts basic input', () => {
+            assert.isNull(validate('template-validator.input.yaml', inputSchema).error);
+        });
+    });
+
+    describe('output', () => {
+        it('validates basic output', () => {
+            assert.isNull(validate('template-validator.output.yaml', outputSchema).error);
+        });
+
+        it('validates basic output with errors', () => {
+            assert.isNull(validate('template-validator.erroroutput.yaml', outputSchema).error);
+        });
+    });
+});

--- a/test/data/template-validator.erroroutput.yaml
+++ b/test/data/template-validator.erroroutput.yaml
@@ -1,0 +1,24 @@
+---
+errors:
+    - context:
+        key: version
+      message: '"version" is required'
+      path: version
+      type: any.required
+template:
+    name: template_namespace/nodejs_main
+    # Version is purposely omitted to assert unit test case
+    # version: 1.1.2
+    description: |
+        Template for building a NodeJS module
+        Installs dependencies and runs tests
+    maintainer: me@nowhere.com
+    config:
+        image: node:6
+        steps:
+            - install: npm install
+            - test: npm test
+        environment:
+            KEYNAME: value
+        secrets:
+            - NPM_TOKEN

--- a/test/data/template-validator.input.yaml
+++ b/test/data/template-validator.input.yaml
@@ -1,0 +1,16 @@
+yaml: |
+  name: template_namespace/nodejs_main
+  version: 1.1.2
+  description: |
+      Template for building a NodeJS module
+      Installs dependencies and runs tests
+  maintainer: me@nowhere.com
+  config:
+      image: node:6
+      steps:
+          - install: npm install
+          - test: npm test
+      environment:
+          KEYNAME: value
+      secrets:
+          - NPM_TOKEN

--- a/test/data/template-validator.output.yaml
+++ b/test/data/template-validator.output.yaml
@@ -1,0 +1,18 @@
+---
+errors: []
+template:
+    name: template_namespace/nodejs_main
+    version: 1.1.2
+    description: |
+        Template for building a NodeJS module
+        Installs dependencies and runs tests
+    maintainer: me@nowhere.com
+    config:
+        image: node:6
+        steps:
+            - install: npm install
+            - test: npm test
+        environment:
+            KEYNAME: value
+        secrets:
+            - NPM_TOKEN


### PR DESCRIPTION
## Context

An API endpoint is being implemented for a user to validate their template configuration.

## Objective

This change will introduce a schema for both input & output for the API to utilize.

It will take a template configuration in the form of a string as input, similar to how the [validator endpoint does](https://github.com/screwdriver-cd/data-schema/blob/master/api/validator.js#L60). 

The output will be an object consisting of the interpreted template configuration and any errors encountered while validating it. A pseudo-code example:

```
{
  template: {
    ...
  },
  errors: [
    ..
  ]
}
```

## Notable Items

* The `template` field is a general `Joi.object()` because the passed-in template could be parseable and still be an invalid Screwdriver template. 
* Contributes to screwdriver-cd/screwdriver#470
* Related to screwdriver-cd/screwdriver#480