### PR TITLE
fix(tokens): Use url-safe base64 encoding

### DIFF
--- a/models/token.js
+++ b/models/token.js
@@ -17,7 +17,7 @@ const MODEL = {
 
     hash: Joi
         .string()
-        .base64()
+        .regex(/[a-zA-Z0-9_-]+~/)
         .length(HASH_LENGTH)
         .description('Hashed token value'),
 

--- a/test/data/token.yaml
+++ b/test/data/token.yaml
@@ -1,6 +1,6 @@
 # Base Token Example
 userId: 1234
-hash: 'aHashedTokenValueMustBe44CharactersLong+++++'
+hash: 'aHashedTokenValueMustBe44CharactersLong_-_-~'
 id: 1111
 name: 'Auth token'
 description: 'A token for authentication'


### PR DESCRIPTION
* the default base64 encoding uses `+`, `/`, and `=`
* replace those with `_`, `-`, and `~`

Related to https://github.com/screwdriver-cd/screwdriver/issues/532