### PR TITLE
fix: Don't store token value, do store a uuid to allow tokens to be revoked

### DIFF
--- a/models/token.js
+++ b/models/token.js
@@ -4,14 +4,17 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 
 const MODEL = {
-    value: Joi
-        .string()
-        .token(),
-
     id: Joi
         .number()
         .integer()
         .positive(),
+
+    uuid: Joi
+        .string()
+        .guid({
+            version: ['uuidv4']
+        })
+        .description('Identifies tokens so they can be revoked'),
 
     userId: Joi
         .number()

--- a/test/data/token.yaml
+++ b/test/data/token.yaml
@@ -1,6 +1,6 @@
 # Base Token Example
 userId: 1234
-value: 'hashed_token_value_goes_here'
+uuid: '110ec58a-a0f2-4ac4-8393-c866d813b8d1'
 id: 1111
 name: 'Auth token'
 description: 'A token for authentication'


### PR DESCRIPTION
We have realized that we don't need to actually store the token value.

The token can be validated by checking it with a public key. It also contains information about the user, to check that they have access to whatever resource they're requesting.

Then the only thing left to do is to check that the user has not revoked the token, which can be done by comparing the uuid in the token against a list of uuid's of valid tokens in the datastore.

Then we don't need to worry about keeping a list of unsealed tokens on the user object. Sealing the incoming token and comparing to the sealed values of the tokens doesn't work, as iron checks the current time as part of sealing.

Related to https://github.com/screwdriver-cd/screwdriver/issues/532