### PR TITLE
feat: sort by id

### DIFF
--- a/models/template.js
+++ b/models/template.js
@@ -88,13 +88,13 @@ module.exports = {
 
     /**
      * Primary column to sort queries by.
-     * This defines queries to optionally sort a query result set by version.
+     * This defines queries to optionally sort a query result set by id.
      * Each range key matches up with an element in the indexes property
      *
      * @property rangeKeys
      * @type {Array}
      */
-    rangeKeys: ['version'],
+    rangeKeys: ['id'],
 
     /**
      * Tablename to be used in the datastore


### PR DESCRIPTION
If sorted by version, 1.0.10 than 1.0.9 it will be priority.
https://api.screwdriver.cd/v4/templates/tifftemplate

In this case, the following processing will feel unnatural.
https://github.com/screwdriver-cd/models/blob/4ec55e60c934f945b3350d569c7164db2bef7b32/lib/templateFactory.js#L126

I think that sorting by id will result in the expected behavior.