### PR TITLE
fix: bump patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This contains the structure/validation for all the models/resources of Screwdriv
 It's broken down into three sections:
  - `api` - API related input/output structure
  - `config` - Screwdriver.yaml definitions
- - `models` - Internal data resources
+ - `models` - Internal data resources (pipeline, job, build, etc.)
  - `plugins` - Plugins (datastore, executor, etc.)
  - `core` - SCM plugin related output structure
 


### PR DESCRIPTION
The previous PR bumped major version, which requires all other packages to use the new data-schema (otherwise API build will fail due to duplicate package found). 
We actually didn't need to bump major (since technically it wouldn't break other people), so I unpublished the major version. Making this change so it will bump to `16.5.2` instead