### PR TITLE
fix(tokens): Use base64url library for encoding

### DIFF
--- a/models/token.js
+++ b/models/token.js
@@ -5,9 +5,8 @@ const mutate = require('../lib/mutate');
 // Token length, measured in bits
 const TOKEN_LENGTH = 256;
 // Calculate the character length of the base64 string representing TOKEN_LENGTH bits
-// Each base64 character represents 6 bits of data, and strings are padded to be a
-// multiple of 4
-const HASH_LENGTH = Math.ceil(TOKEN_LENGTH / 6 / 4) * 4;
+// Each base64 character represents 6 bits of data
+const HASH_LENGTH = Math.ceil(TOKEN_LENGTH / 6);
 
 const MODEL = {
     id: Joi
@@ -17,7 +16,8 @@ const MODEL = {
 
     hash: Joi
         .string()
-        .regex(/[a-zA-Z0-9_-]+~/)
+        // Using https://www.npmjs.com/package/base64url
+        .regex(/[a-zA-Z0-9_-]+/)
         .length(HASH_LENGTH)
         .description('Hashed token value'),
 

--- a/test/data/token.yaml
+++ b/test/data/token.yaml
@@ -1,6 +1,6 @@
 # Base Token Example
 userId: 1234
-hash: 'aHashedTokenValueMustBe44CharactersLong_-_-~'
+hash: 'aHashedTokenValueMustBe43CharactersLong_-_-'
 id: 1111
 name: 'Auth token'
 description: 'A token for authentication'


### PR DESCRIPTION
Didn't see @FenrirUnbound's [comment](https://github.com/screwdriver-cd/data-schema/pull/140#discussion_r120495728) until after the last PR was merged. He has a good point about the relative merits of using a library versus a function defined in the models files.

Notably, it changes how long the hashes we're storing are, because that library replaces `=` with nothing as opposed to a `~`.

Related to https://github.com/screwdriver-cd/screwdriver/issues/532