### PR TITLE
feat(827) support tolerations in executor start scheme

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -11,7 +11,8 @@ const SCHEMA_START = Joi.object().keys({
     apiUri: Joi.string().uri().required()
         .label('API URI'),
     token: Joi.string().required()
-        .label('Build JWT')
+        .label('Build JWT'),
+    tolerations: Joi.array().optional()
 }).required();
 const SCHEMA_STOP = Joi.object().keys({
     annotations: Annotations.annotations,

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -4,3 +4,6 @@ buildId: 8609
 container: node:4
 apiUri: http://localhost:8080
 token: eyJhbGciOiJIUziIsInR5cCI6IkpXVCJ9.eyJ1c2Vybam9obmpvaG5zb24iLCJzY29wZSI6WyJ1c2VyIl0sImlhdCI6MTQ3MDI2NjAwMywiZXhwIjoxNDcwMzA5MjAzfQ.CHaHW2-0wALpWaS4UTXQmSAn_ekMBml-ENEnGhw-9SE
+tolerations:
+    - value: a
+    - value: b


### PR DESCRIPTION
# Context

To support passing toleration config for `executor-k8s-vm`

See https://github.com/screwdriver-cd/screwdriver/pull/828