### PR TITLE
fix(616): Add regex for template tag names

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -7,6 +7,8 @@
 module.exports = {
     // Templates can only be named with A-Z,a-z,0-9,-,_,/
     TEMPLATE_NAME: /^[\w/-]+$/,
+    // Template tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_
+    TEMPLATE_TAG_NAME: /^[a-zA-Z][\w-]+$/,
     // Version can only have up to 2 decimals, like 1.2.3
     VERSION: /^(\d+)?(\.\d+)?(\.\d+)?$/,
     // Full name of template and version. Example: chef/publish@1.2.3 or chef/publish@1-stable

--- a/config/template.js
+++ b/config/template.js
@@ -11,6 +11,13 @@ const TEMPLATE_NAME = Joi
             .description('Name of the Template')
             .example('node/npm-install');
 
+const TEMPLATE_TAG_NAME = Joi
+            .string()
+            .regex(Regex.TEMPLATE_TAG_NAME)
+            .max(30)
+            .description('Name of the Template Tag')
+            .example('latest');
+
 const TEMPLATE_VERSION = Joi
             .string()
             .regex(Regex.VERSION)
@@ -49,6 +56,7 @@ const SCHEMA_TEMPLATE = Joi.object()
 module.exports = {
     template: SCHEMA_TEMPLATE,
     name: TEMPLATE_NAME,
+    templateTag: TEMPLATE_TAG_NAME,
     version: TEMPLATE_VERSION,
     description: TEMPLATE_DESCRIPTION,
     maintainer: TEMPLATE_MAINTAINER,

--- a/models/templateTag.js
+++ b/models/templateTag.js
@@ -9,11 +9,7 @@ const MODEL = {
         .description('Identifier of this template tag')
         .example(123345),
     name: Template.name,
-    tag: Joi
-        .string()
-        .alphanum()
-        .max(30)
-        .required(),
+    tag: Template.templateTag,
     version: Template.version
 };
 

--- a/test/data/templatetag.yaml
+++ b/test/data/templatetag.yaml
@@ -1,5 +1,5 @@
 # Base Template Tag Example
 id: 123234135
 name: test/template
-tag: 'stable'
+tag: stable
 version: '1.2.0'


### PR DESCRIPTION
Adding regex to restrict template tags to have to start with an alpha character, as a part of a discussion from another PR.

**Discussion link:** https://github.com/screwdriver-cd/screwdriver/pull/646/files/d3ae5f42193833e1d0bc0cdd208d7bf2c4c3a3d3#r128141572
**PR:** https://github.com/screwdriver-cd/screwdriver/pull/646
**Issue:** https://github.com/screwdriver-cd/screwdriver/issues/616