### PR TITLE
fix(604): Add annotations to executor start

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const Annotations = require('../config/annotations');
 const Joi = require('joi');
 const models = require('../models');
 const buildId = Joi.reach(models.build.base, 'id').required();
 const SCHEMA_START = Joi.object().keys({
+    annotations: Annotations.annotations,
     buildId,
     container: Joi.reach(models.build.base, 'container').required(),
     apiUri: Joi.string().uri().required()

--- a/test/data/executor.startNoAnnotations.yaml
+++ b/test/data/executor.startNoAnnotations.yaml
@@ -1,5 +1,3 @@
-annotations:
-    beta.screwdriver.cd/executor: k8s
 buildId: 8609
 container: node:4
 apiUri: http://localhost:8080

--- a/test/plugins/executor.test.js
+++ b/test/plugins/executor.test.js
@@ -10,6 +10,10 @@ describe('executor test', () => {
             assert.isNull(validate('executor.start.yaml', executor.start).error);
         });
 
+        it('validates the start with no annotations', () => {
+            assert.isNull(validate('executor.startNoAnnotations.yaml', executor.start).error);
+        });
+
         it('fails the start for empty yaml', () => {
             assert.isNotNull(validate('empty.yaml', executor.start).error);
         });


### PR DESCRIPTION
Adding annotations to the start schema for executors. This will allow people to send annotations to specify which executor to use when starting a build.

Example annotations yaml segment:
```
annotations:
    beta.screwdriver.cd/executor: k8s
```

Related to https://github.com/screwdriver-cd/screwdriver/issues/604