### PR TITLE
feat: add optional startFrom field to event

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -104,5 +104,8 @@ module.exports = {
     settings: SCHEMA_SETTINGS,
     step: SCHEMA_STEP,
     steps: SCHEMA_STEPS,
-    template: SCHEMA_TEMPLATE
+    template: SCHEMA_TEMPLATE,
+    requiresValue: SCHEMA_REQUIRES_VALUE,
+    jobname: SCHEMA_JOBNAME,
+    trigger: SCHEMA_TRIGGER
 };

--- a/models/event.js
+++ b/models/event.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Scm = require('../core/scm');
 const Workflow = require('../config/workflow');
+const { requiresValue } = require('../config/job');
 
 const MODEL = {
     id: Joi
@@ -32,6 +33,9 @@ const MODEL = {
         .string().hex().length(40)
         .description('SHA this project was built on')
         .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'),
+    startFrom: requiresValue
+        .description('Event start point - a job name or trigger name (~commit/~pr)')
+        .example('main'),
     type: Joi
         .string().valid([
             'pr',
@@ -68,6 +72,18 @@ module.exports = {
      */
     get: Joi.object(mutate(MODEL, [
         'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type', 'workflow'
+    ], [
+        'causeMessage', 'startFrom'
+    ])).label('Get Event'),
+
+    /**
+     * Properties for Event that will be passed in a CREATE request
+     *
+     * @property create
+     * @type {Joi}
+     */
+    create: Joi.object(mutate(MODEL, [
+        'pipelineId', 'startFrom'
     ], [
         'causeMessage'
     ])).label('Get Event'),

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -1,3 +1,4 @@
 # Event Create Example
 startFrom: main
 pipelineId: 1235123
+causeMessage: 'Restarted since publish job failed'

--- a/test/data/event.get.full.yaml
+++ b/test/data/event.get.full.yaml
@@ -17,6 +17,7 @@ creator:
     avatar: https://avatars.githubusercontent.com/u/622065?v=3
 pipelineId: 1234
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
+startFrom: 'main'
 type: pipeline
 workflow:
     - down

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -11,6 +11,20 @@ describe('model event', () => {
         });
     });
 
+    describe('create', () => {
+        it('validates the create', () => {
+            assert.isNull(validate('event.create.yaml', models.event.create).error);
+        });
+
+        it('validates the create with optional fields', () => {
+            assert.isNull(validate('event.create.full.yaml', models.event.create).error);
+        });
+
+        it('fails the create', () => {
+            assert.isNotNull(validate('empty.yaml', models.event.create).error);
+        });
+    });
+
     describe('get', () => {
         it('validates the get', () => {
             assert.isNull(validate('event.get.yaml', models.event.get).error);


### PR DESCRIPTION
- Add a optional `startFrom` field to event
- Add `create` event schema for new `POST /event` endpoint

Related: https://github.com/screwdriver-cd/screwdriver/issues/723