### PR TITLE
fix: Add config to required keys for template

### DIFF
--- a/config/template.js
+++ b/config/template.js
@@ -39,7 +39,8 @@ const SCHEMA_TEMPLATE = Joi.object()
         maintainer: TEMPLATE_MAINTAINER,
         config: Job.job
     })
-    .requiredKeys('name', 'version', 'description', 'maintainer', 'config.steps');
+    .requiredKeys('name', 'version', 'description', 'maintainer',
+        'config', 'config.image', 'config.steps');
 
 /**
  * The definition of the Template pieces

--- a/test/config/template.test.js
+++ b/test/config/template.test.js
@@ -9,5 +9,10 @@ describe('config template', () => {
         it('validates safely', () => {
             assert.isNull(validate('config.template.yaml', config.template.template).error);
         });
+
+        it('returns error when no config key in template', () => {
+            assert.isNotNull(validate('config.template.bad.yaml',
+                config.template.template).error);
+        });
     });
 });

--- a/test/data/config.template.bad.yaml
+++ b/test/data/config.template.bad.yaml
@@ -1,0 +1,4 @@
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com


### PR DESCRIPTION
Even though `'config.steps'` is already in the required keys for template `Joi.object`, it turns out that `'config'` itself needs to be required. Currently, this is not valid:

```yaml
name: template/test
version: 1.0.0
description: Publishes the template yaml from sd-template.yaml
maintainer: tiffanykyi@gmail.com
config:
    image: node:6
    # No steps key
```

But this is valid:

```yaml
name: template/test
version: 1.0.0
description: Publishes the template yaml from sd-template.yaml
maintainer: tiffanykyi@gmail.com
# No config key
```