### PR TITLE
feat(collections): Add lastBuilds to pipeline. BREAKING CHANGE

### DIFF
--- a/models/collection.js
+++ b/models/collection.js
@@ -3,8 +3,12 @@
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
 
+const BUILD_MODEL = require('./build').get;
 const PIPELINE_MODEL = require('./pipeline').get;
-const PIPELINES_MODEL = Joi.array().items(PIPELINE_MODEL);
+const PIPELINE_OBJECT = PIPELINE_MODEL.keys({
+    lastBuilds: Joi.array().items(BUILD_MODEL).optional()
+});
+const PIPELINES_MODEL = Joi.array().items(PIPELINE_OBJECT);
 const MODEL = {
     id: Joi
         .number()
@@ -53,6 +57,7 @@ module.exports = {
     get: Joi.object(mutate(GET_MODEL, [
         'id',
         'name',
+        'pipelineIds',
         'pipelines'
     ], [
         'description'

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -48,7 +48,11 @@ const MODEL = {
         .description('Current workflow of the pipeline'),
 
     annotations: Annotations.annotations
-        .description('Pipeline-level annotations')
+        .description('Pipeline-level annotations'),
+
+    lastEventId: Joi.number().integer().positive()
+        .description('Identifier of last event')
+        .example(123345)
 };
 
 module.exports = {
@@ -69,7 +73,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'scmUri', 'scmContext', 'createTime', 'admins'
     ], [
-        'workflow', 'scmRepo', 'annotations'
+        'workflow', 'scmRepo', 'annotations', 'lastEventId'
     ])).label('Get Pipeline'),
 
     /**

--- a/test/data/collection.get.yaml
+++ b/test/data/collection.get.yaml
@@ -2,6 +2,7 @@
 id: 123
 name: 'Screwdriver'
 description: 'Collection of screwdriver related pipelines'
+pipelineIds: [12742, 12576]
 pipelines:
     - id: 12742
       scmUri: github.com:12345678:master
@@ -22,6 +23,21 @@ pipelines:
           - OSX-SIERRA
         screwdriver.cd/notify.email: foo@example.com
         beta.screwdriver.cd/auto_pr_builds: fork-only
+      lastBuilds:
+        - id: 123345
+          eventId: 12351523
+          jobId: 123415
+          number: 1473900790309
+          cause: Commit ccc493 was pushed to master
+          status: SUCCESS
+          createTime: "2017-08-21"
+        - id: 123346
+          eventId: 12351523
+          jobId: 123416
+          number: 1473900790309
+          cause: Commit ccc493 was pushed to master
+          status: SUCCESS
+          createTime: "2017-08-21"
     - id: 12576
       scmUri: github.com:87654321:master
       scmContext: github:github.com

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -18,3 +18,4 @@ annotations:
         - OSX-SIERRA
     screwdriver.cd/notify.email: foo@example.com
     beta.screwdriver.cd/auto_pr_builds: fork-only
+lastEventId: 31135214


### PR DESCRIPTION
## Context

For the UI, it needs information about the last build health for the dashboard.

## Objective

This PR changes the data schema for collection.get to add a lastBuilds field to the pipeline object in the response. It also adds a lastEventId field to the pipeline.get to cache the last event for a pipeline.

## References

Related: [screwdriver-cd/screwdriver#714](https://github.com/screwdriver-cd/screwdriver/pull/714)
Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)