### PR TITLE
fix(tokens): Allow token descriptions to be set to empty

### DIFF
--- a/models/token.js
+++ b/models/token.js
@@ -36,6 +36,7 @@ const MODEL = {
     description: Joi
         .string()
         .max(256)
+        .allow('')
         .description('Token description')
         .example('Used to authenticate the mobile app'),
 

--- a/test/data/token.update.yaml
+++ b/test/data/token.update.yaml
@@ -1,3 +1,3 @@
 # Token UPDATE Example
 name: 'A new token name'
-description: 'A new token description'
+description: ''


### PR DESCRIPTION
## Context:
Currently any attempt to update a token to have an empty description will fail because Joi won't validate it. Joi's `any.optional()` allows `undefined`, but not `''`.
## Objective:
Allow users to set the description of their tokens to be empty.
## References:
https://github.com/hapijs/joi/blob/v10.6.0/API.md#anyoptional