### PR TITLE
fix: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-data-schema",
-  "version": "17.0.0",
+  "version": "18.0.0",
   "description": "Internal Data Schema of Screwdriver",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Perhaps something in semantic_release was incorrect?
https://cd.screwdriver.cd/pipelines/12/

After putting `fix:` in commit message,
and 18.1 has been published, so I am fixed the package.json.
https://www.npmjs.com/package/screwdriver-data-schema