### PR TITLE
fix(tokens): Encode tokens with URI-safe encoding

### DIFF
--- a/models/token.js
+++ b/models/token.js
@@ -4,10 +4,8 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 // Token length, measured in bits
 const TOKEN_LENGTH = 256;
-// Calculate the character length of the base64 string representing TOKEN_LENGTH bits
-// Each base64 character represents 6 bits of data, and strings are padded to be a
-// multiple of 4
-const HASH_LENGTH = Math.ceil(TOKEN_LENGTH / 6 / 4) * 4;
+// Character length of the hex string representing TOKEN_LENGTH bits
+const HASH_LENGTH = TOKEN_LENGTH / 4;
 
 const MODEL = {
     id: Joi
@@ -17,7 +15,7 @@ const MODEL = {
 
     hash: Joi
         .string()
-        .base64()
+        .hex()
         .length(HASH_LENGTH)
         .description('Hashed token value'),
 

--- a/test/data/token.yaml
+++ b/test/data/token.yaml
@@ -1,6 +1,6 @@
 # Base Token Example
 userId: 1234
-hash: 'aHashedTokenValueMustBe44CharactersLong+++++'
+hash: 'abcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd'
 id: 1111
 name: 'Auth token'
 description: 'A token for authentication'


### PR DESCRIPTION
* tokens were previously stored in base64 encoding, which is not URI-safe
* switched encoding to hexadecimal

Related to https://github.com/screwdriver-cd/screwdriver/issues/532