### PR TITLE
fix: add an optional field `buildId` to event create schema

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -8,6 +8,7 @@ const WorkflowGraph = require('../config/workflowGraph');
 const { trigger } = require('../config/job');
 const jobName = Joi.reach(require('./job').base, 'name');
 const parentBuildId = Joi.reach(require('./build').get, 'parentBuildId');
+const buildId = Joi.reach(require('./build').get, 'id');
 
 const MODEL = {
     id: Joi
@@ -67,6 +68,7 @@ const MODEL = {
 
 const CREATE_MODEL = Object.assign({}, MODEL, {
     startFrom: Joi.alternatives().try(trigger, jobName),
+    buildId,
     parentBuildId
 });
 
@@ -104,10 +106,8 @@ module.exports = {
      * @property create
      * @type {Joi}
      */
-    create: Joi.object(mutate(CREATE_MODEL, [
-        'pipelineId', 'startFrom'
-    ], [
-        'causeMessage', 'parentBuildId', 'parentEventId'
+    create: Joi.object(mutate(CREATE_MODEL, [], [
+        'pipelineId', 'startFrom', 'buildId', 'causeMessage', 'parentBuildId', 'parentEventId'
     ])).label('Create Event'),
 
     /**

--- a/test/data/event.create.restart.yaml
+++ b/test/data/event.create.restart.yaml
@@ -1,0 +1,2 @@
+# Event Create for Restarting a Build Example
+buildId: 123

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -24,6 +24,10 @@ describe('model event', () => {
             assert.isNull(validate('event.create.full.yaml', models.event.create).error);
         });
 
+        it('validates the create with only buildId field', () => {
+            assert.isNull(validate('event.create.restart.yaml', models.event.create).error);
+        });
+
         it('fails the create', () => {
             assert.isNotNull(validate('empty.yaml', models.event.create).error);
         });


### PR DESCRIPTION
- add an optional field `buildId` to event create schema so that UI only need to send in `buildId` to restart a job
- will remove the stuff we don't need later, e.g. `parentBuildId`, `parentEventId` later. Just keep them here for now to make it backward compatible.
