### PR TITLE
feat(473): Enable alwaysRun flag on steps

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -57,8 +57,19 @@ const SCHEMA_STEP_OBJECT = Joi.object()
             }
         }
     });
+const SCHEMA_FULL_STEP_OBJECT = Joi.object()
+    .keys({
+        name: Joi.string().regex(Regex.STEP_NAME),
+        command: SCHEMA_STEP_STRING,
+        alwaysRun: Joi.boolean()
+    })
+    .requiredKeys('name', 'command');
 
-const SCHEMA_STEP = Joi.alternatives().try(SCHEMA_STEP_STRING, SCHEMA_STEP_OBJECT);
+const SCHEMA_STEP = Joi.alternatives().try(
+    SCHEMA_STEP_STRING,
+    SCHEMA_STEP_OBJECT,
+    SCHEMA_FULL_STEP_OBJECT
+);
 const SCHEMA_STEPS = Joi.array().items(SCHEMA_STEP).min(1);
 const SCHEMA_IMAGE = Joi.string();
 const SCHEMA_SETTINGS = Joi.object().optional();

--- a/models/build.js
+++ b/models/build.js
@@ -14,6 +14,10 @@ const STEP = {
         .string()
         .description('Command of the Step to execute')
         .example('npm install'),
+    alwaysRun: Joi
+        .boolean()
+        .description('Flag to run a step regardless of past statuses')
+        .example(true),
     code: Joi
         .number().integer()
         .description('Exit code')
@@ -100,7 +104,7 @@ const MODEL = {
     steps: Joi
         .array().items(
             Joi.object(
-                mutate(STEP, ['name'], ['code', 'startTime', 'endTime', 'command'])
+                mutate(STEP, ['name'], ['code', 'startTime', 'endTime', 'command', 'alwaysRun'])
             ).description('Step metadata'))
         .description('List of steps'),
 
@@ -173,7 +177,8 @@ module.exports = {
         'code',
         'startTime',
         'endTime',
-        'command'
+        'command',
+        'alwaysRun'
     ])).label('Get Step Metadata'),
 
     /**

--- a/test/data/config.job.steps.yaml
+++ b/test/data/config.job.steps.yaml
@@ -1,3 +1,6 @@
 - init: npm install
 - test: npm test
 - npm publish
+- name: fullstep
+  command: echo hello
+  alwaysRun: true

--- a/test/data/step.get.yaml
+++ b/test/data/step.get.yaml
@@ -1,4 +1,5 @@
 name: sd-setup
 code: 0
+alwaysRun: true
 startTime: "2038-01-19T03:15:08.131Z"
 endTime: "2038-01-19T03:15:08.532Z"


### PR DESCRIPTION
Allows users to define a step verbosely in their `screwdriver.yaml`, to make it possible for an `alwaysRun` flag to exist:

```yaml
jobs:
    main:
        steps:
            - name: hello
               command: echo hello
               alwaysRun: true
```

After this is merged, I'll be able to test the `config-parser` changes properly

Related to https://github.com/screwdriver-cd/screwdriver/issues/473