### PR TITLE
fix: add prNum as optional to getCommitSha

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -2,6 +2,7 @@
 
 const Joi = require('joi');
 const models = require('../models');
+const core = require('../core');
 const scmUri = Joi.reach(models.pipeline.base, 'scmUri').required();
 const token = Joi.reach(models.user.base, 'token').required();
 const sha = Joi.reach(models.build.base, 'sha').required();
@@ -9,6 +10,7 @@ const buildStatus = Joi.reach(models.build.base, 'status').required();
 const jobName = Joi.reach(models.job.base, 'name').optional();
 const username = Joi.reach(models.user.base, 'username').required();
 const checkoutUrl = Joi.reach(models.pipeline.create, 'checkoutUrl').required();
+const prNum = Joi.reach(core.scm.hook, 'prNum').allow(null).optional();
 
 const ADD_WEBHOOK = Joi.object().keys({
     scmUri,
@@ -37,7 +39,8 @@ const GET_PERMISSIONS = Joi.object().keys({
 
 const GET_COMMIT_SHA = Joi.object().keys({
     scmUri,
-    token
+    token,
+    prNum
 }).required();
 
 const UPDATE_COMMIT_STATUS = Joi.object().keys({

--- a/test/data/scm.getCommitSha.yaml
+++ b/test/data/scm.getCommitSha.yaml
@@ -1,2 +1,3 @@
 scmUri: github.com:12345678:master
 token: 'thisisatokenthingy'
+prNum: null


### PR DESCRIPTION
fix: add `prNum` as optional to getCommitSha

`prNum` is optional and can be `null` since the` job` model may return null if it is not a PR:
https://github.com/screwdriver-cd/models/blob/master/lib/job.js#L93

This change is backward compatible.

Related to https://github.com/screwdriver-cd/screwdriver/issues/244

