### PR TITLE
fix(926): Add template namespace [1]

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -16,6 +16,8 @@ module.exports = {
     // Only <COMMAND_NAMESPACE>/<COMMAND_NAME> or <COMMAND_NAMESPACE>/<COMMAND_NAME> is also acceptable
     FULL_COMMAND_NAME:
         /^([\w-]+)\/([\w-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-]+)))?$/,
+    // Template namespaces can only be named with A-Z,a-z,0-9,-,_
+    TEMPLATE_NAMESPACE: /^[\w-]+$/,
     // Templates can only be named with A-Z,a-z,0-9,-,_,/
     TEMPLATE_NAME: /^[\w/-]+$/,
     // Template tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_

--- a/config/regex.js
+++ b/config/regex.js
@@ -31,6 +31,9 @@ module.exports = {
     // Example: chef/publish@1.2.3 or chef/publish@stable
     // Only <TEMPLATE_NAME> or <TEMPLATE_NAME>@ is also acceptable
     FULL_TEMPLATE_NAME: /^([\w/-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-]+)))?$/,
+    // Full name of template and version with grouping for the namespace
+    // eslint-disable-next-line max-len
+    FULL_TEMPLATE_NAME_WITH_NAMESPACE: /^([\w-]+)\/([\w/-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-]+)))?$/,
     // Steps can only be named with A-Z,a-z,0-9,-,_
     STEP_NAME: /^[\w-]+$/,
     // Jobs can only be named with A-Z,a-z,0-9,-,_

--- a/config/template.js
+++ b/config/template.js
@@ -4,6 +4,13 @@ const Joi = require('joi');
 const Job = require('./job');
 const Regex = require('./regex');
 
+const TEMPLATE_NAMESPACE = Joi
+    .string()
+    .regex(Regex.TEMPLATE_NAMESPACE)
+    .max(64)
+    .description('Namespace of the Template')
+    .example('node');
+
 const TEMPLATE_NAME = Joi
     .string()
     .regex(Regex.TEMPLATE_NAME)
@@ -47,6 +54,7 @@ const TEMPLATE_MAINTAINER = Joi
 
 const SCHEMA_TEMPLATE = Joi.object()
     .keys({
+        namespace: TEMPLATE_NAMESPACE,
         name: TEMPLATE_NAME,
         version: TEMPLATE_VERSION,
         description: TEMPLATE_DESCRIPTION,
@@ -62,6 +70,7 @@ const SCHEMA_TEMPLATE = Joi.object()
  */
 module.exports = {
     template: SCHEMA_TEMPLATE,
+    namespace: TEMPLATE_NAMESPACE,
     name: TEMPLATE_NAME,
     templateTag: TEMPLATE_TAG_NAME,
     version: TEMPLATE_VERSION,

--- a/core/scm.js
+++ b/core/scm.js
@@ -99,10 +99,10 @@ const SCHEMA_HOOK = Joi.object().keys({
         .example('git@github.com:screwdriver-cd/data-schema.git#master')
         .example('https://github.com/screwdriver-cd/data-schema.git#master'),
 
-    hookId: Joi.alternatives().try(
-        Joi.string().required(),
-        null
-    ).label('Uuid of the event'),
+    hookId: Joi.string()
+        .allow('')
+        .optional()
+        .label('Uuid of the event'),
 
     lastCommitMessage: Joi.string()
         .allow('')

--- a/core/scm.js
+++ b/core/scm.js
@@ -99,10 +99,10 @@ const SCHEMA_HOOK = Joi.object().keys({
         .example('git@github.com:screwdriver-cd/data-schema.git#master')
         .example('https://github.com/screwdriver-cd/data-schema.git#master'),
 
-    hookId: Joi.string()
-        .allow('')
-        .optional()
-        .label('Uuid of the event'),
+    hookId: Joi.alternatives().try(
+        Joi.string().required(),
+        null
+    ).label('Uuid of the event'),
 
     lastCommitMessage: Joi.string()
         .allow('')

--- a/models/template.js
+++ b/models/template.js
@@ -18,6 +18,7 @@ const MODEL = {
         .example(['stable', 'latest', 'beta']),
 
     config: Template.config,
+    namespace: Template.namespace,
     name: Template.name,
     version: Template.version,
     description: Template.description,
@@ -41,8 +42,17 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'labels', 'config', 'name', 'version', 'description', 'maintainer', 'pipelineId'
-    ], [])).label('Get Template'),
+        'id',
+        'labels',
+        'config',
+        'name',
+        'version',
+        'description',
+        'maintainer',
+        'pipelineId'
+    ], [
+        'namespace'
+    ])).label('Get Template'),
 
     /**
      * Properties for template that will be passed during a CREATE request
@@ -52,7 +62,7 @@ module.exports = {
      */
     create: Joi.object(mutate(MODEL, [
         'config', 'name', 'version', 'description', 'maintainer'
-    ], ['labels'])).label('Create Template'),
+    ], ['labels', 'namespace'])).label('Create Template'),
 
     /**
      * Properties for template that will be passed during a UPDATE request
@@ -69,7 +79,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['name', 'version'],
+    keys: ['namespace', 'name', 'version'],
 
     /**
      * List of all fields in the model
@@ -84,7 +94,7 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: ['name'],
+    indexes: ['namespace', 'name'],
 
     /**
      * Primary column to sort queries by.
@@ -94,7 +104,7 @@ module.exports = {
      * @property rangeKeys
      * @type {Array}
      */
