### PR TITLE
fix(911): Allow null output for getChangedFiles

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -78,7 +78,10 @@ const GET_CHANGED_FILES_INPUT = Joi.object().keys({
     scmContext
 }).required();
 
-const GET_CHANGED_FILES_OUTPUT = Joi.array().items(Joi.string()).required();
+const GET_CHANGED_FILES_OUTPUT = Joi.alternatives().try(
+    Joi.array().items(Joi.string()).required(),
+    null
+);
 
 const PARSE_HOOK = Joi.alternatives().try(
     hook,

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -66,8 +66,8 @@ describe('scm test', () => {
                 scm.getChangedFilesOutput).error);
         });
 
-        it('fails empty output', () => {
-            assert.isNotNull(validate('empty.yaml', scm.getChangedFilesOutput).error);
+        it('validates empty output', () => {
+            assert.isNull(validate('empty.yaml', scm.getChangedFilesOutput).error);
         });
     });
 


### PR DESCRIPTION
## Context
If an scm plugin does not have getChangedFiles implemented, they should return null. That way, we will know that they do not support the source paths feature.

## Objective
This PR allows getChangedFiles to return null.

## Related links
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/911