### PR TITLE
fix: Add default value for meta field

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -96,6 +96,7 @@ const MODEL = {
 
     meta: Joi
         .object()
+        .default({})
         .description('Key=>Value information from the build itself'),
 
     steps: Joi

--- a/models/event.js
+++ b/models/event.js
@@ -35,6 +35,7 @@ const MODEL = {
         .description('Creator of the event'),
     meta: Joi
         .object()
+        .default({})
         .description('Key=>Value information from the event itself'),
     pipelineId: Joi
         .number().integer().positive()

--- a/test/models/build.test.js
+++ b/test/models/build.test.js
@@ -34,6 +34,7 @@ describe('model build', () => {
     describe('get', () => {
         it('validates the get', () => {
             assert.isNull(validate('build.get.yaml', models.build.get).error);
+            assert.include(validate('build.get.yaml', models.build.get).value.meta, {});
         });
 
         it('fails the get', () => {

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -36,6 +36,7 @@ describe('model event', () => {
     describe('get', () => {
         it('validates the get', () => {
             assert.isNull(validate('event.get.yaml', models.event.get).error);
+            assert.include(validate('event.get.yaml', models.event.get).value.meta, {});
         });
 
         it('validates the get with optional fields', () => {


### PR DESCRIPTION
## Context

There is a bug that causes builds to break if you run a detached job after an event occurs with no builds run (e.g., if someone makes a change to the screwdriver.yaml without triggering any builds). The code will try to marshal the meta and no meta will exist in the parent event.

## Objective

This PR adds a default empty object to `meta` in builds and events.

## Related links
- Related to the event meta work: https://github.com/screwdriver-cd/screwdriver/issues/904