### PR TITLE
fix(616): Update full template name

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -10,9 +10,14 @@ module.exports = {
     // Template tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_
     TEMPLATE_TAG_NAME: /^[a-zA-Z][\w-]+$/,
     // Version can only have up to 2 decimals, like 1.2.3
-    VERSION: /^(\d+)?(\.\d+)?(\.\d+)?$/,
-    // Full name of template and version. Example: chef/publish@1.2.3 or chef/publish@1-stable
-    FULL_TEMPLATE_NAME: /^([\w/-]+)(@)?((\d+)?(\.\d+)?(\.\d+)?)(-[\w]+)?$/,
+    // It can also be just major or major and minor versions, like 1 or 1.2
+    VERSION: /^(\d+)+(\.\d+)?(\.\d+)?$/,
+    // Exact version should contain the major, minor, and patch versions, e.g. 1.2.3
+    EXACT_VERSION: /^(\d+)+(\.\d+)+(\.\d+)+$/,
+    // Full name of template and version. Can be <TEMPLATE_NAME>@<VERSION> or <TEMPLATE_NAME>@<TEMPLATE_TAG_NAME>
+    // Example: chef/publish@1.2.3 or chef/publish@stable
+    // Only <TEMPLATE_NAME> or <TEMPLATE_NAME>@ is also acceptable
+    FULL_TEMPLATE_NAME: /^([\w/-]+)(@(((\d+)+(\.\d+)?(\.\d+)?)|([a-zA-Z][\w-]+))?)?$/,
     // Steps can only be named with A-Z,a-z,0-9,-,_
     STEP_NAME: /^[\w-]+$/,
     // Jobs can only be named with A-Z,a-z,0-9,-,_

--- a/config/template.js
+++ b/config/template.js
@@ -23,6 +23,13 @@ const TEMPLATE_VERSION = Joi
             .regex(Regex.VERSION)
             .max(16)
             .description('Version of the Template')
+            .example('1.2');
+
+const TEMPLATE_EXACT_VERSION = Joi
+            .string()
+            .regex(Regex.EXACT_VERSION)
+            .max(16)
+            .description('Exact version of the Template')
             .example('1.2.3');
 
 const TEMPLATE_DESCRIPTION = Joi
@@ -58,6 +65,7 @@ module.exports = {
     name: TEMPLATE_NAME,
     templateTag: TEMPLATE_TAG_NAME,
     version: TEMPLATE_VERSION,
+    exactVersion: TEMPLATE_EXACT_VERSION,
     description: TEMPLATE_DESCRIPTION,
     maintainer: TEMPLATE_MAINTAINER,
     config: Job.job

--- a/models/templateTag.js
+++ b/models/templateTag.js
@@ -10,7 +10,7 @@ const MODEL = {
         .example(123345),
     name: Template.name,
     tag: Template.templateTag,
-    version: Template.version
+    version: Template.exactVersion
 };
 
 module.exports = {

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -54,7 +54,7 @@ describe('config job', () => {
     describe('template', () => {
         it('validates good template', () => {
             assert.isNull(validate('config.job.template.good.yaml', config.job.job).error);
-            assert.isNull(validate('config.job.template-with-label.good.yaml',
+            assert.isNull(validate('config.job.template-with-tag.good.yaml',
                 config.job.job).error);
         });
 

--- a/test/data/config.job.template-with-label.good.yaml
+++ b/test/data/config.job.template-with-label.good.yaml
@@ -1,1 +1,0 @@
-template: node/build@1.2-stable

--- a/test/data/config.job.template-with-tag.good.yaml
+++ b/test/data/config.job.template-with-tag.good.yaml
@@ -1,0 +1,1 @@
+template: node/build@1.2

--- a/test/data/config.job.template.good.yaml
+++ b/test/data/config.job.template.good.yaml
@@ -1,3 +1,3 @@
-template: node/build@1.2.3
+template: node/build@1.2
 environment:
     NODE_ENV: production


### PR DESCRIPTION
Full template names should follow the format: `<TEMPLATE_NAME>@<VERSION>` or `<TEMPLATE_NAME>@<TEMPLATE_TAG_NAME>`, like `chef/publish@1.2.3` or `chef/publish@stable`. We will also accept `<TEMPLATE_NAME>` or `<TEMPLATE_NAME>@`. The models should handle the logic for those cases.

This PR makes the change to the full template name regex.

Related to https://github.com/screwdriver-cd/screwdriver/issues/616