### PR TITLE
fix(collections): Change the GET schema to include pipelines

### DIFF
--- a/models/collection.js
+++ b/models/collection.js
@@ -3,6 +3,8 @@
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
 
+const PIPELINE_MODEL = require('./pipeline').get;
+const PIPELINES_MODEL = Joi.array().items(PIPELINE_MODEL);
 const MODEL = {
     id: Joi
         .number()
@@ -31,6 +33,7 @@ const MODEL = {
         .array()
         .items(Joi.number().integer().positive())
 };
+const GET_MODEL = Object.assign({}, MODEL, { pipelines: PIPELINES_MODEL });
 
 module.exports = {
     /**
@@ -47,10 +50,10 @@ module.exports = {
      * @property get
      * @type {Joi}
      */
-    get: Joi.object(mutate(MODEL, [
+    get: Joi.object(mutate(GET_MODEL, [
         'id',
         'name',
-        'pipelineIds'
+        'pipelines'
     ], [
         'description'
     ])).label('Get collection'),

--- a/test/data/collection.get.yaml
+++ b/test/data/collection.get.yaml
@@ -2,8 +2,40 @@
 id: 123
 name: 'Screwdriver'
 description: 'Collection of screwdriver related pipelines'
-pipelineIds:
-    - 912
-    - 345
-    - 567
-    - 765
+pipelines:
+    - id: 12742
+      scmUri: github.com:12345678:master
+      createTime: "2017-07-14"
+      admins:
+        username: true
+      workflow:
+        - main
+        - publish
+      scmRepo:
+        name: screwdriver-cd/screwdriver
+        branch: master
+        url: https://github.com/screwdriver-cd/screwdriver/tree/master
+      annotations:
+        screwdriver.cd/executor.resource:
+          - XCODE8
+          - OSX-SIERRA
+        screwdriver.cd/notify.email: foo@example.com
+        beta.screwdriver.cd/auto_pr_builds: fork-only
+    - id: 12576
+      scmUri: github.com:87654321:master
+      createTime: "2017-07-14"
+      admins:
+        username: true
+      workflow:
+        - main
+        - publish
+      scmRepo:
+        name: screwdriver-cd/config-parser
+        branch: master
+        url: https://github.com/screwdriver-cd/config-parser/tree/master
+      annotations:
+        screwdriver.cd/executor.resource:
+          - XCODE8
+          - OSX-SIERRA
+        screwdriver.cd/notify.email: foo@example.com
+        beta.screwdriver.cd/auto_pr_builds: fork-only


### PR DESCRIPTION
# Context

Currently, the GET schema is designed to only return an array of
pipeline IDs but it would make more sense if the GET for a collection
returned an array of the pipeline objects.

# Objective

This PR changes the GET schema of collection so that an array of pipeline objects are sent back when a collection is requested instead of just the IDs for the pipelines in that collection

# References

issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)
