### PR TITLE
feat: add workflowGraph to pipeline and events

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -5,6 +5,7 @@ const Job = require('../config/job');
 const Joi = require('joi');
 const Regex = require('../config/regex');
 const Workflow = require('../config/workflow');
+const WorkflowGraph = require('../config/workflowGraph');
 
 const SCHEMA_JOB_COMMAND = Joi.object()
     .keys({
@@ -49,7 +50,8 @@ const SCHEMA_OUTPUT = Joi.object()
         annotations: Annotations.annotations,
         errors: Joi.array().items(Joi.string()).optional(),
         jobs: SCHEMA_JOBS,
-        workflow: Workflow.workflow
+        workflow: Workflow.workflow,
+        workflowGraph: WorkflowGraph.workflowGraph
     })
     .label('Execution information');
 

--- a/config/index.js
+++ b/config/index.js
@@ -6,5 +6,6 @@ const job = require('./job');
 const regex = require('./regex');
 const template = require('./template');
 const workflow = require('./workflow');
+const workflowGraph = require('./workflowGraph');
 
-module.exports = { annotations, base, job, regex, template, workflow };
+module.exports = { annotations, base, job, regex, template, workflow, workflowGraph };

--- a/config/workflowGraph.js
+++ b/config/workflowGraph.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const Joi = require('joi');
+const { jobname, requiresValue } = require('../config/job');
+
+const SCHEMA_WORKFLOW_GRAPH = Joi.object().keys({
+    nodes: Joi.array().items(Joi.object().keys({
+        name: requiresValue
+    }).unknown()),
+    edges: Joi.array().items(Joi.object().keys({
+        src: requiresValue,
+        dest: jobname
+    }).unknown())
+});
+
+/**
+ * The definition of the Workflow Graph pieces
+ * @type {Object}
+ */
+module.exports = {
+    workflowGraph: SCHEMA_WORKFLOW_GRAPH
+};

--- a/models/event.js
+++ b/models/event.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Scm = require('../core/scm');
 const Workflow = require('../config/workflow');
+const WorkflowGraph = require('../config/workflowGraph');
 const { requiresValue } = require('../config/job');
 
 const MODEL = {
@@ -46,7 +47,13 @@ const MODEL = {
         .example('pr'),
     workflow: Workflow.workflow
         .description('Workflow of the associated pipeline')
-        .example(['main', 'publish', 'deploy'])
+        .example(['main', 'publish', 'deploy']),
+    workflowGraph: WorkflowGraph.workflowGraph
+        .description('Graph representation of the workflow')
+        .example({
+            nodes: [{ name: '~commit' }, { name: 'main' }, { name: 'publish' }],
+            edges: [{ src: '~commit', dest: 'main' }, { src: 'main', dest: 'publish' }]
+        })
 };
 
 const CREATE_MODEL = Object.assign({}, MODEL, { startFrom: requiresValue });
@@ -74,9 +81,9 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type', 'workflow'
+        'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type'
     ], [
-        'causeMessage', 'startFrom'
+        'causeMessage', 'startFrom', 'workflow', 'workflowGraph'
     ])).label('Get Event'),
 
     /**

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -5,6 +5,7 @@ const Joi = require('joi');
 const Regex = require('../config/regex');
 const Scm = require('../core/scm');
 const Workflow = require('../config/workflow');
+const WorkflowGraph = require('../config/workflowGraph');
 const mutate = require('../lib/mutate');
 
 const CHECKOUT_URL = {
@@ -47,6 +48,9 @@ const MODEL = {
     workflow: Workflow.workflow
         .description('Current workflow of the pipeline'),
 
+    workflowGraph: WorkflowGraph.workflowGraph
+        .description('Graph representation of the workflow'),
+
     annotations: Annotations.annotations
         .description('Pipeline-level annotations'),
 
@@ -73,7 +77,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'scmUri', 'scmContext', 'createTime', 'admins'
     ], [
-        'workflow', 'scmRepo', 'annotations', 'lastEventId'
+        'workflow', 'workflowGraph', 'scmRepo', 'annotations', 'lastEventId'
     ])).label('Get Pipeline'),
 
     /**

--- a/test/config/workflowGraph.test.js
+++ b/test/config/workflowGraph.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('chai').assert;
+const config = require('../../').config;
+const validate = require('../helper').validate;
+
+describe('config workflowGraph', () => {
+    describe('workflowGraph', () => {
+        it('validates safely', () => {
+            assert.isNull(
+                validate('config.workflowGraph.yaml', config.workflowGraph.workflowGraph).error);
+        });
+
+        it('allows extra fields', () => {
+            assert.isNull(
+                validate('config.workflowGraph.unknown.yaml',
+                    config.workflowGraph.workflowGraph).error);
+        });
+    });
+});

--- a/test/data/config.workflowGraph.unknown.yaml
+++ b/test/data/config.workflowGraph.unknown.yaml
@@ -1,0 +1,12 @@
+nodes:
+    - name: ~commit
+      jobId: 1
+    - name: main
+      jobId: 2
+    - name: publish
+      jobId: 3
+edges:
+    - src: ~commit
+      dest: main
+    - src: main
+      dest: publish

--- a/test/data/config.workflowGraph.yaml
+++ b/test/data/config.workflowGraph.yaml
@@ -1,0 +1,9 @@
+nodes:
+    - name: ~commit
+    - name: main
+    - name: publish
+edges:
+    - src: ~commit
+      dest: main
+    - src: main
+      dest: publish

--- a/test/data/event.get.full.yaml
+++ b/test/data/event.get.full.yaml
@@ -20,6 +20,15 @@ sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
 startFrom: 'main'
 type: pipeline
 workflow:
-    - down
-    - right
-    - fierce_punch
+    - main
+    - publish
+workflowGraph:
+    nodes:
+        - name: ~commit
+        - name: main
+        - name: publish
+    edges:
+        - src: ~commit
+          dest: main
+        - src: main
+          dest: publish

--- a/test/data/validator-with-requires.output.yaml
+++ b/test/data/validator-with-requires.output.yaml
@@ -58,5 +58,10 @@ jobs:
     secrets:
       - NPM_TOKEN
 
-workflow:
-    - publish
+workflowGraph:
+    nodes:
+        - name: main
+        - name: publish
+    edges:
+        - src: main
+          dest: publish


### PR DESCRIPTION
### Objective
Store graph generated by [workflow-parser](https://github.com/screwdriver-cd/workflow-parser) into a new optional field `workflowGraph` in both event and pipeline

- Add an optional field `workflowGraph` to `pipeline` and `event` model
- Allow `workflowGraph` in output generated by config-parser (used by API `validator`)

For legacy workflow config:
- Pipeline and events will have both workflow and workflowGraph

For new workflow config:
- Pipeline and events will only have workflowGraph

Related to https://github.com/screwdriver-cd/screwdriver/issues/723
