### PR TITLE
fix: remove schema for delete and create tag

### DIFF
--- a/models/templateTag.js
+++ b/models/templateTag.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Joi = require('joi');
-const mutate = require('../lib/mutate');
 const Template = require('../config/template');
 
 const MODEL = {
@@ -26,24 +25,6 @@ module.exports = {
      * @type {Joi}
      */
     base: Joi.object(MODEL).label('TemplateTag'),
-
-    /**
-     * Properties for template tag that will be passed during a CREATE request
-     *
-     * @property create
-     * @type {Joi}
-     */
-    create: Joi.object(mutate(MODEL, ['name', 'tag', 'version'], []))
-        .label('Create Template Tag'),
-
-    /**
-     * Properties for template tag that will be passed during a DELETE request
-     *
-     * @property remove
-     * @type {Joi}
-     */
-    remove: Joi.object(mutate(MODEL, ['name', 'tag'], []))
-        .label('Remove Template Tag'),
 
     /**
      * List of fields that determine a unique row

--- a/test/data/templatetag.create.yaml
+++ b/test/data/templatetag.create.yaml
@@ -1,4 +1,0 @@
-# Template Tag CREATE Example
-name: test/template
-tag: 'stable'
-version: '1.2.0'

--- a/test/data/templatetag.remove.yaml
+++ b/test/data/templatetag.remove.yaml
@@ -1,3 +1,0 @@
-# Template Tag DELETE Example
-name: test/template
-tag: 'stable'

--- a/test/models/templatetag.test.js
+++ b/test/models/templatetag.test.js
@@ -10,24 +10,4 @@ describe('model template tag', () => {
             assert.isNull(validate('templatetag.yaml', models.templateTag.base).error);
         });
     });
-
-    describe('create', () => {
-        it('validates the create', () => {
-            assert.isNull(validate('templatetag.create.yaml', models.templateTag.create).error);
-        });
-
-        it('fails the create', () => {
-            assert.isNotNull(validate('empty.yaml', models.templateTag.create).error);
-        });
-    });
-
-    describe('remove', () => {
-        it('validates the remove', () => {
-            assert.isNull(validate('templatetag.remove.yaml', models.templateTag.remove).error);
-        });
-
-        it('fails the remove', () => {
-            assert.isNotNull(validate('empty.yaml', models.templateTag.remove).error);
-        });
-    });
 });


### PR DESCRIPTION
Remove these since we changed the endpoints. They are no longer needed in https://github.com/screwdriver-cd/screwdriver/commit/7d342943b10b58312a411902f842bf0a51d2ae56

Related: https://github.com/screwdriver-cd/screwdriver/issues/616