### PR TITLE
fix(562): Add schema for updating a pipeline

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -76,6 +76,14 @@ module.exports = {
     create: Joi.object(CHECKOUT_URL).label('Create Pipeline'),
 
     /**
+     * Properties for Pipeline that will be passed during an UPDATE request
+     *
+     * @property update
+     * @type {Joi}
+     */
+    update: Joi.object(CHECKOUT_URL).label('Update Pipeline'),
+
+    /**
      * List of fields that determine a unique row
      *
      * @property keys

--- a/test/data/pipeline.update.yaml
+++ b/test/data/pipeline.update.yaml
@@ -1,0 +1,2 @@
+# Pipeline Create Example
+checkoutUrl: git@github.com:screwdriver-cd/data-schema.git#branch

--- a/test/models/pipeline.test.js
+++ b/test/models/pipeline.test.js
@@ -30,4 +30,14 @@ describe('model pipeline', () => {
             assert.isNotNull(validate('empty.yaml', models.pipeline.get).error);
         });
     });
+
+    describe('update', () => {
+        it('validates the update', () => {
+            assert.isNull(validate('pipeline.update.yaml', models.pipeline.update).error);
+        });
+
+        it('fails the update', () => {
+            assert.isNotNull(validate('empty.yaml', models.pipeline.update).error);
+        });
+    });
 });


### PR DESCRIPTION
## Context

Users currently cannot update the repo/branch for their pipeline.

## Objective

This PR adds a schema for updating a pipeline. We're keeping it as a `checkoutUrl` since it is more user friendly.

## References
https://github.com/screwdriver-cd/screwdriver/issues/562