### PR TITLE
[1] feat(937): Add config pipeline fields and scmUrl schema

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -11,12 +11,15 @@ const SCHEMA_JOBS = Joi.object()
     // All others are marked as invalid
     .unknown(false);
 const SCHEMA_SHARED = Job.job;
+const SCHEMA_SCM_URL = Joi.string().regex(Regex.CHECKOUT_URL);
+const SCHEMA_SCM_URLS = Joi.array().items(SCHEMA_SCM_URL).min(1);
 const SCHEMA_CONFIG = Joi.object()
     .keys({
         version: Joi.number().integer().min(1).max(50),
         annotations: Annotations.annotations,
         jobs: SCHEMA_JOBS,
-        shared: SCHEMA_SHARED
+        shared: SCHEMA_SHARED,
+        scmUrls: SCHEMA_SCM_URLS
     })
     .requiredKeys('jobs')
     .unknown(false);
@@ -28,5 +31,6 @@ const SCHEMA_CONFIG = Joi.object()
 module.exports = {
     jobs: SCHEMA_JOBS,
     shared: SCHEMA_SHARED,
+    scmUrls: SCHEMA_SCM_URLS,
     config: SCHEMA_CONFIG
 };

--- a/models/event.js
+++ b/models/event.js
@@ -44,6 +44,10 @@ const MODEL = {
         .string().hex().length(40)
         .description('SHA this project was built on')
         .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'),
+    configPipelineSha: Joi
+        .string().hex().length(40)
+        .description('SHA of the configuration pipeline this project depends on')
+        .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'),
     startFrom: Joi
         .string()
         .description('Event start point - a job name or trigger name (~commit/~pr)')
@@ -96,7 +100,8 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type'
     ], [
-        'causeMessage', 'meta', 'parentEventId', 'startFrom', 'workflowGraph', 'pr'
+        'causeMessage', 'meta', 'parentEventId', 'startFrom', 'workflowGraph', 'pr',
+        'configPipelineSha'
     ])).label('Get Event'),
 
     /**
@@ -106,7 +111,8 @@ module.exports = {
      * @type {Joi}
      */
     create: Joi.object(mutate(CREATE_MODEL, [], [
-        'pipelineId', 'startFrom', 'buildId', 'causeMessage', 'parentBuildId', 'parentEventId'
+        'pipelineId', 'startFrom', 'buildId', 'causeMessage', 'parentBuildId', 'parentEventId',
+        'configPipelineSha'
     ])).label('Create Event'),
 
     /**

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -52,7 +52,15 @@ const MODEL = {
 
     lastEventId: Joi.number().integer().positive()
         .description('Identifier of last event')
-        .example(123345)
+        .example(123345),
+
+    configPipelineId: Joi.number().integer().positive()
+        .description('Identifier of pipeline containing external configuration')
+        .example(123),
+
+    isConfigPipeline: Joi.boolean()
+        .description('Is this pipeline an external configuration one?')
+        .example(true)
 };
 
 module.exports = {
@@ -73,7 +81,8 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'scmUri', 'scmContext', 'createTime', 'admins'
     ], [
-        'workflowGraph', 'scmRepo', 'annotations', 'lastEventId'
+        'workflowGraph', 'scmRepo', 'annotations', 'lastEventId',
+        'configPipelineId', 'isConfigPipeline'
     ])).label('Get Pipeline'),
 
     /**

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Annotations = require('../config/annotations');
+const Base = require('../config/base');
 const Joi = require('joi');
 const Regex = require('../config/regex');
 const Scm = require('../core/scm');
@@ -58,9 +59,8 @@ const MODEL = {
         .description('Identifier of pipeline containing external configuration')
         .example(123),
 
-    isConfigPipeline: Joi.boolean()
-        .description('Is this pipeline an external configuration one?')
-        .example(true)
+    scmUrls: Base.scmUrls
+        .description('List of SCM URLs that use this pipeline as an external configuration')
 };
 
 module.exports = {
@@ -82,7 +82,7 @@ module.exports = {
         'id', 'scmUri', 'scmContext', 'createTime', 'admins'
     ], [
         'workflowGraph', 'scmRepo', 'annotations', 'lastEventId',
-        'configPipelineId', 'isConfigPipeline'
+        'configPipelineId', 'scmUrls'
     ])).label('Get Pipeline'),
 
     /**

--- a/test/config/base.test.js
+++ b/test/config/base.test.js
@@ -22,4 +22,10 @@ describe('config base', () => {
             assert.isNull(validate('config.base.shared.yaml', config.base.shared).error);
         });
     });
+
+    describe('scmUrls', () => {
+        it('validates a list of scmUrls', () => {
+            assert.isNull(validate('config.base.scmUrls.yaml', config.base.scmUrls).error);
+        });
+    });
 });

--- a/test/data/config.base.config.yaml
+++ b/test/data/config.base.config.yaml
@@ -1,5 +1,9 @@
 version: 4
 
+scmUrls:
+  - git@github.com:org/repo.git
+  - https://git@github.com:org/repo2.git
+
 shared:
     environment:
         NODE_TAG: latest

--- a/test/data/config.base.scmUrls.yaml
+++ b/test/data/config.base.scmUrls.yaml
@@ -1,0 +1,2 @@
+- git@github.com:org/repo.git
+- https://git@github.com:org/repo2.git

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -4,3 +4,4 @@ parentBuildId: 123
 parentEventId: 123456
 pipelineId: 1235123
 causeMessage: 'Restarted since publish job failed'
+configPipelineSha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -17,4 +17,6 @@ annotations:
     beta.screwdriver.cd/auto_pr_builds: fork-only
 lastEventId: 31135214
 configPipelineId: 123
-isConfigPipeline: false
+scmUrls:
+    - git@github.com:org/repo.git
+    - https://github.com:org/repo2.git

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -16,3 +16,5 @@ annotations:
     screwdriver.cd/notify.email: foo@example.com
     beta.screwdriver.cd/auto_pr_builds: fork-only
 lastEventId: 31135214
+configPipelineId: 123
+isConfigPipeline: false


### PR DESCRIPTION
**Update 5/30**

Add `configPipelineSha` field to the events model. 

---
**Update 5/29**

Replace `isConfigPipeline` field with `scmUrls`.

---

Add optional fields `configPipelineId` and `isConfigPipeline` to the pipeline model to distinguish between **config**, **child**, and **regular** pipelines (unsure how to officially name each of these types of pipelines).

`configPipelineId` is the id of the pipeline that contains the configuration for this pipeline. This field will only be populated for child pipelines.

`isConfigPipeline` is true if the pipeline is a config pipeline.

We should discuss if adding these fields is the correct approach to distinguish between different pipeline types.

---

Also add `scmUrls ` schema into the pipeline level config.

https://github.com/screwdriver-cd/screwdriver/issues/937