### PR TITLE
fix: template ties to pipelineId instead of scmUri

### DIFF
--- a/models/template.js
+++ b/models/template.js
@@ -3,7 +3,7 @@
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Template = require('../config/template');
-const scmUri = Joi.reach(require('./pipeline').base, 'scmUri');
+const pipelineId = Joi.reach(require('./pipeline').base, 'id');
 
 const MODEL = {
     id: Joi
@@ -22,7 +22,7 @@ const MODEL = {
     version: Template.version,
     description: Template.description,
     maintainer: Template.maintainer,
-    scmUri
+    pipelineId
 };
 
 module.exports = {
@@ -41,7 +41,7 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'labels', 'config', 'name', 'version', 'description', 'maintainer', 'scmUri'
+        'id', 'labels', 'config', 'name', 'version', 'description', 'maintainer', 'pipelineId'
     ], [])).label('Get Template'),
 
     /**

--- a/test/data/template.get.yaml
+++ b/test/data/template.get.yaml
@@ -4,7 +4,7 @@ name: test/template
 version: "1.3"
 description: Template for testing
 maintainer: foo@bar.com
-scmUri: github.com:123:master
+pipelineId: 8765
 labels:
     - stable
     - test

--- a/test/data/template.yaml
+++ b/test/data/template.yaml
@@ -4,7 +4,7 @@ name: test/template
 version: "1.3"
 description: Template for testing
 maintainer: foo@bar.com
-scmUri: github.com:123:master
+pipelineId: 8765
 labels:
     - stable
     - test


### PR DESCRIPTION
This was brought up by @stjohnjohnson  a while ago. 
Since we use `id` to identify a pipeline, we should just use it here instead of `scmUri`
This is a breaking change, it will break all the existing templates right now. But since all the templates we have are test templates that were created by me, I just emptied the table. 