### PR TITLE
fix(890): increase job name max length

### DIFF
--- a/models/job.js
+++ b/models/job.js
@@ -12,7 +12,7 @@ const MODEL = {
 
     name: Joi
         .string().regex(/^(PR-[0-9]+:)?[\w-]+$/)
-        .max(25)
+        .max(50)
         .description('Name of the Job')
         .example('main'),
 


### PR DESCRIPTION
Job name is too short and a shown error message "Data too long for column 'name' at row 1"  is hard to understand.

Related: https://github.com/screwdriver-cd/screwdriver/issues/890