### PR TITLE
fix: Validate hashed token value

### DIFF
--- a/models/token.js
+++ b/models/token.js
@@ -2,6 +2,12 @@
 
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
+// Token length, measured in bits
+const TOKEN_LENGTH = 256;
+// Calculate the character length of the base64 string representing TOKEN_LENGTH bits
+// Each base64 character represents 6 bits of data, and strings are padded to be a
+// multiple of 4
+const HASH_LENGTH = Math.ceil(TOKEN_LENGTH / 6 / 4) * 4;
 
 const MODEL = {
     id: Joi
@@ -9,9 +15,11 @@ const MODEL = {
         .integer()
         .positive(),
 
-    value: Joi
+    hash: Joi
         .string()
-        .description('Token value'),
+        .base64()
+        .length(HASH_LENGTH)
+        .description('Hashed token value'),
 
     userId: Joi
         .number()
@@ -114,5 +122,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: ['userId']
+    indexes: ['hash', 'userId']
 };

--- a/test/data/token.yaml
+++ b/test/data/token.yaml
@@ -1,6 +1,6 @@
 # Base Token Example
 userId: 1234
-value: 'a secret token value'
+hash: 'aHashedTokenValueMustBe44CharactersLong+++++'
 id: 1111
 name: 'Auth token'
 description: 'A token for authentication'


### PR DESCRIPTION
* Need to index on the hashed value so we can look it up easily
* Not using iron means we can specify exactly what the hashed value should look like

Related to https://github.com/screwdriver-cd/screwdriver/issues/532