### PR TITLE
feat: allow PR-1:main as job name in model

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -22,6 +22,8 @@ module.exports = {
     STEP_NAME: /^[\w-]+$/,
     // Jobs can only be named with A-Z,a-z,0-9,-,_
     JOB_NAME: /^[\w-]+$/,
+    // PR JOB Name can only be PR-1 or PR-1:main, group1: PR-prNum, group2: jobName
+    PR_JOB_NAME: /^(PR-\d+)(?::([\w-]+))?$/,
     // Can be ~pr, ~commit, or ~commit:branchName
     TRIGGER: /^~(pr|commit(:.+)?)$/,
     // IEEE Std 1003.1-2001

--- a/models/job.js
+++ b/models/job.js
@@ -11,7 +11,7 @@ const MODEL = {
         .example(123345),
 
     name: Joi
-        .string().regex(/^[A-Za-z0-9_-]+$/)
+        .string().regex(/^(PR-[0-9]+:)?[\w-]+$/)
         .max(25)
         .description('Name of the Job')
         .example('main'),

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -42,6 +42,19 @@ describe('config regex', () => {
         it('fails on bad job names', () => {
             assert.isFalse(config.regex.JOB_NAME.test('run all the things'));
         });
+
+        it('checks good PR job names', () => {
+            assert.isTrue(config.regex.PR_JOB_NAME.test('PR-1'));
+            assert.isTrue(config.regex.PR_JOB_NAME.test('PR-1:main'));
+            assert.isTrue(config.regex.PR_JOB_NAME.test('PR-1:main-job'));
+            assert.deepEqual('PR-1:main-job'.match(config.regex.PR_JOB_NAME)[1], 'PR-1');
+            assert.deepEqual('PR-1:main-job'.match(config.regex.PR_JOB_NAME)[2], 'main-job');
+        });
+
+        it('checks bad PR job names', () => {
+            assert.isFalse(config.regex.PR_JOB_NAME.test('PR-1-main'));
+            assert.isFalse(config.regex.PR_JOB_NAME.test('PR-1:main:job'));
+        });
     });
 
     describe('environment', () => {

--- a/test/data/job.pr.get.yaml
+++ b/test/data/job.pr.get.yaml
@@ -1,0 +1,7 @@
+# Job Get Example
+id: 675979578
+name: PR-1:main
+description: build and test the code
+pipelineId: 76857568576
+state: ENABLED
+archived: false

--- a/test/models/job.test.js
+++ b/test/models/job.test.js
@@ -16,6 +16,10 @@ describe('model job', () => {
             assert.isNull(validate('job.get.yaml', models.job.get).error);
         });
 
+        it('validates the get with PR job', () => {
+            assert.isNull(validate('job.pr.get.yaml', models.job.get).error);
+        });
+
         it('fails the get for empty yaml', () => {
             assert.isNotNull(validate('empty.yaml', models.job.get).error);
         });


### PR DESCRIPTION
- allow `PR-1:main` as job name in job model
   - in user yaml, jobNames start with `PR-` are not allowed so we do not take care of cases like `PR-1-main` in job model
- add a regex only for PR job name
  - will be used later to parse PR job name

   