### PR TITLE
fix(collections): Change keys in collections schema

### DIFF
--- a/models/collection.js
+++ b/models/collection.js
@@ -86,7 +86,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['id'],
+    keys: ['userId', 'name'],
 
     /**
      * List of all fields in the model


### PR DESCRIPTION
# Context

Since id is auto-incremented and thus unique, it makes more sense to
have the keys be `userId` and `name` as a User should not have 2
collections with the same name.

# Objective

To set `userId` and `name` as the unique fields for a row as we do not want to allow a particular user to have 2 collections with the same name.

# References

Pull Request: [screwdriver-cd/models#178](https://github.com/screwdriver-cd/models/pull/178#pullrequestreview-49010254)
Feature issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)