### PR TITLE
fix: rename `command` key to `name`.

### DIFF
--- a/config/command.js
+++ b/config/command.js
@@ -65,7 +65,7 @@ const COMMAND_FORMAT = Joi
 const SCHEMA_COMMAND = Joi.object()
     .keys({
         namespace: COMMAND_NAMESPACE,
-        command: COMMAND_NAME,
+        name: COMMAND_NAME,
         version: COMMAND_VERSION,
         description: COMMAND_DESCRIPTION,
         maintainer: COMMAND_MAINTAINER,
@@ -77,7 +77,7 @@ const SCHEMA_COMMAND = Joi.object()
         binary: CommandFormat.binary
             .when('format', { is: 'binary', then: Joi.required() })
     })
-    .requiredKeys('namespace', 'command', 'version', 'description', 'maintainer',
+    .requiredKeys('namespace', 'name', 'version', 'description', 'maintainer',
         'format')
     // any one of them
     .or('habitat', 'docker', 'binary')
@@ -90,7 +90,7 @@ const SCHEMA_COMMAND = Joi.object()
 module.exports = {
     schemaCommand: SCHEMA_COMMAND,
     namespace: COMMAND_NAMESPACE,
-    command: COMMAND_NAME,
+    name: COMMAND_NAME,
     commandTag: COMMAND_TAG_NAME,
     version: COMMAND_VERSION,
     exactVersion: COMMAND_EXACT_VERSION,

--- a/models/command.js
+++ b/models/command.js
@@ -11,7 +11,7 @@ const MODEL = {
         .example(123345),
 
     namespace: Command.namespace,
-    command: Command.command,
+    name: Command.name,
     version: Command.version,
     description: Command.description,
     maintainer: Command.maintainer,
@@ -39,7 +39,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id',
         'namespace',
-        'command',
+        'name',
         'version',
         'description',
         'maintainer',
@@ -58,7 +58,7 @@ module.exports = {
      */
     create: Joi.object(mutate(MODEL, [
         'namespace',
-        'command',
+        'name',
         'version',
         'description',
         'maintainer',
@@ -75,7 +75,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['namespace', 'command', 'version'],
+    keys: ['namespace', 'name', 'version'],
 
     /**
      * List of all fields in the model
@@ -90,7 +90,7 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: ['namespace', 'command'],
+    indexes: ['namespace', 'name'],
 
     /**
      * Primary column to sort queries by.

--- a/models/commandTag.js
+++ b/models/commandTag.js
@@ -9,7 +9,7 @@ const MODEL = {
         .description('Identifier of this command tag')
         .example(123345),
     namespace: Command.namespace,
-    command: Command.command,
+    name: Command.name,
     tag: Command.commandTag,
     version: Command.exactVersion
 };
@@ -29,7 +29,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['namespace', 'command', 'tag'],
+    keys: ['namespace', 'name', 'tag'],
 
     /**
      * List of all fields in the model
@@ -44,7 +44,7 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: ['namespace', 'command', 'tag'],
+    indexes: ['namespace', 'name', 'tag'],
 
     /**
      * Tablename to be used in the datastore

--- a/test/data/command.create.yaml
+++ b/test/data/command.create.yaml
@@ -1,6 +1,6 @@
 # Command CREATE Example
 namespace: foo
-command: bar
+name: bar
 version: '1.0'
 description: |
   Lorem ipsum dolor sit amet.

--- a/test/data/command.get.yaml
+++ b/test/data/command.get.yaml
@@ -1,7 +1,7 @@
 # Command Get Example
 id: 123234135
 namespace: foo
-command: bar
+name: bar
 version: '1.0'
 description: |
   Lorem ipsum dolor sit amet.

--- a/test/data/command.yaml
+++ b/test/data/command.yaml
@@ -1,7 +1,7 @@
 # Base Command Example
 id: 123234135
 namespace: foo
-command: bar
+name: bar
 version: '1.0'
 description: |
   Lorem ipsum dolor sit amet.

--- a/test/data/commandTag.yaml
+++ b/test/data/commandTag.yaml
@@ -1,6 +1,6 @@
 # Base Command Tag Example
 id: 123234135
 namespace: chefdk
-command: knife
+name: knife
 tag: stable
 version: '1.2.0'

--- a/test/data/config.command.bad.yaml
+++ b/test/data/config.command.bad.yaml
@@ -1,5 +1,5 @@
 namespace: foo
-command: bar
+name: bar
 version: '1.0'
 description: |
   Lorem ipsum dolor sit amet.

--- a/test/data/config.command.yaml
+++ b/test/data/config.command.yaml
@@ -1,5 +1,5 @@
 namespace: foo
-command: bar
+name: bar
 version: '1.0'
 description: |
   Lorem ipsum dolor sit amet.


### PR DESCRIPTION
## Context

Screwdriver Commands feature.

## Objective

Rename `command` key of the `command` data schema to `name`.

## Note

- It may be necessary to recreate `commands` and `commandTags` tables, if those old schema tables already exist.

## References

- [Design](https://github.com/screwdriver-cd/screwdriver/blob/master/design/commands.md) 
- https://github.com/screwdriver-cd/screwdriver/pull/829