### PR TITLE
feat(579): Exposing new field `source`

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -107,6 +107,14 @@ const SCHEMA_HOOK = Joi.object().keys({
         .when('type', { is: 'ping', then: Joi.optional(), otherwise: Joi.required() })
         .label('Branch of the repository'),
 
+    prSource: Joi.string()
+        .when('type', {
+            is: 'pr',
+            then: Joi.valid(['fork', 'branch'])
+        })
+        .optional()
+        .label('PR original source'),
+
     prRef: Joi.string()
         .optional()
         .label('PR reference of the repository'),

--- a/test/data/scm.hook.pr.yaml
+++ b/test/data/scm.hook.pr.yaml
@@ -6,5 +6,6 @@ prNum: 123
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
 branch: master
 prRef: reference
+prSource: fork
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 username: stjohnjohnson


### PR DESCRIPTION
This field will indicate the source of the pull request (branch or
fork).  That way we can do some magic around automatically starting the
pr build or not.

_note: I did not make the field required, that ensures it's backwards compatible with other plugins_

Related to: https://github.com/screwdriver-cd/screwdriver/issues/579