### PR TITLE
fix: allow alwaysRun in validator output

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -5,13 +5,7 @@ const Regex = require('../config/regex');
 const Job = require('../config/job');
 const Workflow = require('../config/workflow');
 
-const SCHEMA_JOB_COMMAND = Joi.object()
-    .keys({
-        name: Joi.string(),
-        command: Joi.string()
-    })
-    .unknown(false)
-    .label('Named command to execute');
+const SCHEMA_JOB_COMMAND = Job.fullstep;
 
 const SCHEMA_JOB_COMMANDS = Joi.array()
     .items(SCHEMA_JOB_COMMAND)

--- a/config/job.js
+++ b/config/job.js
@@ -100,5 +100,6 @@ module.exports = {
     image: SCHEMA_IMAGE,
     job: SCHEMA_JOB,
     settings: SCHEMA_SETTINGS,
-    template: SCHEMA_TEMPLATE
+    template: SCHEMA_TEMPLATE,
+    fullstep: SCHEMA_FULL_STEP_OBJECT
 };

--- a/test/data/validator.output.yaml
+++ b/test/data/validator.output.yaml
@@ -4,10 +4,13 @@ jobs:
     commands:
       - name: install
         command: npm install
+        alwaysRun: false
       - name: test
         command: npm test
+        alwaysRun: false
       - name: build
         command: npm run build
+        alwaysRun: false
     environment:
       NODE_VERSION: 4
     settings:
@@ -16,10 +19,13 @@ jobs:
     commands:
     - name: install
       command: npm install
+      alwaysRun: false
     - name: test
       command: npm test
+      alwaysRun: false
     - name: build
       command: npm run build
+      alwaysRun: false
     environment:
       NODE_VERSION: 5
     settings:
@@ -28,10 +34,13 @@ jobs:
     commands:
     - name: install
       command: npm install
+      alwaysRun: false
     - name: test
       command: npm test
+      alwaysRun: false
     - name: build
       command: npm run build
+      alwaysRun: false
     environment:
       NODE_VERSION: 6
     settings:
@@ -44,6 +53,7 @@ jobs:
     commands:
     - name: install
       command: npm publish
+      alwaysRun: false
     environment: {}
     secrets:
       - NPM_TOKEN


### PR DESCRIPTION
Pipeline is currently failing due to this: https://cd.screwdriver.cd/pipelines/1/builds/3615

We need to allow this field for the validator output. 
Related: https://github.com/screwdriver-cd/screwdriver/issues/473
