### PR TITLE
fix: Allow parentBuildId to be an array of ids

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -110,11 +110,12 @@ const MODEL = {
 
     status: Joi
         .string().valid([
-            'SUCCESS',
-            'FAILURE',
-            'QUEUED',
             'ABORTED',
-            'RUNNING'
+            'CREATED', // when the build is created but not started
+            'FAILURE',
+            'QUEUED', // when the build is created and put into the queue
+            'RUNNING', // after the build is created, went through the queue, and has started
+            'SUCCESS'
         ])
         .description('Current status of the build')
         .example('SUCCESS')

--- a/models/build.js
+++ b/models/build.js
@@ -48,11 +48,11 @@ const MODEL = {
         .description('Identifier of the parent job')
         .example(123345),
 
-    parentBuildId: Joi
-        .alternatives().try(
-            Joi.array().items(PARENT_BUILD_ID),
-            PARENT_BUILD_ID
-        )
+    parentBuildId: PARENT_BUILD_ID
+        .description('Identifier(s) of this parent build')
+        .example([123, 234]),
+
+    parentBuildIds: Joi.array().items(PARENT_BUILD_ID)
         .description('Identifier(s) of this parent build')
         .example([123, 234]),
 
@@ -144,8 +144,8 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'jobId', 'number', 'cause', 'createTime', 'status'
     ], [
-        'container', 'parentBuildId', 'sha', 'startTime', 'endTime', 'meta', 'parameters', 'steps',
-        'commit', 'eventId', 'environment', 'statusMessage'
+        'container', 'parentBuildId', 'parentBuildIds', 'sha', 'startTime', 'endTime',
+        'meta', 'parameters', 'steps', 'commit', 'eventId', 'environment', 'statusMessage'
     ])).label('Get Build'),
 
     /**

--- a/models/build.js
+++ b/models/build.js
@@ -48,11 +48,11 @@ const MODEL = {
         .description('Identifier of the parent job')
         .example(123345),
 
-    parentBuildId: PARENT_BUILD_ID
-        .description('Identifier(s) of this parent build')
-        .example([123, 234]),
-
-    parentBuildIds: Joi.array().items(PARENT_BUILD_ID)
+    parentBuildId: Joi
+        .alternatives().try(
+            Joi.array().items(PARENT_BUILD_ID),
+            PARENT_BUILD_ID
+        )
         .description('Identifier(s) of this parent build')
         .example([123, 234]),
 
@@ -144,7 +144,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'jobId', 'number', 'cause', 'createTime', 'status'
     ], [
-        'container', 'parentBuildId', 'parentBuildIds', 'sha', 'startTime', 'endTime',
+        'container', 'parentBuildId', 'sha', 'startTime', 'endTime',
         'meta', 'parameters', 'steps', 'commit', 'eventId', 'environment', 'statusMessage'
     ])).label('Get Build'),
 

--- a/models/build.js
+++ b/models/build.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Scm = require('../core/scm');
 const Job = require('../config/job');
+const PARENT_BUILD_ID = Joi.number().integer().positive();
 
 const STEP = {
     name: Joi
@@ -48,9 +49,12 @@ const MODEL = {
         .example(123345),
 
     parentBuildId: Joi
-        .number().integer().positive()
-        .description('Identifier of this parent build')
-        .example(123345),
+        .alternatives().try(
+            Joi.array().items(PARENT_BUILD_ID),
+            PARENT_BUILD_ID
+        )
+        .description('Identifier(s) of this parent build')
+        .example([123, 234]),
 
     number: Joi
         .number().positive()

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -1,7 +1,7 @@
 # Build Example
 id: 123234135
 jobId: 790878907896
-parentBuildId: 123234134
+parentBuildId: [123, 234, 456]
 number: 1473900790309.1
 container: node:4
 cause: Because I clicked it

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -1,8 +1,7 @@
 # Build Example
 id: 123234135
 jobId: 790878907896
-parentBuildId: 123345
-parentBuildIds: [123345, 123346, 123347]
+parentBuildId: [123, 234, 456]
 number: 1473900790309.1
 container: node:4
 cause: Because I clicked it

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -1,7 +1,8 @@
 # Build Example
 id: 123234135
 jobId: 790878907896
-parentBuildId: [123, 234, 456]
+parentBuildId: 123345
+parentBuildIds: [123345, 123346, 123347]
 number: 1473900790309.1
 container: node:4
 cause: Because I clicked it


### PR DESCRIPTION
## Context
As a part of updating the metadata used in builds, we want to merge together meta from all parentBuildIds when running a join job.

## Objective
This PR allows the `parentBuildId` key to be a single number or an array of numbers (for backwards compatibility.
~This PR adds a `parentBuildIds` key which will be an array of parentBuildIds. Golang cannot handle multiple types for fields and we want to make sure our change is backwards compatible.~

Also adding `CREATED` status so the join build can be populated with `parentBuildId`s before starting.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/904