### PR TITLE
fix: Edit comments

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -17,5 +17,5 @@ jobs:
         secrets:
             # Publishing to NPM
             - NPM_TOKEN
-            # Pushing tags to Git
+            # Github token to push tags to Git
             - GH_TOKEN


### PR DESCRIPTION
The github squash and merge from this PR https://github.com/screwdriver-cd/data-schema/pull/130 created a new commit message, and it didn't conform with semantic-release. So `publish` job failed because it couldn't find a version change: https://cd.screwdriver.cd/pipelines/12/builds/4263