### PR TITLE
fix: pin semantic release back and do not save dependency

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -12,7 +12,7 @@ jobs:
 
     publish:
         steps:
-            - install: npm install semantic-release
+            - install: npm install --no-save semantic-release@^7
             - publish: npm run semantic-release
         secrets:
             # Publishing to NPM


### PR DESCRIPTION
The same as [this](https://github.com/screwdriver-cd/circuit-fuses/commit/9b4300dc6fe0158c587ba4f1f33f119d6b7cd46c#diff-e917068babdeb1068c2aa1a34cb665ca).