### PR TITLE
feat(470): allow template field in screwdriver.yaml

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -57,10 +57,12 @@ const SCHEMA_STEP_OBJECT = Joi.object()
             }
         }
     });
+
 const SCHEMA_STEP = Joi.alternatives().try(SCHEMA_STEP_STRING, SCHEMA_STEP_OBJECT);
 const SCHEMA_STEPS = Joi.array().items(SCHEMA_STEP).min(1);
 const SCHEMA_IMAGE = Joi.string();
 const SCHEMA_SETTINGS = Joi.object().optional();
+const SCHEMA_TEMPLATE = Joi.string().regex(Regex.FULL_TEMPLATE_NAME);
 const SCHEMA_JOB = Joi.object()
     .keys({
         steps: SCHEMA_STEPS,
@@ -68,7 +70,8 @@ const SCHEMA_JOB = Joi.object()
         matrix: SCHEMA_MATRIX,
         image: SCHEMA_IMAGE,
         secrets: SCHEMA_SECRETS,
-        settings: SCHEMA_SETTINGS
+        settings: SCHEMA_SETTINGS,
+        template: SCHEMA_TEMPLATE
     })
     .default({});
 
@@ -85,5 +88,6 @@ module.exports = {
     environment: SCHEMA_ENVIRONMENT,
     image: SCHEMA_IMAGE,
     job: SCHEMA_JOB,
-    settings: SCHEMA_SETTINGS
+    settings: SCHEMA_SETTINGS,
+    template: SCHEMA_TEMPLATE
 };

--- a/config/regex.js
+++ b/config/regex.js
@@ -8,7 +8,9 @@ module.exports = {
     // Templates can only be named with A-Z,a-z,0-9,-,_,/
     TEMPLATE_NAME: /^[\w/-]+$/,
     // Version can only have up to 2 decimals, like 1.2.3
-    VERSION: /^(\d+\.)?(\d+\.)?(\d+)$/,
+    VERSION: /^(\d+)?(\.\d+)?(\.\d+)?$/,
+    // Full name of template and version. Example: chef/publish@1.2.3
+    FULL_TEMPLATE_NAME: /^([\w/-]+)(@)?((\d+)?(\.\d+)?(\.\d+)?)$/,
     // Steps can only be named with A-Z,a-z,0-9,-,_
     STEP_NAME: /^[\w-]+$/,
     // Jobs can only be named with A-Z,a-z,0-9,-,_

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -46,4 +46,14 @@ describe('config job', () => {
             assert.isNull(validate('config.job.settings.yaml', config.job.settings).error);
         });
     });
+
+    describe('template', () => {
+        it('validates good template', () => {
+            assert.isNull(validate('config.job.template.good.yaml', config.job.job).error);
+        });
+
+        it('returns error for bad template', () => {
+            assert.isNotNull(validate('config.job.template.bad.yaml', config.job.job).error);
+        });
+    });
 });

--- a/test/data/config.job.template.bad.yaml
+++ b/test/data/config.job.template.bad.yaml
@@ -1,0 +1,1 @@
+template: node@1.2.3.4

--- a/test/data/config.job.template.good.yaml
+++ b/test/data/config.job.template.good.yaml
@@ -1,0 +1,3 @@
+template: node/build@1.2.3
+environment:
+    NODE_ENV: production


### PR DESCRIPTION
This is for the user's side, when they specify `template` inside their `screwdriver.yaml`

This will probably be used by the `config-parser` here https://github.com/screwdriver-cd/config-parser/blob/master/lib/phase/structural.js

Related: https://github.com/screwdriver-cd/screwdriver/issues/470