### PR TITLE
fix: add a missing range key to the command model.

### DIFF
--- a/models/command.js
+++ b/models/command.js
@@ -100,7 +100,7 @@ module.exports = {
      * @property rangeKeys
      * @type {Array}
      */
-    rangeKeys: ['id'],
+    rangeKeys: ['id', 'id'],
 
     /**
      * Tablename to be used in the datastore


### PR DESCRIPTION
## Context

Sharing Commands implementation.

## Objective

This PR add a missing rang key to the command model so many as index keys. 
If these range keys are not enough, Sequelize's data scan fails.
```
data: TypeError: Cannot read property '_modelAttribute' of undefined
```