### PR TITLE
feat(1082): add get branch list property

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -114,6 +114,11 @@ const PARSE_URL = Joi.object().keys({
     scmContext
 }).required();
 
+const GET_BRANCH_LIST = Joi.object().keys({
+    scmUri,
+    token
+}).required();
+
 module.exports = {
     /**
      * Properties for Scm Base that will be passed for the addWebhook method
@@ -217,5 +222,13 @@ module.exports = {
      * @property getCheckoutCommand
      * @type {Joi}
      */
-    getCheckoutCommand: GET_CHECKOUT_COMMAND
+    getCheckoutCommand: GET_CHECKOUT_COMMAND,
+
+    /**
+     * Properties for Scm Base that will be passed for the getBranchList method
+     *
+     * @property getBranchList
+     * @type {Joi}
+     */
+    getBranchList: GET_BRANCH_LIST
 };

--- a/test/data/scm.getBranchList.yaml
+++ b/test/data/scm.getBranchList.yaml
@@ -1,0 +1,3 @@
+---
+scmUri: github.com:126987453:master
+token: thisisashinytoken

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -140,4 +140,14 @@ describe('scm test', () => {
             assert.isNotNull(validate('empty.yaml', scm.addWebhook).error);
         });
     });
+
+    describe('getBranchList', () => {
+        it('validates', () => {
+            assert.isNull(validate('scm.getBranchList.yaml', scm.getBranchList).error);
+        });
+
+        it('fails', () => {
+            assert.isNotNull(validate('empty.yaml', scm.getBranchList).error);
+        });
+    });
 });


### PR DESCRIPTION
## Context
To get pipelines, we need to get branches by scm api.  
Scm will have new function for getting pipelines and that need properties for arguments.

## Objective
Add getBranchList properties which require scmUri and token.

## References
[github branch list api](https://developer.github.com/v3/repos/branches/#list-branches)
[bitbucket branch list api](https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/refs/branches)
Related to https://github.com/screwdriver-cd/screwdriver/issues/1082