### PR TITLE
fix: allow alwaysRun field for now to fix the pipeline

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -8,7 +8,8 @@ const Workflow = require('../config/workflow');
 const SCHEMA_JOB_COMMAND = Joi.object()
     .keys({
         name: Joi.string(),
-        command: Joi.string()
+        command: Joi.string(),
+        alwaysRun: Joi.boolean()
     })
     .unknown(false)
     .label('Named command to execute');


### PR DESCRIPTION
Our pipeline is failing at beta functional test:

Cuz it has alwaysRun in job permutation and we revert all changes so that job cannot be retrieved correctly. Allow it for now and when it run through the pipeline, alwaysRun flag will be removed. Then we can revert this. 