### PR TITLE
fix: allow event startFrom PR-1:main

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -5,7 +5,8 @@ const mutate = require('../lib/mutate');
 const Scm = require('../core/scm');
 const Workflow = require('../config/workflow');
 const WorkflowGraph = require('../config/workflowGraph');
-const { requiresValue } = require('../config/job');
+const { trigger } = require('../config/job');
+const jobName = Joi.reach(require('./job').base, 'name');
 
 const MODEL = {
     id: Joi
@@ -56,7 +57,9 @@ const MODEL = {
         })
 };
 
-const CREATE_MODEL = Object.assign({}, MODEL, { startFrom: requiresValue });
+const CREATE_MODEL = Object.assign({}, MODEL, {
+    startFrom: Joi.alternatives().try(trigger, jobName)
+});
 
 module.exports = {
     /**

--- a/test/data/event.create.pr.yaml
+++ b/test/data/event.create.pr.yaml
@@ -1,0 +1,3 @@
+# Event Create Example
+startFrom: PR-1:main
+pipelineId: 1235123

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -16,6 +16,10 @@ describe('model event', () => {
             assert.isNull(validate('event.create.yaml', models.event.create).error);
         });
 
+        it('validates the create with startFrom PR job name', () => {
+            assert.isNull(validate('event.create.pr.yaml', models.event.create).error);
+        });
+
         it('validates the create with optional fields', () => {
             assert.isNull(validate('event.create.full.yaml', models.event.create).error);
         });


### PR DESCRIPTION
allow event startFrom PR-1:main

When user go to the UI and try to restart a specific PR job, e.g.`PR-1:main`, they should be able to do it.

To unblock https://github.com/screwdriver-cd/screwdriver/pull/762