### PR TITLE
feat(545): add field to timeout builds

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -89,6 +89,11 @@ const MODEL = {
         .isoDate()
         .description('When this build stopped running'),
 
+    timeoutTime: Joi
+        .string()
+        .isoDate()
+        .description('When this build should stop due to timeout'),
+
     parameters: Joi
         .object()
         .description('Input parameters that defined this build'),
@@ -136,7 +141,7 @@ module.exports = {
         'id', 'jobId', 'number', 'cause', 'createTime', 'status'
     ], [
         'container', 'parentBuildId', 'sha', 'startTime', 'endTime', 'meta', 'parameters', 'steps',
-        'commit', 'eventId', 'environment'
+        'commit', 'eventId', 'environment', 'timeoutTime'
     ])).label('Get Build'),
 
     /**
@@ -148,7 +153,8 @@ module.exports = {
     update: Joi.object(mutate(MODEL, [
         'status'
     ], [
-        'meta'
+        'meta',
+        'timeoutTime'
     ])).label('Update Build'),
 
     /**

--- a/test/data/build.update.yaml
+++ b/test/data/build.update.yaml
@@ -1,4 +1,5 @@
 # Build Update Example
 status: ABORTED
+timeoutTime: '2017-05-08T22:48:53+00:00'
 meta:
     yes: no


### PR DESCRIPTION
Users (and admins) will want builds to timeout after some period of time to free up compute nodes. 

This PR adds a new field that can be used to store a date, after which the build should be aborted automatically due to a timeout.

* Relates to issue https://github.com/screwdriver-cd/screwdriver/issues/545
* Duplicates PR #127 in the hope that the `alter table` issue is fixed when https://github.com/screwdriver-cd/datastore-sequelize/pull/18 is merged.