### PR TITLE
feat(1041): Include job SCM schema in validator permutations

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -27,6 +27,7 @@ const SCHEMA_JOB_PERMUTATION = Joi.object()
         environment: Job.environment,
         image: Job.image,
         requires: Job.requires,
+        scm: Job.scm,
         secrets: Job.secrets,
         settings: Job.settings,
         sourcePaths: Job.sourcePaths

--- a/test/data/job.yaml
+++ b/test/data/job.yaml
@@ -14,6 +14,8 @@ permutations:
           command: npm run build
       environment:
         NODE_VERSION: 4
+      scm:
+        repo: git@github.com:screwdriver-cd/data-schema.git/RepoManifest.xml#branch
 
     - image: node:6
       commands:


### PR DESCRIPTION
Expose the job SCM object in permutations.

https://github.com/screwdriver-cd/screwdriver/issues/1041