### PR TITLE
feat(365): Add scmContext to models

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -27,6 +27,11 @@ const MODEL = {
         .description('Unique identifier for the application')
         .example('github.com:123456:master'),
 
+    scmContext: Joi
+        .string().max(128)
+        .description('The SCM in which the repository exists')
+        .example('github.com'),
+
     scmRepo: Scm.repo,
 
     createTime: Joi
@@ -62,7 +67,7 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'scmUri', 'createTime', 'admins'
+        'id', 'scmUri', 'scmContext', 'createTime', 'admins'
     ], [
         'workflow', 'scmRepo', 'annotations'
     ])).label('Get Pipeline'),

--- a/models/user.js
+++ b/models/user.js
@@ -17,7 +17,13 @@ const MODEL = {
 
     token: Joi
         .string()
-        .description('Github token')
+        .description('Github token'),
+
+    scmContext: Joi
+        .string()
+        .max(128)
+        .description('The SCM to which the user belongs')
+        .example('github.com')
 };
 
 module.exports = {
@@ -36,7 +42,7 @@ module.exports = {
      * @type {Joi}
      */
     create: Joi.object(mutate(MODEL, [
-        'username'
+        'username', 'scmContext'
     ], [])).label('Create User'),
 
     /**
@@ -45,7 +51,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['username'],
+    keys: ['username', 'scmContext'],
 
     /**
      * List of all fields in the model
@@ -68,5 +74,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: ['username']
+    indexes: ['username', 'scmContext']
 };

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -1,6 +1,7 @@
 # Pipeline Get Example
 id: 12742
 scmUri: github.com:12345678:master
+scmContext: github.com
 createTime: "2017-04-11"
 admins:
     username: true

--- a/test/data/pipeline.yaml
+++ b/test/data/pipeline.yaml
@@ -1,6 +1,7 @@
 # Pipeline Example
 id: 7969
 scmUri: github.com:12345678:master
+scmContext: github.com
 createTime: "2017-04-19T14:55:11"
 scmRepo:
     name: screwdriver-cd/screwdriver

--- a/test/data/user.create.yaml
+++ b/test/data/user.create.yaml
@@ -1,2 +1,3 @@
 # User Create Example
 username: superman
+scmContext: super-github.com

--- a/test/data/user.yaml
+++ b/test/data/user.yaml
@@ -1,2 +1,3 @@
 # User Example
 username: batman
+scmContext: github.com


### PR DESCRIPTION
This PR add `scmContext` to models.It is a change for the support multiple SCMs.
`scmContext` determines that an user is currently logged into by which scm.