### PR TITLE
feat: Allow Multiple-Documents

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -17,6 +17,7 @@ const SCHEMA_JOBS = Joi.object()
 const SCHEMA_SHARED = Job.job;
 const SCHEMA_CONFIG = Joi.object()
     .keys({
+        version: Joi.number().integer().min(1).max(50),
         annotations: Annotations.annotations,
         jobs: SCHEMA_JOBS,
         shared: SCHEMA_SHARED,

--- a/test/data/config.base.config.yaml
+++ b/test/data/config.base.config.yaml
@@ -1,3 +1,5 @@
+version: 4
+
 shared:
     environment:
         NODE_TAG: latest


### PR DESCRIPTION
This adds an optional field in the base config to allow us to hint about
what version the config is.