### PR TITLE
feat(770): allows sd@pipelineId:jobName for requires

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -24,8 +24,10 @@ module.exports = {
     JOB_NAME: /^[\w-]+$/,
     // PR JOB Name can only be PR-1 or PR-1:main, group1: PR-prNum, group2: jobName
     PR_JOB_NAME: /^(PR-\d+)(?::([\w-]+))?$/,
-    // Can be ~pr, ~commit, or ~commit:branchName
-    TRIGGER: /^~(pr|commit(:.+)?)$/,
+    // External trigger like ~sd@123:component
+    EXTERNAL_TRIGGER: /^~sd@(\d+):([\w-]+)$/,
+    // Can be ~pr, ~commit, or ~commit:branchName, or ~sd@123:component
+    TRIGGER: /^~(sd@\d+:[\w-]+|pr|commit(:.+)?)$/,
     // IEEE Std 1003.1-2001
     // Environment names contain uppercase letters, digits, and underscore
     // They cannot start with digits

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -14,6 +14,10 @@ describe('config job', () => {
             assert.isNull(validate('config.job.jobv2.yaml', config.job.job).error);
         });
 
+        it('validates a job with requires from an external pipeline', () => {
+            assert.isNull(validate('config.job.jobv2.externalrequires.yaml', config.job.job).error);
+        });
+
         it('returns error for bad requires format', () => {
             assert.isNotNull(validate('config.job.jobv2.bad.yaml', config.job.job).error);
         });

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -4,6 +4,26 @@ const assert = require('chai').assert;
 const config = require('../../').config;
 
 describe('config regex', () => {
+    describe('external trigger', () => {
+        it('checks good external trigger', () => {
+            assert.isTrue(config.regex.EXTERNAL_TRIGGER.test('~sd@123:main'));
+        });
+
+        it('fails on bad external trigger', () => {
+            assert.isFalse(config.regex.EXTERNAL_TRIGGER.test('~sd:123'));
+        });
+    });
+
+    describe('trigger', () => {
+        it('checks good trigger', () => {
+            assert.isTrue(config.regex.TRIGGER.test('~commit'));
+        });
+
+        it('fails on bad trigger', () => {
+            assert.isFalse(config.regex.TRIGGER.test('~'));
+        });
+    });
+
     describe('templates', () => {
         it('checks good template names', () => {
             assert.isTrue(config.regex.TEMPLATE_NAME.test('node/npm-install'));

--- a/test/data/config.job.jobv2.externalrequires.yaml
+++ b/test/data/config.job.jobv2.externalrequires.yaml
@@ -1,0 +1,4 @@
+image: node:6
+steps:
+    - init: npm install
+requires: ~sd@123:component-job


### PR DESCRIPTION
We want to allow this so that the pipeline will be rebuilt when sd@pipelineId:jobName completes successfully

Related https://github.com/screwdriver-cd/screwdriver/issues/770
