### PR TITLE
fix(616): Add remove schema for template tags

### DIFF
--- a/models/templateTag.js
+++ b/models/templateTag.js
@@ -37,6 +37,15 @@ module.exports = {
         .label('Create Template Tag'),
 
     /**
+     * Properties for template tag that will be passed during a DELETE request
+     *
+     * @property remove
+     * @type {Joi}
+     */
+    remove: Joi.object(mutate(MODEL, ['name', 'tag'], []))
+        .label('Remove Template Tag'),
+
+    /**
      * List of fields that determine a unique row
      *
      * @property keys


### PR DESCRIPTION
## Context

We would like to add an endpoint for deleting template tags.

## Objective

This PR adds a schema for the delete endpoint for template tags.

## Related Links
- Template tag data schema PR: https://github.com/screwdriver-cd/data-schema/pull/157
- Original issue: https://github.com/screwdriver-cd/screwdriver/issues/616