### PR TITLE
fix: remove joi.alternatives in build model

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -49,11 +49,8 @@ const MODEL = {
         .example(123345),
 
     parentBuildId: Joi
-        .alternatives().try(
-            Joi.array().items(PARENT_BUILD_ID),
-            PARENT_BUILD_ID
-        )
-        .description('Identifier(s) of this parent build')
+        .array().items(PARENT_BUILD_ID)
+        .description('Identifier(s) of this parent build(s)')
         .example([123, 234]),
 
     number: Joi
@@ -127,6 +124,16 @@ const MODEL = {
         .example('Build failed due to infrastructure error')
 };
 
+const parentBuildIdSchema = Joi
+    .alternatives().try(
+        Joi.array().items(PARENT_BUILD_ID),
+        PARENT_BUILD_ID
+    )
+    .description('Identifier(s) of this parent build')
+    .example([123, 234]);
+
+const GET_MODEL = Object.assign({}, MODEL, { parentBuildId: parentBuildIdSchema });
+
 module.exports = {
     /**
      * All the available properties of Build
@@ -142,7 +149,7 @@ module.exports = {
      * @property get
      * @type {Joi}
      */
-    get: Joi.object(mutate(MODEL, [
+    get: Joi.object(mutate(GET_MODEL, [
         'id', 'jobId', 'number', 'cause', 'createTime', 'status'
     ], [
         'container', 'parentBuildId', 'sha', 'startTime', 'endTime',

--- a/models/event.js
+++ b/models/event.js
@@ -7,7 +7,7 @@ const Workflow = require('../config/workflow');
 const WorkflowGraph = require('../config/workflowGraph');
 const { trigger } = require('../config/job');
 const jobName = Joi.reach(require('./job').base, 'name');
-const parentBuildId = Joi.reach(require('./build').base, 'parentBuildId');
+const parentBuildId = Joi.reach(require('./build').get, 'parentBuildId');
 
 const MODEL = {
     id: Joi


### PR DESCRIPTION
sequelize doesn't know how to deal with `Joi.alternatives` when it tries to save the field into the database. Change the field to array so that it will be mapped to `TEXT`. https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L98

But for validation, to be backward compatible, we still use `Joi.alternatives` to validate. So that a single parentBuildId value will still work.