### PR TITLE
feat(911): Add validation for scm methods parseHook and getChangedFiles [1]

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -74,15 +74,6 @@ const SCHEMA_COMMIT = Joi.object().keys({
 }).label('SCM Commit');
 
 const SCHEMA_HOOK = Joi.object().keys({
-    type: Joi.string()
-        .valid(['pr', 'repo', 'ping'])
-        .required()
-        .label('Type of the event'),
-
-    hookId: Joi.string()
-        .required()
-        .label('Uuid of the event'),
-
     action: Joi.string()
         .when('type', { is: 'pr',
             then: Joi.valid(['opened', 'reopened', 'closed', 'synchronized']) })
@@ -90,11 +81,9 @@ const SCHEMA_HOOK = Joi.object().keys({
         .when('type', { is: 'ping', then: Joi.optional(), otherwise: Joi.required() })
         .label('Action of the event'),
 
-    prNum: Joi.number()
-        .integer()
-        .positive()
-        .optional()
-        .label('PR number'),
+    branch: Joi.string()
+        .when('type', { is: 'ping', then: Joi.optional(), otherwise: Joi.required() })
+        .label('Branch of the repository'),
 
     checkoutUrl: Joi
         .string().regex(Regex.CHECKOUT_URL)
@@ -103,9 +92,23 @@ const SCHEMA_HOOK = Joi.object().keys({
         .example('git@github.com:screwdriver-cd/data-schema.git#master')
         .example('https://github.com/screwdriver-cd/data-schema.git#master'),
 
-    branch: Joi.string()
-        .when('type', { is: 'ping', then: Joi.optional(), otherwise: Joi.required() })
-        .label('Branch of the repository'),
+    hookId: Joi.string()
+        .required()
+        .label('Uuid of the event'),
+
+    lastCommitMessage: Joi.string()
+        .optional()
+        .label('Last commit message'),
+
+    prNum: Joi.number()
+        .integer()
+        .positive()
+        .optional()
+        .label('PR number'),
+
+    prRef: Joi.string()
+        .optional()
+        .label('PR reference of the repository'),
 
     prSource: Joi.string()
         .when('type', {
@@ -115,14 +118,21 @@ const SCHEMA_HOOK = Joi.object().keys({
         .optional()
         .label('PR original source'),
 
-    prRef: Joi.string()
-        .optional()
-        .label('PR reference of the repository'),
+    scmContext: Joi
+        .string().max(128)
+        .required()
+        .description('The SCM in which the repository exists')
+        .example('github:github.com'),
 
     sha: Joi.string().hex()
         .when('type', { is: 'ping', then: Joi.optional(), otherwise: Joi.required() })
         .label('Commit SHA')
         .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'),
+
+    type: Joi.string()
+        .valid(['pr', 'repo', 'ping'])
+        .required()
+        .label('Type of the event'),
 
     username: Joi.string()
         .required()

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -79,8 +79,6 @@ const GET_CHANGED_FILES_INPUT = Joi.object().keys({
 
 const GET_CHANGED_FILES_OUTPUT = Joi.array().items(Joi.string()).required();
 
-const PARSE_HOOK_OUTPUT = hook;
-
 const DECORATE_URL = Joi.object().keys({
     scmUri,
     token,
@@ -145,7 +143,7 @@ module.exports = {
      * @property parseHookOutput
      * @type {Joi}
      */
-    parseHookOutput: PARSE_HOOK_OUTPUT,
+    parseHookOutput: hook,
 
     /**
      * Properties for Scm Base that will be passed into the getChangedFiles method

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -6,6 +6,7 @@ const models = require('../models');
 
 const buildStatus = Joi.reach(models.build.base, 'status').required();
 const checkoutUrl = Joi.reach(models.pipeline.create, 'checkoutUrl').required();
+const hook = Joi.reach(core.scm.hook, '').required();
 const jobName = Joi.reach(models.job.base, 'name').optional();
 const pipelineId = Joi.reach(models.pipeline.base, 'id').optional();
 const prNum = Joi.reach(core.scm.hook, 'prNum').allow(null).optional();
@@ -13,6 +14,7 @@ const scmContext = Joi.reach(models.pipeline.base, 'scmContext').optional();
 const scmUri = Joi.reach(models.pipeline.base, 'scmUri').required();
 const sha = Joi.reach(models.build.base, 'sha').required();
 const token = Joi.reach(models.user.base, 'token').required();
+const type = Joi.reach(core.scm.hook, 'type').required();
 const username = Joi.reach(models.user.base, 'username').required();
 
 const ADD_WEBHOOK = Joi.object().keys({
@@ -68,6 +70,16 @@ const GET_FILE = Joi.object().keys({
     ref: Joi.string().optional(),
     scmContext
 }).required();
+
+const GET_CHANGED_FILES_INPUT = Joi.object().keys({
+    type,
+    payload: Joi.object().required(),
+    token
+}).required();
+
+const GET_CHANGED_FILES_OUTPUT = Joi.array().items(Joi.string()).required();
+
+const PARSE_HOOK_OUTPUT = hook;
 
 const DECORATE_URL = Joi.object().keys({
     scmUri,
@@ -126,6 +138,30 @@ module.exports = {
      * @type {Joi}
      */
     updateCommitStatus: UPDATE_COMMIT_STATUS,
+
+    /**
+     * Properties for Scm Base that will be passed out of the parseHook method
+     *
+     * @property parseHookOutput
+     * @type {Joi}
+     */
+    parseHookOutput: PARSE_HOOK_OUTPUT,
+
+    /**
+     * Properties for Scm Base that will be passed into the getChangedFiles method
+     *
+     * @property getChangedFilesInput
+     * @type {Joi}
+     */
+    getChangedFilesInput: GET_CHANGED_FILES_INPUT,
+
+    /**
+     * Properties for Scm Base that will be passed out of the getChangedFiles method
+     *
+     * @property getChangedFilesOutput
+     * @type {Joi}
+     */
+    getChangedFilesOutput: GET_CHANGED_FILES_OUTPUT,
 
     /**
      * Properties for Scm Base that will be passed for the getFile method

--- a/test/data/scm.getChangedFilesInput.yaml
+++ b/test/data/scm.getChangedFilesInput.yaml
@@ -1,0 +1,6 @@
+payload:
+    ref: 'refs/heads/master'
+    before: '9049f1265b7d61be4a8904a9a27120d2064dab3b'
+    after: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
+type: pr
+token: 'thisisatoken'

--- a/test/data/scm.getChangedFilesOutput.yaml
+++ b/test/data/scm.getChangedFilesOutput.yaml
@@ -1,0 +1,2 @@
+- 'README.md'
+- 'folder/folder2/hi'

--- a/test/data/scm.hook.ping.yaml
+++ b/test/data/scm.hook.ping.yaml
@@ -1,5 +1,6 @@
 # SCM Hook example
-type: ping
-hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
+hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
+scmContext: github:github.com
+type: ping
 username: stjohnjohnson

--- a/test/data/scm.hook.pr.yaml
+++ b/test/data/scm.hook.pr.yaml
@@ -1,11 +1,13 @@
 # SCM Hook example
-type: pr
-hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 action: opened
-prNum: 123
-checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
 branch: master
+checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
+hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
+lastCommitMessage: meow
+prNum: 123
 prRef: reference
 prSource: fork
+scmContext: github:github.com
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
+type: pr
 username: stjohnjohnson

--- a/test/data/scm.hook.push.yaml
+++ b/test/data/scm.hook.push.yaml
@@ -1,8 +1,9 @@
 # SCM Hook example
-type: repo
-hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 action: push
-checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
 branch: master
+checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
+hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
+scmContext: github:github.com
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
+type: repo
 username: stjohnjohnson

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -45,6 +45,26 @@ describe('scm test', () => {
         });
     });
 
+    describe('getChangedFiles', () => {
+        it('validates input', () => {
+            assert.isNull(validate('scm.getChangedFilesInput.yaml',
+                scm.getChangedFilesInput).error);
+        });
+
+        it('fails empty input', () => {
+            assert.isNotNull(validate('empty.yaml', scm.getChangedFilesInput).error);
+        });
+
+        it('validates output', () => {
+            assert.isNull(validate('scm.getChangedFilesOutput.yaml',
+                scm.getChangedFilesOutput).error);
+        });
+
+        it('fails empty output', () => {
+            assert.isNotNull(validate('empty.yaml', scm.getChangedFilesOutput).error);
+        });
+    });
+
     describe('decorateUrl', () => {
         it('validates', () => {
             assert.isNull(validate('scm.decorateUrl.yaml', scm.decorateUrl).error);


### PR DESCRIPTION
## Context
We'd like to add a method to scm-base that gets a list of changed files when a push or PR occurs in Git. This will allow for subdirectory support.

## Objective
This PR:
- alphabetizes the keys in the **parseHook** schema
- adds `lastCommitMessage` and `scmContext` to the parseHook schema
- adds input/output validation for **parseHook** and **getFilesChanged** methods

## Related links
- Related to https://github.com/screwdriver-cd/screwdriver/issues/911