### PR TITLE
fix(115): Add schemas for versions, auth contexts, stats, and status

### DIFF
--- a/api/auth.js
+++ b/api/auth.js
@@ -14,8 +14,16 @@ const SCHEMA_CRUMB = Joi.object().keys({
     crumb: Joi.string().label('Crumb to prevent CSRF')
 }).label('Crumb to prevent CSRF Object');
 
+const SCHEMA_CONTEXTS = Joi.array().items(
+    Joi.object().keys({
+        context: Joi.string().label('Context name'),
+        displayName: Joi.string().label('Display name')
+    }).label('Context Object')
+).label('Array of Contexts');
+
 module.exports = {
     key: SCHEMA_KEY,
     token: SCHEMA_TOKEN,
-    crumb: SCHEMA_CRUMB
+    crumb: SCHEMA_CRUMB,
+    contexts: SCHEMA_CONTEXTS
 };

--- a/api/index.js
+++ b/api/index.js
@@ -4,7 +4,20 @@ const auth = require('./auth');
 const commandValidator = require('./commandValidator');
 const loglines = require('./loglines');
 const pagination = require('./pagination');
+const stats = require('./stats');
+const status = require('./status');
 const templateValidator = require('./templateValidator');
 const validator = require('./validator');
+const versions = require('./versions');
 
-module.exports = { auth, commandValidator, loglines, pagination, templateValidator, validator };
+module.exports = {
+    auth,
+    commandValidator,
+    loglines,
+    pagination,
+    stats,
+    status,
+    templateValidator,
+    validator,
+    versions
+};

--- a/api/stats.js
+++ b/api/stats.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const Joi = require('joi');
+
+const SCHEMA_REQUESTS = Joi.object().keys({
+    total: Joi
+            .number().integer()
+            .description('Total number of requests')
+            .example(100),
+    timeouts: Joi
+                .number().integer()
+                .description('Number of timeouts')
+                .example(0),
+    success: Joi
+              .number().integer()
+              .description('Number of successes')
+              .example(95),
+    failure: Joi
+              .number().integer()
+              .description('Number of failures')
+              .example('5'),
+    concurrent: Joi
+                  .number().integer()
+                  .description('Number of concurrent requests')
+                  .example(0),
+    averageTime: Joi
+                  .number()
+                  .label('Average time per request')
+                  .example(5.3134)
+}).label('Requests Object');
+
+const SCHEMA_BREAKER = Joi.object().keys({
+    isClosed: Joi.boolean().label('Breaker is closed')
+}).label('Breaker Object');
+
+const SCHEMA_EXECUTOR = Joi.object().keys({
+    requests: SCHEMA_REQUESTS,
+    breaker: SCHEMA_BREAKER
+}).label('Executor Object');
+
+const SCHEMA_STATS = Joi.object().keys({
+    executor: SCHEMA_EXECUTOR,
+    scm: Joi.object().pattern(/^\S*:\S*$/, SCHEMA_EXECUTOR)
+}).label('Stats Object');
+
+module.exports = SCHEMA_STATS;

--- a/api/status.js
+++ b/api/status.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const Joi = require('joi');
+
+const SCHEMA_STATUS = Joi.string().valid('OK');
+
+module.exports = SCHEMA_STATUS;

--- a/api/versions.js
+++ b/api/versions.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const Joi = require('joi');
+
+const SCHEMA_PACKAGE_VERSIONS = Joi.array().items(
+   Joi.string().description('Package and its version')
+).label('List of package versions');
+
+const SCHEMA_LICENSES = Joi.array().items(
+    Joi.object().keys({
+        name: Joi.string().label('Package name'),
+        repository: Joi.string().label('Package repository'),
+        licenses: Joi.any().label('License type')
+    }).label('License Object')
+).label('List of Licenses');
+
+const SCHEMA_VERSIONS = Joi.object().keys({
+    versions: SCHEMA_PACKAGE_VERSIONS,
+    licenses: SCHEMA_LICENSES
+}).label('Versions Object');
+
+module.exports = SCHEMA_VERSIONS;

--- a/test/api/auth.test.js
+++ b/test/api/auth.test.js
@@ -16,4 +16,8 @@ describe('api auth', () => {
     it('key', () => {
         assert.isNull(validate('auth.key.yaml', api.auth.key).error);
     });
+
+    it('contexts', () => {
+        assert.isNull(validate('auth.contexts.yaml', api.auth.contexts).error);
+    });
 });

--- a/test/api/stats.test.js
+++ b/test/api/stats.test.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const assert = require('chai').assert;
+const api = require('../../').api;
+const validate = require('../helper').validate;
+
+describe('api stats', () => {
+    it('stats', () => {
+        assert.isNull(validate('stats.yaml', api.stats).error);
+    });
+});

--- a/test/api/status.test.js
+++ b/test/api/status.test.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const assert = require('chai').assert;
+const api = require('../../').api;
+const validate = require('../helper').validate;
+
+describe('api status', () => {
+    it('status', () => {
+        assert.isNull(validate('status.yaml', api.status).error);
+    });
+});

--- a/test/api/versions.test.js
+++ b/test/api/versions.test.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const assert = require('chai').assert;
+const api = require('../../').api;
+const validate = require('../helper').validate;
+
+describe('api versions', () => {
+    it('versions', () => {
+        assert.isNull(validate('versions.yaml', api.versions).error);
+    });
+});

--- a/test/data/auth.contexts.yaml
+++ b/test/data/auth.contexts.yaml
@@ -1,0 +1,4 @@
+# Contexts example
+-
+  context: this is a context,
+  displayName: this is a display name

--- a/test/data/stats.yaml
+++ b/test/data/stats.yaml
@@ -1,0 +1,22 @@
+# Stats example
+executor:
+  requests:
+    total: 0
+    timeouts: 0
+    success: 0
+    failure: 0
+    concurrent: 0
+    averageTime: 0.0
+  breaker:
+    isClosed: false
+scm:
+  github:github.com:
+      requests:
+        total: 0
+        timeouts: 0
+        success: 0
+        failure: 0
+        concurrent: 0
+        averageTime: 0.0
+      breaker:
+        isClosed: false

--- a/test/data/status.yaml
+++ b/test/data/status.yaml
@@ -1,0 +1,2 @@
+# Status example
+OK

--- a/test/data/versions.yaml
+++ b/test/data/versions.yaml
@@ -1,0 +1,8 @@
+# Versions example
+versions:
+   - package@1.0
+licenses:
+  -
+    name: package
+    repository: https://github.com/test/package
+    licenses: MIT


### PR DESCRIPTION
## Context

There are response object schemas missing for several endpoints as detailed in https://github.com/screwdriver-cd/screwdriver/issues/115

## Objective

Create schemas for:
- [x] versions
- [x] contexts
- [x] stats
- [x] status 

## References

Swagger documentation:
https://api.screwdriver.cd/v4/documentation


