### PR TITLE
fix: do not require main job in validator output

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -36,9 +36,6 @@ const SCHEMA_JOB_PERMUTATIONS = Joi.array().items(SCHEMA_JOB_PERMUTATION)
     .label('List of job permutations');
 
 const SCHEMA_JOBS = Joi.object()
-    .keys({
-        main: SCHEMA_JOB_PERMUTATIONS.required()
-    })
     // Jobs can only be named with A-Z,a-z,0-9,-,_
     .pattern(Regex.JOB_NAME, SCHEMA_JOB_PERMUTATIONS)
     // All others are marked as invalid

--- a/test/data/validator-with-requires.output.yaml
+++ b/test/data/validator-with-requires.output.yaml
@@ -1,5 +1,5 @@
 jobs:
-  main:
+  first:
   - image: node:4
     commands:
       - name: install
@@ -50,7 +50,7 @@ jobs:
 
   publish:
   - image: node:4
-    requires: main
+    requires: first
     commands:
     - name: install
       command: npm publish
@@ -60,8 +60,8 @@ jobs:
 
 workflowGraph:
     nodes:
-        - name: main
+        - name: first
         - name: publish
     edges:
-        - src: main
+        - src: first
           dest: publish


### PR DESCRIPTION
We should not require main job in validator output since new workflow won't have it.

Resolves https://github.com/screwdriver-cd/screwdriver/issues/792