### PR TITLE
fix(tokens): Sequelize didn't like null values

### DIFF
--- a/models/token.js
+++ b/models/token.js
@@ -42,7 +42,7 @@ const MODEL = {
     lastUsed: Joi
         .string()
         .isoDate()
-        .allow(null)
+        .allow('')
         .description('Last used')
 };
 


### PR DESCRIPTION
The datastore wasn't validating tokens that hadn't been used, because the `.allow(null)` was being ignored by the datastore-sequelize plugin. Now using empty strings instead of `null`.

Related to https://github.com/screwdriver-cd/screwdriver/issues/532