### PR TITLE
fix(616): Fix template and version regexes

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -11,13 +11,13 @@ module.exports = {
     TEMPLATE_TAG_NAME: /^[a-zA-Z][\w-]+$/,
     // Version can only have up to 2 decimals, like 1.2.3
     // It can also be just major or major and minor versions, like 1 or 1.2
-    VERSION: /^(\d+)+(\.\d+)?(\.\d+)?$/,
+    VERSION: /^(\d+)(\.\d+)?(\.\d+)?$/,
     // Exact version should contain the major, minor, and patch versions, e.g. 1.2.3
-    EXACT_VERSION: /^(\d+)+(\.\d+)+(\.\d+)+$/,
+    EXACT_VERSION: /^(\d+)\.(\d+)\.(\d+)$/,
     // Full name of template and version. Can be <TEMPLATE_NAME>@<VERSION> or <TEMPLATE_NAME>@<TEMPLATE_TAG_NAME>
     // Example: chef/publish@1.2.3 or chef/publish@stable
     // Only <TEMPLATE_NAME> or <TEMPLATE_NAME>@ is also acceptable
-    FULL_TEMPLATE_NAME: /^([\w/-]+)(@(((\d+)+(\.\d+)?(\.\d+)?)|([a-zA-Z][\w-]+))?)?$/,
+    FULL_TEMPLATE_NAME: /^([\w/-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-]+)))?$/,
     // Steps can only be named with A-Z,a-z,0-9,-,_
     STEP_NAME: /^[\w-]+$/,
     // Jobs can only be named with A-Z,a-z,0-9,-,_


### PR DESCRIPTION
## Summary
Current regex not good; new regex **gooder**.

## Related Links

Due to comments based on https://github.com/screwdriver-cd/data-schema/pull/165
Related issue: https://github.com/screwdriver-cd/screwdriver/issues/616
