### PR TITLE
fix: allow pipelineId in updateCommitStatus

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -11,6 +11,7 @@ const jobName = Joi.reach(models.job.base, 'name').optional();
 const username = Joi.reach(models.user.base, 'username').required();
 const checkoutUrl = Joi.reach(models.pipeline.create, 'checkoutUrl').required();
 const prNum = Joi.reach(core.scm.hook, 'prNum').allow(null).optional();
+const pipelineId = Joi.reach(models.pipeline.base, 'id').optional();
 
 const ADD_WEBHOOK = Joi.object().keys({
     scmUri,
@@ -49,7 +50,8 @@ const UPDATE_COMMIT_STATUS = Joi.object().keys({
     sha,
     buildStatus,
     jobName,
-    url: Joi.string().uri().required()
+    url: Joi.string().uri().required(),
+    pipelineId
 }).required();
 
 const GET_FILE = Joi.object().keys({

--- a/test/data/scm.updateCommitStatus.yaml
+++ b/test/data/scm.updateCommitStatus.yaml
@@ -4,3 +4,4 @@ sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
 buildStatus: SUCCESS
 jobName: main
 url: https://foo.bar
+pipelineId: 123


### PR DESCRIPTION
We need the pipelineId to distinguish different pipelines, when subdirectory is supported. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/471