### PR TITLE
fix(604): Add annotations to executor stop

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -14,6 +14,7 @@ const SCHEMA_START = Joi.object().keys({
         .label('Build JWT')
 }).required();
 const SCHEMA_STOP = Joi.object().keys({
+    annotations: Annotations.annotations,
     buildId
 }).required();
 const SCHEMA_STATUS = Joi.object().keys({

--- a/test/data/executor.stop.yaml
+++ b/test/data/executor.stop.yaml
@@ -1,1 +1,3 @@
+annotations:
+    beta.screwdriver.cd/executor: k8s
 buildId: 453264


### PR DESCRIPTION
Executor stop needs to be able to take in `annotations`

Original issue: https://github.com/screwdriver-cd/screwdriver/issues/604
Related to https://github.com/screwdriver-cd/screwdriver/pull/607