### PR TITLE
Fix a typo in readme, change a field name for clarity and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The model represents a combination of what is required to create the resource an
 
 ### Methodology
 
-Each model contains seven (8) schemas:
+Each model contains eight (8) schemas:
  - `base` - List of all available fields in the model
  - `allKeys` - List of all fields in the model
  - `get` - Expected return values from a GET request against this resource

--- a/models/token.js
+++ b/models/token.js
@@ -4,7 +4,7 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 
 const MODEL = {
-    token: Joi
+    value: Joi
         .string()
         .token(),
 

--- a/test/data/token.yaml
+++ b/test/data/token.yaml
@@ -1,6 +1,6 @@
 # Base Token Example
 userId: 1234
-token: 'hashed_token_value_goes_here'
+value: 'hashed_token_value_goes_here'
 id: 1111
 name: 'Auth token'
 description: 'A token for authentication'


### PR DESCRIPTION
* In the readme.md, I updated the number in brackets last time but forgot to update the word, so it said "seven (8)"
* token.value is clearer than token.token, and matches the naming of the secrets schema