### PR TITLE
fix: add length to template for mysql index

### DIFF
--- a/config/template.js
+++ b/config/template.js
@@ -7,23 +7,27 @@ const Regex = require('./regex');
 const TEMPLATE_NAME = Joi
             .string()
             .regex(Regex.TEMPLATE_NAME)
+            .max(64)
             .description('Name of the Template')
             .example('node/npm-install');
 
 const TEMPLATE_VERSION = Joi
             .string()
             .regex(Regex.VERSION)
+            .max(16)
             .description('Version of the Template')
             .example('1.2.3');
 
 const TEMPLATE_DESCRIPTION = Joi
             .string()
+            .max(256)
             .description('Description of the Template')
             .example('Installs npm modules');
 
 const TEMPLATE_MAINTAINER = Joi
             .string()
             .email()
+            .max(64)
             .description('Maintainer of the Template')
             .example('foo@bar.com');
 


### PR DESCRIPTION
This issue is same as https://github.com/screwdriver-cd/screwdriver/issues/325 and https://github.com/screwdriver-cd/data-schema/pull/102. 
I fixed same way.
If the max value are not appropriate, please tell me.

```
api_1    | error:  SequelizeDatabaseError: ER_BLOB_KEY_WITHOUT_LENGTH: BLOB/TEXT column 'name' used in key specification without a key length
api_1    |     at Query.formatError (/usr/src/app/node_modules/sequelize/lib/dialects/mysql/query.js:175:14)
api_1    |     at Query._callback (/usr/src/app/node_modules/sequelize/lib/dialects/mysql/query.js:49:21)
api_1    |     at Query.Sequence.end (/usr/src/app/node_modules/mysql/lib/protocol/sequences/Sequence.js:86:24)
api_1    |     at Query.ErrorPacket (/usr/src/app/node_modules/mysql/lib/protocol/sequences/Query.js:88:8)
api_1    |     at Protocol._parsePacket (/usr/src/app/node_modules/mysql/lib/protocol/Protocol.js:280:23)
api_1    |     at Parser.write (/usr/src/app/node_modules/mysql/lib/protocol/Parser.js:75:12)
api_1    |     at Protocol.write (/usr/src/app/node_modules/mysql/lib/protocol/Protocol.js:39:16)
api_1    |     at Socket.<anonymous> (/usr/src/app/node_modules/mysql/lib/Connection.js:103:28)
api_1    |     at emitOne (events.js:96:13)
api_1    |     at Socket.emit (events.js:188:7)
api_1    |     at readableAddChunk (_stream_readable.js:176:18)
api_1    |     at Socket.Readable.push (_stream_readable.js:134:10)
api_1    |     at TCP.onread (net.js:548:20)
```