### PR TITLE
feat(collections): Add pr info to pipelines in collections get schema

### DIFF
--- a/models/collection.js
+++ b/models/collection.js
@@ -5,8 +5,13 @@ const mutate = require('../lib/mutate');
 
 const BUILD_MODEL = require('./build').get;
 const PIPELINE_MODEL = require('./pipeline').get;
+const PRS = {
+    open: Joi.number().integer().min(0),
+    failing: Joi.number().integer().min(0)
+};
 const PIPELINE_OBJECT = PIPELINE_MODEL.keys({
-    lastBuilds: Joi.array().items(BUILD_MODEL).optional()
+    lastBuilds: Joi.array().items(BUILD_MODEL).optional(),
+    prs: Joi.object(PRS).optional()
 });
 const PIPELINES_MODEL = Joi.array().items(PIPELINE_OBJECT);
 const MODEL = {

--- a/test/data/collection.get.yaml
+++ b/test/data/collection.get.yaml
@@ -57,3 +57,6 @@ pipelines:
           - OSX-SIERRA
         screwdriver.cd/notify.email: foo@example.com
         beta.screwdriver.cd/auto_pr_builds: fork-only
+      prs:
+        open: 1
+        failing: 0


### PR DESCRIPTION
## Context

For the user dashboards, we want to display information about the number of PRs open and failing for each pipeline in the collection.

## Objective

This PR adds pr info to each pipeline in the GET for a collection

## References

Issue: [screwdriver-cd/screwdriver#523](https://github.com/screwdriver-cd/screwdriver/issues/523)