### PR TITLE
feat(1041): Include manifest in GET_CHECKOUT_COMMAND schema

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -36,6 +36,7 @@ const GET_CHECKOUT_COMMAND = Joi.object().keys({
     repo: Joi.string().required(),
     sha: Joi.string().required(),
     prRef: Joi.string().optional(),
+    manifest: Joi.string().optional(),
     scmContext
 }).required();
 

--- a/test/data/scm.getCheckoutCommand.yaml
+++ b/test/data/scm.getCheckoutCommand.yaml
@@ -4,3 +4,4 @@ org: screwdriver-cd
 repo: data-schema
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 scmContext: github:github.com
+manifest: git@github.com:org/repo.git/default.xml


### PR DESCRIPTION
In order to pass the `screwdriver.cd/repoManifest` annotation to `_getCheckoutCommand` we include the field as part of the schema.

https://github.com/screwdriver-cd/screwdriver/issues/1041