### PR TITLE
fix: Allow null for hookId

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -92,10 +92,10 @@ const SCHEMA_HOOK = Joi.object().keys({
         .example('git@github.com:screwdriver-cd/data-schema.git#master')
         .example('https://github.com/screwdriver-cd/data-schema.git#master'),
 
-    hookId: Joi.alternatives().try(
-        Joi.string().required(),
-        null
-    ).label('Uuid of the event'),
+    hookId: Joi.string()
+        .allow('')
+        .optional()
+        .label('Uuid of the event'),
 
     lastCommitMessage: Joi.string()
         .allow('')

--- a/core/scm.js
+++ b/core/scm.js
@@ -92,9 +92,10 @@ const SCHEMA_HOOK = Joi.object().keys({
         .example('git@github.com:screwdriver-cd/data-schema.git#master')
         .example('https://github.com/screwdriver-cd/data-schema.git#master'),
 
-    hookId: Joi.string()
-        .required()
-        .label('Uuid of the event'),
+    hookId: Joi.alternatives().try(
+        Joi.string().required(),
+        null
+    ).label('Uuid of the event'),
 
     lastCommitMessage: Joi.string()
         .allow('')

--- a/test/data/scm.parseHook.yaml
+++ b/test/data/scm.parseHook.yaml
@@ -2,7 +2,6 @@
 action: push
 branch: master
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
-hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 scmContext: github:github.com
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 type: repo


### PR DESCRIPTION
## Context
scm-gitlab returns null for hookId.

## Objective
This PR allows null for hookId.

## Related links
scm-gitlab: https://github.com/tkyi/scm-gitlab/blob/master/index.js#L320
Original issue: https://github.com/screwdriver-cd/screwdriver/issues/911