### PR TITLE
fix(collections): Add list schema for collections

### DIFF
--- a/models/collection.js
+++ b/models/collection.js
@@ -59,6 +59,19 @@ module.exports = {
     ])).label('Get collection'),
 
     /**
+     * Properties for collections that will come back during a LIST request.
+     * The LIST request will list all of the requesting user's collections.
+     */
+    list: Joi.array().items(Joi.object(mutate(MODEL, [
+        'id',
+        'name',
+        'pipelineIds',
+        'userId'
+    ], [
+        'description'
+    ]))).label('List collections for requesting user'),
+
+    /**
      * Properties for Collection that will be passed during a CREATE request
      *
      * @property create

--- a/test/data/collection.list.yaml
+++ b/test/data/collection.list.yaml
@@ -1,0 +1,15 @@
+- id: 12
+  name: 'collection1'
+  description: 'pipelines for collection 1'
+  pipelineIds: [11, 12, 13]
+  userId: 123
+- id: 13
+  name: 'collection2'
+  description: 'pipelines for collection 2'
+  pipelineIds: [14, 15, 16]
+  userId: 123
+- id: 14
+  name: 'collection3'
+  description: 'pipelines for collection 3'
+  pipelineIds: [17, 18, 19]
+  userId: 123

--- a/test/models/collection.test.js
+++ b/test/models/collection.test.js
@@ -21,6 +21,16 @@ describe('collection template', () => {
         });
     });
 
+    describe('list', () => {
+        it('validates the list', () => {
+            assert.isNull(validate('collection.list.yaml', models.collection.list).error);
+        });
+
+        it('fails the list', () => {
+            assert.isNotNull(validate('empty.yaml', models.collection.list).error);
+        });
+    });
+
     describe('create', () => {
         it('validates the create', () => {
             assert.isNull(validate('collection.create.yaml', models.collection.create).error);


### PR DESCRIPTION
# Context

Due to the difference in the structure of a collection object in the GET and LIST API responses, we need a separate schema for LIST. In the LIST request, the UI will primarily require id, name, and description for each of the user's collections. The GET request will populate all the pipelineIds with the pipeline objects instead.

# Objective

This PR adds a schema for the LIST request along with a unit test.

# References 

issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)