### PR TITLE
feat: add pipelineId to command

### DIFF
--- a/models/command.js
+++ b/models/command.js
@@ -3,6 +3,7 @@
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Command = require('../config/command');
+const pipelineId = Joi.reach(require('./pipeline').base, 'id');
 
 const MODEL = {
     id: Joi
@@ -18,7 +19,8 @@ const MODEL = {
     format: Command.format,
     habitat: Command.habitat,
     docker: Command.docker,
-    binary: Command.binary
+    binary: Command.binary,
+    pipelineId
 };
 
 module.exports = {
@@ -43,7 +45,8 @@ module.exports = {
         'version',
         'description',
         'maintainer',
-        'format'
+        'format',
+        'pipelineId'
     ], [
         'habitat',
         'docker',

--- a/test/data/command.get.yaml
+++ b/test/data/command.get.yaml
@@ -16,3 +16,4 @@ habitat:
 #    command: knife
 #binary:
 #    file: ./foobar.sh
+pipelineId: 8765

--- a/test/data/command.yaml
+++ b/test/data/command.yaml
@@ -16,3 +16,4 @@ docker:
     command: knife
 binary:
     file: ./foobar.sh
+pipelineId: 8765


### PR DESCRIPTION
## Context
Like `template`, to limit a pipeline which updates the command only a pipeline which created the command, I add a `pipelineId` to the `command`.

## Objective
Add a pipelineId to the command schema.