### PR TITLE
fix(collections): Allow empty string for description

### DIFF
--- a/models/collection.js
+++ b/models/collection.js
@@ -30,6 +30,7 @@ const MODEL = {
     description: Joi
         .string()
         .max(256)
+        .allow('')
         .description('Collection description')
         .example('List of my favorite pipelines'),
 


### PR DESCRIPTION
Allows descriptions to be an empty string