### PR TITLE
fix(911): Add scmContext to input schema for getChangedFiles

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -74,7 +74,8 @@ const GET_FILE = Joi.object().keys({
 const GET_CHANGED_FILES_INPUT = Joi.object().keys({
     type,
     payload: Joi.object().required(),
-    token
+    token,
+    scmContext
 }).required();
 
 const GET_CHANGED_FILES_OUTPUT = Joi.array().items(Joi.string()).required();

--- a/test/data/scm.getChangedFilesInput.yaml
+++ b/test/data/scm.getChangedFilesInput.yaml
@@ -4,3 +4,4 @@ payload:
     after: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
 type: pr
 token: 'thisisatoken'
+scmContext: github:github.com


### PR DESCRIPTION
## Context

scm-router will pass in `scmContext` to _getChangedFiles.

## Objective

This PR allows for scmContext for getChangedFiles input.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/911
Related to https://github.com/screwdriver-cd/screwdriver/pull/956