### PR TITLE
feat(723): make main not required in jobs

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -7,9 +7,6 @@ const Regex = require('./regex');
 const Workflow = require('./workflow');
 
 const SCHEMA_JOBS = Joi.object()
-    .keys({
-        main: Job.job.required()
-    })
     // Jobs can only be named with A-Z,a-z,0-9,-,_
     .pattern(Regex.JOB_NAME, Job.job)
     // All others are marked as invalid

--- a/test/data/config.base.config.yaml
+++ b/test/data/config.base.config.yaml
@@ -5,7 +5,7 @@ shared:
         NODE_TAG: latest
 
 jobs:
-    main:
+    first:
         environment:
             NODE_ENV: production
         matrix:


### PR DESCRIPTION
We are using this schema to validate user yaml and makes `main` as requried.
https://github.com/screwdriver-cd/config-parser/blob/master/lib/phase/structural.js#L4


Removes the `main` job requirement from here and add it to the `config-parser` to check only against legacy config.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/723

