### PR TITLE
feat(periodicBuilds): Schema for executor.startPeriodic and executor.stopPeriodic

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -17,6 +17,15 @@ const SCHEMA_STOP = Joi.object().keys({
     annotations: Annotations.annotations,
     buildId
 }).required();
+const SCHEMA_START_PERIODIC = Joi.object().keys({
+    pipeline: Joi.object().required(),
+    job: Joi.object().required(),
+    tokenGen: Joi.func().required(),
+    update: Joi.boolean().required()
+}).required();
+const SCHEMA_STOP_PERIODIC = Joi.object().keys({
+    jobId: Joi.reach(models.job.base, 'id').required()
+}).required();
 const SCHEMA_STATUS = Joi.object().keys({
     buildId
 }).required();
@@ -37,6 +46,22 @@ module.exports = {
      * @type {Joi}
      */
     stop: SCHEMA_STOP,
+
+    /**
+     * Properties for Executor that will be passed for the STARTPERIODIC method
+     *
+     * @property startPeriodic
+     * @type {Joi}
+     */
+    startPeriodic: SCHEMA_START_PERIODIC,
+
+    /**
+     * Properties for Executor that will be passed for the STOPPERIODIC method
+     *
+     * @property stopPeriodic
+     * @type {Joi}
+     */
+    stopPeriodic: SCHEMA_STOP_PERIODIC,
 
     /**
      * Properties for Executor that will be passed for the STATUS method

--- a/test/plugins/executor.test.js
+++ b/test/plugins/executor.test.js
@@ -3,6 +3,23 @@
 const assert = require('chai').assert;
 const executor = require('../../plugins/executor');
 const validate = require('../helper').validate;
+const joi = require('joi');
+const pipelineMock = {
+    id: 123,
+    scmUri: 'github.com:12345:branchName',
+    scmContext: 'github:github.com',
+    createTime: '2038-01-19T03:14:08.131Z',
+    admins: {
+        foobar: true
+    }
+};
+const jobMock = {
+    id: 1234,
+    pipelineId: 123,
+    name: 'deploy',
+    state: 'ENABLED'
+};
+const tokenGen = () => true;
 
 describe('executor test', () => {
     describe('start', () => {
@@ -26,6 +43,31 @@ describe('executor test', () => {
 
         it('fails the stop', () => {
             assert.isNotNull(validate('empty.yaml', executor.stop).error);
+        });
+    });
+
+    describe('startPeriodic', () => {
+        it('validates the startPeriodic', () => {
+            assert.isNull(joi.validate({
+                pipeline: pipelineMock,
+                job: jobMock,
+                tokenGen,
+                update: false
+            }, executor.startPeriodic).error);
+        });
+
+        it('fails the start for empty object', () => {
+            assert.isNotNull(joi.validate({}, executor.startPeriodic).error);
+        });
+    });
+
+    describe('stopPeriodic', () => {
+        it('validates the stopPeriodic', () => {
+            assert.isNull(joi.validate({ jobId: 1 }, executor.stopPeriodic).error);
+        });
+
+        it('fails the stopPeriodic', () => {
+            assert.isNotNull(joi.validate({}, executor.stopPeriodic).error);
         });
     });
 


### PR DESCRIPTION
# Context

To implement functions for periodic starts and stops on the executor-base, we need schemas to provide validation.

# Objective

This PR implements executor.startPeriodic and executor.stopPeriodic schemas that can be used in the corresponding executor-base functions.

# Related links

executor-base PR: https://github.com/screwdriver-cd/executor-base/pull/39
executor-queue PR: https://github.com/screwdriver-cd/executor-queue/pull/12
Issue that tracks the periodic build feature: https://github.com/screwdriver-cd/screwdriver/issues/688