-    rangeKeys: ['id'],
+    rangeKeys: ['id', 'id'],
 
     /**
      * Tablename to be used in the datastore

--- a/models/template.js
+++ b/models/template.js
@@ -42,17 +42,8 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id',
-        'labels',
-        'config',
-        'name',
-        'version',
-        'description',
-        'maintainer',
-        'pipelineId'
-    ], [
-        'namespace'
-    ])).label('Get Template'),
+        'id', 'labels', 'config', 'name', 'version', 'description', 'maintainer', 'pipelineId'
+    ], ['namespace'])).label('Get Template'),
 
     /**
      * Properties for template that will be passed during a CREATE request

--- a/models/templateTag.js
+++ b/models/templateTag.js
@@ -8,6 +8,7 @@ const MODEL = {
         .number().integer().positive()
         .description('Identifier of this template tag')
         .example(123345),
+    namespace: Template.namespace,
     name: Template.name,
     tag: Template.templateTag,
     version: Template.exactVersion
@@ -28,7 +29,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['name', 'tag'],
+    keys: ['namespace', 'name', 'tag'],
 
     /**
      * List of all fields in the model
@@ -43,7 +44,7 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: ['name', 'tag'],
+    indexes: ['namespace', 'name', 'tag'],
 
     /**
      * Tablename to be used in the datastore

--- a/test/api/templateValidator.test.js
+++ b/test/api/templateValidator.test.js
@@ -13,6 +13,11 @@ describe('api validator', () => {
             assert.isNull(validate('template-validator.input.yaml', inputSchema).error);
         });
 
+        it('accepts input with namespace', () => {
+            // eslint-disable-next-line max-len
+            assert.isNull(validate('template-validator.inputWithNamespace.yaml', inputSchema).error);
+        });
+
         it('fails', () => {
             assert.isOk(validate('template-validator.invalid-input.yaml', inputSchema).error);
         });

--- a/test/api/templateValidator.test.js
+++ b/test/api/templateValidator.test.js
@@ -14,8 +14,8 @@ describe('api validator', () => {
         });
 
         it('accepts input with namespace', () => {
-            // eslint-disable-next-line max-len
-            assert.isNull(validate('template-validator.inputWithNamespace.yaml', inputSchema).error);
+            assert.isNull(validate('template-validator.inputWithNamespace.yaml',
+                inputSchema).error);
         });
 
         it('fails', () => {

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -59,8 +59,40 @@ describe('config regex', () => {
     });
 
     describe('templates', () => {
+        it('checks good template namespaces', () => {
+            assert.isTrue(config.regex.TEMPLATE_NAMESPACE.test('chefdk'));
+        });
+
+        it('fails on bad template namespaces', () => {
+            assert.isFalse(config.regex.TEMPLATE_NAMESPACE.test('bad/namespace'));
+        });
+
         it('checks good template names', () => {
             assert.isTrue(config.regex.TEMPLATE_NAME.test('node/npm-install'));
+        });
+
+        it('fails on bad template names', () => {
+            assert.isFalse(config.regex.TEMPLATE_NAME.test('bad@/name'));
+        });
+
+        it('checks good template full names', () => {
+            assert.isTrue(config.regex.FULL_TEMPLATE_NAME.test('chefdk/knife@1.2.3'));
+        });
+
+        it('checks good template full names with namespace', () => {
+            assert.isTrue(config.regex.FULL_TEMPLATE_NAME_WITH_NAMESPACE.test('chefdk/knife'));
+        });
+
+        it('checks good template full names without version', () => {
+            assert.isTrue(config.regex.FULL_TEMPLATE_NAME.test('chefdk/knife'));
+        });
+
+        it('fails on bad template full names', () => {
+            assert.isFalse(config.regex.FULL_TEMPLATE_NAME.test('bad name'));
+        });
+
+        it('fails on bad formatted template full names', () => {
+            assert.isFalse(config.regex.FULL_TEMPLATE_NAME.test('namespace::command@1.2.3'));
         });
 
         it('fails on bad template names', () => {

--- a/test/config/template.test.js
+++ b/test/config/template.test.js
@@ -10,8 +10,18 @@ describe('config template', () => {
             assert.isNull(validate('config.template.yaml', config.template.template).error);
         });
 
+        it('validates safely with namespace', () => {
+            assert.isNull(validate('config.template.withNamespace.yaml',
+                config.template.template).error);
+        });
+
         it('returns error when no config key in template', () => {
             assert.isNotNull(validate('config.template.bad.yaml',
+                config.template.template).error);
+        });
+
+        it('returns error when template namespace has bad format', () => {
+            assert.isNotNull(validate('config.template.badWithNamespace.yaml',
                 config.template.template).error);
         });
     });

--- a/test/data/config.template.badWithNamespace.yaml
+++ b/test/data/config.template.badWithNamespace.yaml
@@ -1,0 +1,15 @@
+namespace: foo/bar
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/data/config.template.withNamespace.yaml
+++ b/test/data/config.template.withNamespace.yaml
@@ -1,0 +1,15 @@
+namespace: test
+name: template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/data/template-validator.inputWithNamespace.yaml
+++ b/test/data/template-validator.inputWithNamespace.yaml
@@ -1,0 +1,17 @@
+yaml: |
+  namespace: template_namespace
+  name: nodejs_main
+  version: 1.1.2
+  description: |
+      Template for building a NodeJS module
+      Installs dependencies and runs tests
+  maintainer: me@nowhere.com
+  config:
+      image: node:6
+      steps:
+          - install: npm install
+          - test: npm test
+      environment:
+          KEYNAME: value
+      secrets:
+          - NPM_TOKEN

--- a/test/data/template.createWithNamespace.yaml
+++ b/test/data/template.createWithNamespace.yaml
@@ -1,0 +1,20 @@
+# Template CREATE Example
+namespace: test
+name: template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+labels:
+    - stable
+    - test
+    - beta
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/data/template.getWithNamespace.yaml
+++ b/test/data/template.getWithNamespace.yaml
@@ -1,0 +1,22 @@
+# Template GET Example
+id: 123234135
+namespace: test
+name: template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+pipelineId: 8765
+labels:
+    - stable
+    - test
+    - beta
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/data/template.updateWithNamespace.yaml
+++ b/test/data/template.updateWithNamespace.yaml
@@ -1,4 +1,5 @@
 # Template UPDATE example
+namespace: batman
 labels:
     - stable
     - test

--- a/test/data/templatetag.withNamespace.yaml
+++ b/test/data/templatetag.withNamespace.yaml
@@ -1,0 +1,6 @@
+# Base Template Tag Example
+id: 123234135
+namespace: test
+name: template
+tag: stable
+version: '1.2.0'

--- a/test/models/template.test.js
+++ b/test/models/template.test.js
@@ -16,6 +16,11 @@ describe('model template', () => {
             assert.isNull(validate('template.create.yaml', models.template.create).error);
         });
 
+        it('validates the create with namespace', () => {
+            assert.isNull(validate('template.createWithNamespace.yaml',
+                models.template.create).error);
+        });
+
         it('fails the create', () => {
             assert.isNotNull(validate('empty.yaml', models.template.create).error);
         });
@@ -26,6 +31,10 @@ describe('model template', () => {
             assert.isNull(validate('template.get.yaml', models.template.get).error);
         });
 
+        it('validates the get with namespace', () => {
+            assert.isNull(validate('template.getWithNamespace.yaml', models.template.get).error);
+        });
+
         it('fails the get', () => {
             assert.isNotNull(validate('empty.yaml', models.template.get).error);
         });
@@ -34,6 +43,11 @@ describe('model template', () => {
     describe('update', () => {
         it('validates the update', () => {
             assert.isNull(validate('template.update.yaml', models.template.update).error);
+        });
+
+        it('fails the update with namespace', () => {
+            assert.isNotNull(validate('template.updateWithNamespace.yaml',
+                models.template.update).error);
         });
 
         it('fails the update', () => {

--- a/test/models/templatetag.test.js
+++ b/test/models/templatetag.test.js
@@ -9,5 +9,10 @@ describe('model template tag', () => {
         it('validates the base', () => {
             assert.isNull(validate('templatetag.yaml', models.templateTag.base).error);
         });
+
+        it('validates the base with namespace', () => {
+            assert.isNull(validate('templatetag.withNamespace.yaml',
+                models.templateTag.base).error);
+        });
     });
 });


### PR DESCRIPTION
## Context

We would like to group templates by namespace, but we don't explicitly define it anywhere.

## Objective

This PR adds the `namespace` field to templates similar to command namespaces.
Also adds template full name regex that will group for namespace.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/926