### PR TITLE
fix(911): Add sourcePaths to job config and validator

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -27,9 +27,10 @@ const SCHEMA_JOB_PERMUTATION = Joi.object()
         description: Job.description,
         environment: Job.environment,
         image: Job.image,
+        requires: Job.requires,
         secrets: Job.secrets,
         settings: Job.settings,
-        requires: Job.requires
+        sourcePaths: Job.sourcePaths
     }).label('Job permutation');
 
 const SCHEMA_JOB_PERMUTATIONS = Joi.array().items(SCHEMA_JOB_PERMUTATION)

--- a/config/job.js
+++ b/config/job.js
@@ -72,16 +72,22 @@ const SCHEMA_REQUIRES = Joi.alternatives().try(
     Joi.array().items(SCHEMA_REQUIRES_VALUE),
     SCHEMA_REQUIRES_VALUE
 );
+const SCHEMA_SOURCEPATH = Joi.string().max(100).optional();
+const SCHEMA_SOURCEPATHS = Joi.alternatives().try(
+    Joi.array().items(SCHEMA_SOURCEPATH),
+    SCHEMA_SOURCEPATH
+);
 const SCHEMA_JOB = Joi.object()
     .keys({
-        requires: SCHEMA_REQUIRES,
         annotations: Annotations.annotations,
         description: SCHEMA_DESCRIPTION,
         environment: SCHEMA_ENVIRONMENT,
         image: SCHEMA_IMAGE,
         matrix: SCHEMA_MATRIX,
+        requires: SCHEMA_REQUIRES,
         secrets: SCHEMA_SECRETS,
         settings: SCHEMA_SETTINGS,
+        sourcePaths: SCHEMA_SOURCEPATHS,
         steps: SCHEMA_STEPS,
         template: SCHEMA_TEMPLATE
     })
@@ -102,6 +108,8 @@ module.exports = {
     secret: SCHEMA_SECRET,
     secrets: SCHEMA_SECRETS,
     settings: SCHEMA_SETTINGS,
+    sourcePath: SCHEMA_SOURCEPATH,
+    sourcePaths: SCHEMA_SOURCEPATHS,
     step: SCHEMA_STEP,
     steps: SCHEMA_STEPS,
     template: SCHEMA_TEMPLATE,

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -45,6 +45,12 @@ describe('config job', () => {
         });
     });
 
+    describe('sourcePaths', () => {
+        it('validates sourcePaths', () => {
+            assert.isNull(validate('config.job.sourcePaths.yaml', config.job.sourcePaths).error);
+        });
+    });
+
     describe('environment', () => {
         it('validates environment', () => {
             assert.isNull(validate('config.job.environment.yaml', config.job.environment).error);

--- a/test/data/config.job.sourcePaths.yaml
+++ b/test/data/config.job.sourcePaths.yaml
@@ -1,0 +1,2 @@
+- src/A
+- src/AConfig

--- a/test/data/validator.input.yaml
+++ b/test/data/validator.input.yaml
@@ -17,6 +17,7 @@ yaml: |
 
 
       publish:
+          sourcePaths: src/A
           image: node:4
           steps:
               install: npm publish

--- a/test/data/validator.input.yaml
+++ b/test/data/validator.input.yaml
@@ -7,12 +7,14 @@ yaml: |
           image: node:{{NODE_VERSION}}
           matrix:
               NODE_VERSION: [4,5,6]
+          settings:
+              email: foo@bar.com
+          sourcePaths: [src/A, src/AConfig]
           steps:
               install: npm install
               test: npm test
               build: npm run build
-          settings:
-              email: foo@bar.com
+
 
       publish:
           image: node:4

--- a/test/data/validator.output.yaml
+++ b/test/data/validator.output.yaml
@@ -15,6 +15,9 @@ jobs:
       NODE_VERSION: 4
     settings:
       email: foo@bar.com
+    sourcePaths:
+      - src/A
+      - src/AConfig
   - image: node:5
     commands:
     - name: install
@@ -30,6 +33,9 @@ jobs:
       NODE_VERSION: 5
     settings:
       email: foo@bar.com
+    sourcePaths:
+      - src/A
+      - src/AConfig
   - image: node:6
     commands:
     - name: install
@@ -45,6 +51,9 @@ jobs:
       NODE_VERSION: 6
     settings:
       email: foo@bar.com
+    sourcePaths:
+      - src/A
+      - src/AConfig
     secrets:
       - ANOTHER_SECRET
 


### PR DESCRIPTION
## Context
Users don't always want builds to be triggered for all files in their repositories. Sometimes it would be nice if they could just configure certain source paths in their repos.

## Objective
This PR adds the `sourcePaths` keyword to job configs. It can either be an array of strings or a string.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/911