### PR TITLE
fix: add length for mysql index.

### DIFF
--- a/models/trigger.js
+++ b/models/trigger.js
@@ -13,7 +13,7 @@ const MODEL = {
         .example('~sd@1234:component'),
 
     dest: Joi
-        .string().regex(Regex.EXTERNAL_TRIGGER)
+        .string().regex(Regex.EXTERNAL_TRIGGER).max(64)
         .example('~sd@5678:test')
 
 };

--- a/models/trigger.js
+++ b/models/trigger.js
@@ -9,7 +9,7 @@ const MODEL = {
         .example(12345),
 
     src: Joi
-        .string().regex(Regex.EXTERNAL_TRIGGER)
+        .string().regex(Regex.EXTERNAL_TRIGGER).max(64)
         .example('~sd@1234:component'),
 
     dest: Joi


### PR DESCRIPTION
This is the same issue as #102 and #114 .
I added max length to 'src' in trigger.js.
```
error:  SequelizeDatabaseError: BLOB/TEXT column 'src' used in key specification without a key length
    at Query.formatError (/usr/src/app/node_modules/sequelize/lib/dialects/mysql/query.js:223:16)
    at Query.connection.query [as onResult] (/usr/src/app/node_modules/sequelize/lib/dialects/mysql/query.js:55:23)
    at Query.Command.execute (/usr/src/app/node_modules/mysql2/lib/commands/command.js:30:12)
    at Connection.handlePacket (/usr/src/app/node_modules/mysql2/lib/connection.js:515:28)
    at PacketParser.onPacket (/usr/src/app/node_modules/mysql2/lib/connection.js:94:16)
    at PacketParser.executeStart (/usr/src/app/node_modules/mysql2/lib/packet_parser.js:77:14)
    at Socket.<anonymous> (/usr/src/app/node_modules/mysql2/lib/connection.js:102:29)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at TCP.onread (net.js:547:20)
```