### PR TITLE
fix: Tokens are unique by hash

### DIFF
--- a/models/token.js
+++ b/models/token.js
@@ -99,7 +99,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['userId', 'name'],
+    keys: ['hash'],
 
     /**
      * List of all fields in the model


### PR DESCRIPTION
Name/username uniqueness can be checked manually in the API.

In order to be able to call `tokenFactory.get({ hash })` and not have to reimplement the base `get` function the schema has to say that hash is a unique column.

Related to https://github.com/screwdriver-cd/screwdriver/issues/532