### PR TITLE
feat: allow status for creating build container

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -106,6 +106,7 @@ const MODEL = {
 
     status: Joi
         .string().valid([
+            'CREATING_CONTAINER',
             'SUCCESS',
             'FAILURE',
             'QUEUED',

--- a/test/data/build.update-creating-container.yaml
+++ b/test/data/build.update-creating-container.yaml
@@ -1,0 +1,5 @@
+# Build Update Example
+status: CREATING_CONTAINER
+statusMessage: 'Creating build container'
+meta:
+    yes: no

--- a/test/models/build.test.js
+++ b/test/models/build.test.js
@@ -26,6 +26,11 @@ describe('model build', () => {
             assert.isNull(validate('build.update.yaml', models.build.update).error);
         });
 
+        it('validates updating status to creating container', () => {
+            assert.isNull(validate('build.update-creating-container.yaml',
+                    models.build.update).error);
+        });
+
         it('fails the update', () => {
             assert.isNotNull(validate('empty.yaml', models.build.update).error);
         });


### PR DESCRIPTION
## Context

Before a build executes its first command, Screwdriver needs to perform a series of setup and configuration operations. Today, there isn't a specific state for describing these pre-build operations.

For this proposal, we aim to not solve the problem of describing every operation. We instead want to describe one state of all the setup operations.

## Objective

Enable a "creating container" build status in order to describe that a build is constructing the build container.