### PR TITLE
fix: allow . in repoName for checkoutUrl

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -34,7 +34,7 @@ module.exports = {
     ENV_NAME: /^[A-Z_][A-Z0-9_]*$/,
     // Repo checkout url. For example: https://github.com/screwdriver-cd/data-schema.git#branchName or git@github.com:screwdriver-cd/data-schema.git
     // eslint-disable-next-line max-len
-    CHECKOUT_URL: /^(?:(?:https?|git):\/\/)?(?:[^@]+@)?([^/:]+)(?:\/|:)([^/]+)\/([^.#]+)(?:\.git)?(#.+)?$/,
+    CHECKOUT_URL: /^(?:(?:https?|git):\/\/)?(?:[^@]+@)?([^/:]+)(?:\/|:)([^/]+)\/(.+?)(?:\.git)?(#.+)?$/,
     // scmUri. For example: github.com:abc-123:master or bitbucket.org:{123}:master
     SCM_URI: /^([^:]+):([^:]+):([^:]+)$/
 };

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -170,6 +170,16 @@ describe('config regex', () => {
                         'data-schema',
                         '#banana'
                     ]
+                },
+                {
+                    url: 'git@bitbucket.org:screwdriver-cd/data.schema#banana',
+                    match: [
+                        'git@bitbucket.org:screwdriver-cd/data.schema#banana',
+                        'bitbucket.org',
+                        'screwdriver-cd',
+                        'data.schema',
+                        '#banana'
+                    ]
                 }
             ];
 
@@ -185,7 +195,7 @@ describe('config regex', () => {
 
         it('fails on bad checkout Url', () => {
             assert.isFalse(
-                config.regex.CHECKOUT_URL.test('https://github.com/screwdriver-cd/.git'));
+                config.regex.CHECKOUT_URL.test('https://github.com/screwdriver-cd/'));
             assert.isFalse(
                 config.regex.CHECKOUT_URL.test('git@screwdriver-cd/data-schema.git'));
         });


### PR DESCRIPTION
- Users can name their repository with `.`, e.g. 'my.repo'.

The old regex for `checkoutUrl` will fail that.
Fixed it to allow that. Regex credit to @jithin1987!

### Drawback
Previously `https://github.com/screwdriver-cd/.git` will be invalid.
Now with the new regex, it's valid but when it goes through `create pipeline`, user will get err `repo does not exist`. I think that's good enough. 