### PR TITLE
fix: Add parentEventId to events model

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -14,6 +14,10 @@ const MODEL = {
         .number().integer().positive()
         .description('Identifier of this event')
         .example(123345),
+    parentEventId: Joi
+        .number().integer().positive()
+        .description('Identifier of the parent event')
+        .example(123344),
     causeMessage: Joi
         .string().max(512).truncate()
         .description('Message that describes why the event was created')
@@ -88,7 +92,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type'
     ], [
-        'causeMessage', 'startFrom', 'workflow', 'workflowGraph'
+        'causeMessage', 'startFrom', 'workflow', 'workflowGraph', 'parentEventId'
     ])).label('Get Event'),
 
     /**
@@ -100,7 +104,7 @@ module.exports = {
     create: Joi.object(mutate(CREATE_MODEL, [
         'pipelineId', 'startFrom'
     ], [
-        'causeMessage', 'parentBuildId'
+        'causeMessage', 'parentBuildId', 'parentEventId'
     ])).label('Create Event'),
 
     /**

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -1,5 +1,6 @@
 # Event Create Example
 startFrom: main
 parentBuildId: 123
+parentEventId: 123456
 pipelineId: 1235123
 causeMessage: 'Restarted since publish job failed'

--- a/test/data/event.get.full.yaml
+++ b/test/data/event.get.full.yaml
@@ -15,6 +15,7 @@ creator:
     username: stjohnjohnson
     url: https://github.com/stjohnjohnson
     avatar: https://avatars.githubusercontent.com/u/622065?v=3
+parentEventId: 123456
 pipelineId: 1234
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
 startFrom: 'main'


### PR DESCRIPTION
## Context
Adding a parentEventId so we can fetch meta from the parent event when trying to run a detached build.

## Objective
This PR adds an optional parentEventId to the GET and CREATE schemas for an event.

## Related links
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/806