### PR TITLE
feat: add template tag

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -7,7 +7,10 @@ const pipeline = require('./pipeline');
 const user = require('./user');
 const secret = require('./secret');
 const template = require('./template');
+const templateTag = require('./templateTag');
 const token = require('./token');
 const collection = require('./collection');
 
-module.exports = { build, event, job, pipeline, user, secret, template, token, collection };
+module.exports = {
+    build, event, job, pipeline, user, secret, template, templateTag, token, collection
+};

--- a/models/template.js
+++ b/models/template.js
@@ -55,7 +55,7 @@ module.exports = {
     ], ['labels'])).label('Create Template'),
 
     /**
-     * Properties for template that will be passed during a UPDATE requeste
+     * Properties for template that will be passed during a UPDATE request
      *
      * @property update
      * @type {Joi}

--- a/models/templateTag.js
+++ b/models/templateTag.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const Joi = require('joi');
+const mutate = require('../lib/mutate');
+const Template = require('../config/template');
+
+const MODEL = {
+    id: Joi
+        .number().integer().positive()
+        .description('Identifier of this template tag')
+        .example(123345),
+    name: Template.name,
+    tag: Joi
+        .string()
+        .alphanum()
+        .max(30)
+        .required(),
+    version: Template.version
+};
+
+module.exports = {
+    /**
+     * All the available properties of Template Tag
+     *
+     * @property base
+     * @type {Joi}
+     */
+    base: Joi.object(MODEL).label('TemplateTag'),
+
+    /**
+     * Properties for template tag that will be passed during a CREATE request
+     *
+     * @property create
+     * @type {Joi}
+     */
+    create: Joi.object(mutate(MODEL, ['name', 'tag', 'version'], []))
+        .label('Create Template Tag'),
+
+    /**
+     * List of fields that determine a unique row
+     *
+     * @property keys
+     * @type {Array}
+     */
+    keys: ['name', 'tag'],
+
+    /**
+     * List of all fields in the model
+     * @property allKeys
+     * @type {Array}
+     */
+    allKeys: Object.keys(MODEL),
+
+    /**
+     * List of indexes to create in the datastore
+     *
+     * @property indexes
+     * @type {Array}
+     */
+    indexes: ['name', 'tag'],
+
+    /**
+     * Tablename to be used in the datastore
+     *
+     * @property tableName
+     * @type {String}
+     */
+    tableName: 'templateTags'
+};

--- a/test/data/templatetag.create.yaml
+++ b/test/data/templatetag.create.yaml
@@ -1,0 +1,4 @@
+# Template Tag CREATE Example
+name: test/template
+tag: 'stable'
+version: '1.2.0'

--- a/test/data/templatetag.yaml
+++ b/test/data/templatetag.yaml
@@ -1,0 +1,5 @@
+# Base Template Tag Example
+id: 123234135
+name: test/template
+tag: 'stable'
+version: '1.2.0'

--- a/test/models/templatetag.test.js
+++ b/test/models/templatetag.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const assert = require('chai').assert;
+const models = require('../../').models;
+const validate = require('../helper').validate;
+
+describe('model template tag', () => {
+    describe('base', () => {
+        it('validates the base', () => {
+            assert.isNull(validate('templatetag.yaml', models.templateTag.base).error);
+        });
+    });
+
+    describe('create', () => {
+        it('validates the create', () => {
+            assert.isNull(validate('templatetag.create.yaml', models.templateTag.create).error);
+        });
+
+        it('fails the create', () => {
+            assert.isNotNull(validate('empty.yaml', models.templateTag.create).error);
+        });
+    });
+});


### PR DESCRIPTION
Add a Template Tag model, which consists of name, tag, and version. 

Example: `mytemplate@1.2.0` can be tagged as `stable` and `latest`

In the templateTags table, there will be a record that looks like 

| id | name | tag | version | 
|---|---|---|---|
| 1 | mytemplate | stable | 1.2.0 | 
| 2 | mytemplate | latest | 1.2.0 | 

If they want to change `stable` to `1.1.0`, then the table will look like 

| id | name | tag | version | 
|---|---|---|---|
| 1 | mytemplate | stable | 1.1.0 | 
| 2 | mytemplate | latest | 1.2.0 | 

Related: https://github.com/screwdriver-cd/screwdriver/issues/616