### PR TITLE
Revert "feat(365): Add scmContext to models #152"

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -27,11 +27,6 @@ const MODEL = {
         .description('Unique identifier for the application')
         .example('github.com:123456:master'),
 
-    scmContext: Joi
-        .string().max(128)
-        .description('The SCM in which the repository exists')
-        .example('github.com'),
-
     scmRepo: Scm.repo,
 
     createTime: Joi
@@ -67,7 +62,7 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'scmUri', 'scmContext', 'createTime', 'admins'
+        'id', 'scmUri', 'createTime', 'admins'
     ], [
         'workflow', 'scmRepo', 'annotations'
     ])).label('Get Pipeline'),

--- a/models/user.js
+++ b/models/user.js
@@ -17,13 +17,7 @@ const MODEL = {
 
     token: Joi
         .string()
-        .description('Github token'),
-
-    scmContext: Joi
-        .string()
-        .max(128)
-        .description('The SCM to which the user belongs')
-        .example('github.com')
+        .description('Github token')
 };
 
 module.exports = {
@@ -42,7 +36,7 @@ module.exports = {
      * @type {Joi}
      */
     create: Joi.object(mutate(MODEL, [
-        'username', 'scmContext'
+        'username'
     ], [])).label('Create User'),
 
     /**
@@ -51,7 +45,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['username', 'scmContext'],
+    keys: ['username'],
 
     /**
      * List of all fields in the model
@@ -74,5 +68,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: ['username', 'scmContext']
+    indexes: ['username']
 };

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -1,7 +1,6 @@
 # Pipeline Get Example
 id: 12742
 scmUri: github.com:12345678:master
-scmContext: github.com
 createTime: "2017-04-11"
 admins:
     username: true

--- a/test/data/pipeline.yaml
+++ b/test/data/pipeline.yaml
@@ -1,7 +1,6 @@
 # Pipeline Example
 id: 7969
 scmUri: github.com:12345678:master
-scmContext: github.com
 createTime: "2017-04-19T14:55:11"
 scmRepo:
     name: screwdriver-cd/screwdriver

--- a/test/data/user.create.yaml
+++ b/test/data/user.create.yaml
@@ -1,3 +1,2 @@
 # User Create Example
 username: superman
-scmContext: super-github.com

--- a/test/data/user.yaml
+++ b/test/data/user.yaml
@@ -1,3 +1,2 @@
 # User Example
 username: batman
-scmContext: github.com


### PR DESCRIPTION
Revert https://github.com/screwdriver-cd/data-schema/pull/152 because of failing build https://cd.screwdriver.cd/pipelines/1/builds/7373 
We need other component (api, model. scm-XXX) update  before merge.

Related: https://github.com/screwdriver-cd/screwdriver/issues/365