### PR TITLE
fix: Update joi error path to array

### DIFF
--- a/api/commandValidator.js
+++ b/api/commandValidator.js
@@ -9,7 +9,8 @@ const COMMAND_ERROR = Joi.object()
             .label('Functional context regarding the error'),
         message: Joi.string()
             .label('Description of a particular validation error'),
-        path: Joi.string()
+        path: Joi.array()
+            .items(Joi.string())
             .label('Dot-notation path to the field that caused the validation error'),
         type: Joi.string()
             .label('The the Joi-type that categorizes the error')

--- a/api/templateValidator.js
+++ b/api/templateValidator.js
@@ -9,8 +9,9 @@ const TEMPLATE_ERROR = Joi.object()
             .label('Functional context regarding the error'),
         message: Joi.string()
             .label('Description of a particular validation error'),
-        path: Joi.string()
-            .label('Dot-notation path to the field that caused the validation error'),
+        path: Joi.array()
+            .items(Joi.string())
+            .label('Array of path to the field that caused the validation error'),
         type: Joi.string()
             .label('The the Joi-type that categorizes the error')
     })

--- a/test/data/command-validator.erroroutput.yaml
+++ b/test/data/command-validator.erroroutput.yaml
@@ -3,7 +3,8 @@ errors:
     - context:
         key: version
       message: '"version" is required'
-      path: version
+      path:
+          - version
       type: any.required
 command:
     namespace: foo

--- a/test/data/template-validator.erroroutput.yaml
+++ b/test/data/template-validator.erroroutput.yaml
@@ -3,7 +3,8 @@ errors:
     - context:
         key: version
       message: '"version" is required'
-      path: version
+      path:
+          - version
       type: any.required
 template:
     name: template_namespace/nodejs_main


### PR DESCRIPTION
Need to update the Joi error path to array of strings due to Joi v13 change.

Related to https://github.com/screwdriver-cd/screwdriver/pull/884