### PR TITLE
feat(523): Add collection schemas and tests

### DIFF
--- a/models/collection.js
+++ b/models/collection.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const Joi = require('joi');
+const mutate = require('../lib/mutate');
+
+const MODEL = {
+    id: Joi
+        .number()
+        .integer()
+        .positive(),
+
+    userId: Joi
+        .number()
+        .integer()
+        .positive()
+        .description('User ID'),
+
+    name: Joi
+        .string()
+        .max(128)
+        .description('Collection name')
+        .example('Favorites'),
+
+    description: Joi
+        .string()
+        .max(256)
+        .description('Collection description')
+        .example('List of my favorite pipelines'),
+
+    pipelineIds: Joi
+        .array()
+        .items(Joi.number().integer().positive())
+};
+
+module.exports = {
+    /**
+     * All the available properties of Collection
+     *
+     * @property base
+     * @type {Joi}
+     */
+    base: Joi.object(MODEL).label('Collection'),
+
+    /**
+     * Properties for collection that will come back during a GET request
+     *
+     * @property get
+     * @type {Joi}
+     */
+    get: Joi.object(mutate(MODEL, [
+        'id',
+        'name',
+        'pipelineIds'
+    ], [
+        'description'
+    ])).label('Get collection'),
+
+    /**
+     * Properties for Collection that will be passed during a CREATE request
+     *
+     * @property create
+     * @type {Joi}
+     */
+    create: Joi.object(mutate(MODEL, [
+        'name'
+    ], [
+        'description',
+        'pipelineIds'
+    ])).label('Create collection'),
+
+    /**
+     * Properties for Collection that will be passed during a UPDATE request
+     *
+     * @property update
+     * @type {Joi}
+     */
+    update: Joi.object(mutate(MODEL, [], [
+        'name',
+        'description',
+        'pipelineIds'
+    ])).label('Update collection'),
+
+    /**
+     * List of fields that determine a unique row
+     *
+     * @property keys
+     * @type {Array}
+     */
+    keys: ['id'],
+
+    /**
+     * List of all fields in the model
+     *
+     * @property allKeys
+     * @type {Array}
+     */
+    allKeys: Object.keys(MODEL),
+
+    /**
+     * Tablename to be used in the datastore
+     *
+     * @property tableName
+     * @type {String}
+     */
+    tableName: 'collections',
+
+    /**
+     * List of indexes to create in the datastore
+     *
+     * @property indexes
+     * @type {Array}
+     */
+    indexes: ['userId']
+};

--- a/models/index.js
+++ b/models/index.js
@@ -8,5 +8,6 @@ const user = require('./user');
 const secret = require('./secret');
 const template = require('./template');
 const token = require('./token');
+const collection = require('./collection');
 
-module.exports = { build, event, job, pipeline, user, secret, template, token };
+module.exports = { build, event, job, pipeline, user, secret, template, token, collection };

--- a/test/data/collection.create.yaml
+++ b/test/data/collection.create.yaml
@@ -1,0 +1,2 @@
+# Collection Create Example
+name: 'Personal'

--- a/test/data/collection.createWithDescription.yaml
+++ b/test/data/collection.createWithDescription.yaml
@@ -1,0 +1,3 @@
+# Collection Create with Description Example
+name: 'Personal'
+description: 'Collection for personal pipelines'

--- a/test/data/collection.createWithPipelineIds.yaml
+++ b/test/data/collection.createWithPipelineIds.yaml
@@ -1,0 +1,7 @@
+# Collection Create with PipelineIds
+name: 'Personal'
+pipelineIds:
+    - 23
+    - 45
+    - 67
+    - 89

--- a/test/data/collection.get.yaml
+++ b/test/data/collection.get.yaml
@@ -1,0 +1,9 @@
+# Collection GET Example
+id: 123
+name: 'Screwdriver'
+description: 'Collection of screwdriver related pipelines'
+pipelineIds:
+    - 912
+    - 345
+    - 567
+    - 765

--- a/test/data/collection.update.yaml
+++ b/test/data/collection.update.yaml
@@ -1,0 +1,8 @@
+# Collection Update Example
+name: 'New Collection'
+description: 'Changed description'
+pipelineIds:
+    - 15
+    - 25
+    - 35
+    - 45

--- a/test/data/collection.yaml
+++ b/test/data/collection.yaml
@@ -1,0 +1,10 @@
+# Base Collection Example
+id: 123
+userId: 456
+name: 'Screwdriver'
+description: 'A collection for screwdriver pipelines'
+pipelineIds:
+    - 1
+    - 2
+    - 3
+    - 4

--- a/test/models/collection.test.js
+++ b/test/models/collection.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const assert = require('chai').assert;
+const models = require('../../').models;
+const validate = require('../helper').validate;
+
+describe('collection template', () => {
+    describe('base', () => {
+        it('validates the base', () => {
+            assert.isNull(validate('collection.yaml', models.collection.base).error);
+        });
+    });
+
+    describe('get', () => {
+        it('validates the get', () => {
+            assert.isNull(validate('collection.get.yaml', models.collection.get).error);
+        });
+
+        it('fails the get', () => {
+            assert.isNotNull(validate('empty.yaml', models.collection.get).error);
+        });
+    });
+
+    describe('create', () => {
+        it('validates the create', () => {
+            assert.isNull(validate('collection.create.yaml', models.collection.create).error);
+        });
+
+        it('validates the create with a description', () => {
+            assert.isNull(validate(
+                'collection.createWithDescription.yaml',
+                models.collection.create).error
+            );
+        });
+
+        it('validates the create with pipeline ids', () => {
+            assert.isNull(validate(
+                'collection.createWithPipelineIds.yaml',
+                models.collection.create).error
+            );
+        });
+
+        it('fails the create', () => {
+            assert.isNotNull(validate('empty.yaml', models.collection.create).error);
+        });
+    });
+
+    describe('update', () => {
+        it('validates the update', () => {
+            assert.isNull(validate('collection.update.yaml', models.collection.update).error);
+        });
+
+        it('fails the update', () => {
+            assert.isNotNull(validate('empty.yaml', models.collection.update).error);
+        });
+    });
+});


### PR DESCRIPTION
# Context

Schema validation for Collections

# Objective

This PR adds a schema for Collections along with tests to be used for the creation of a CRUD API for collections

# References

issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)