### PR TITLE
fix(926): Add extra logic for template name schema

### DIFF
--- a/api/templateValidator.js
+++ b/api/templateValidator.js
@@ -22,7 +22,7 @@ const SCHEMA_OUTPUT = Joi.object()
         errors: Joi.array()
             .items(TEMPLATE_ERROR)
             .label('Array of errors encountered while validating the given template'),
-        // since a template could be parseable but invalid, the contents are unpredicatble
+        // since a template could be parseable but invalid, the contents are unpredictable
         template: Joi.object()
             .label('The end-result of parsing the given template')
     })

--- a/config/regex.js
+++ b/config/regex.js
@@ -18,8 +18,10 @@ module.exports = {
         /^([\w-]+)\/([\w-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-]+)))?$/,
     // Template namespaces can only be named with A-Z,a-z,0-9,-,_
     TEMPLATE_NAMESPACE: /^[\w-]+$/,
-    // Templates can only be named with A-Z,a-z,0-9,-,_,/
-    TEMPLATE_NAME: /^[\w/-]+$/,
+    // Templates can only be named with A-Z,a-z,0-9,-,_,/; can only contain one /
+    TEMPLATE_NAME_ALLOW_SLASH: /^(?:([\w-]+)\/)?([\w-]+)$/,
+    // Templates can only be named with A-Z,a-z,0-9,-,_ if namespace exists
+    TEMPLATE_NAME_NO_SLASH: /^[\w-]+$/,
     // Template tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_
     TEMPLATE_TAG_NAME: /^[a-zA-Z][\w-]+$/,
     // Version can only have up to 2 decimals, like 1.2.3

--- a/config/template.js
+++ b/config/template.js
@@ -11,10 +11,12 @@ const TEMPLATE_NAMESPACE = Joi
     .description('Namespace of the Template')
     .example('node');
 
-const TEMPLATE_NAME = Joi
-    .string()
-    .regex(Regex.TEMPLATE_NAME)
-    .max(64)
+// Don't allow slashes in the template name when namespace exists
+// Allow one slash in the template name when namespace does not exist
+const TEMPLATE_NAME = Joi.alternatives()
+    .when('namespace', { is: Joi.exist(),
+        then: Joi.string().regex(Regex.TEMPLATE_NAME_NO_SLASH).max(64),
+        otherwise: Joi.string().regex(Regex.TEMPLATE_NAME_ALLOW_SLASH).max(64) })
     .description('Name of the Template')
     .example('node/npm-install');
 

--- a/core/scm.js
+++ b/core/scm.js
@@ -99,10 +99,10 @@ const SCHEMA_HOOK = Joi.object().keys({
         .example('git@github.com:screwdriver-cd/data-schema.git#master')
         .example('https://github.com/screwdriver-cd/data-schema.git#master'),
 
-    hookId: Joi.alternatives().try(
-        Joi.string().required(),
-        null
-    ).label('Uuid of the event'),
+    hookId: Joi.string()
+        .allow('')
+        .optional()
+        .label('Uuid of the event'),
 
     lastCommitMessage: Joi.string()
         .allow('')

--- a/core/scm.js
+++ b/core/scm.js
@@ -99,10 +99,10 @@ const SCHEMA_HOOK = Joi.object().keys({
         .example('git@github.com:screwdriver-cd/data-schema.git#master')
         .example('https://github.com/screwdriver-cd/data-schema.git#master'),
 
-    hookId: Joi.string()
-        .allow('')
-        .optional()
-        .label('Uuid of the event'),
+    hookId: Joi.alternatives().try(
+        Joi.string().required(),
+        null
+    ).label('Uuid of the event'),
 
     lastCommitMessage: Joi.string()
         .allow('')

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -68,11 +68,11 @@ describe('config regex', () => {
         });
 
         it('checks good template names', () => {
-            assert.isTrue(config.regex.TEMPLATE_NAME.test('node/npm-install'));
+            assert.isTrue(config.regex.TEMPLATE_NAME_ALLOW_SLASH.test('node/npm-install'));
         });
 
         it('fails on bad template names', () => {
-            assert.isFalse(config.regex.TEMPLATE_NAME.test('bad@/name'));
+            assert.isFalse(config.regex.TEMPLATE_NAME_ALLOW_SLASH.test('bad@/name'));
         });
 
         it('checks good template full names', () => {
@@ -96,7 +96,7 @@ describe('config regex', () => {
         });
 
         it('fails on bad template names', () => {
-            assert.isFalse(config.regex.TEMPLATE_NAME.test('run all the things'));
+            assert.isFalse(config.regex.TEMPLATE_NAME_NO_SLASH.test('run all the things'));
         });
     });
 

--- a/test/config/template.test.js
+++ b/test/config/template.test.js
@@ -24,5 +24,15 @@ describe('config template', () => {
             assert.isNotNull(validate('config.template.badWithNamespace.yaml',
                 config.template.template).error);
         });
+
+        it('returns error when template name has more than one slash', () => {
+            assert.isNotNull(validate('config.template.badName.yaml',
+                config.template.template).error);
+        });
+
+        it('returns error when template namespace exists and name has a slash', () => {
+            assert.isNotNull(validate('config.template.badNameWithSlash.yaml',
+                config.template.template).error);
+        });
     });
 });

--- a/test/data/config.template.badName.yaml
+++ b/test/data/config.template.badName.yaml
@@ -1,0 +1,14 @@
+name: test/template/extraslash
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/data/config.template.badNameWithSlash.yaml
+++ b/test/data/config.template.badNameWithSlash.yaml
@@ -1,0 +1,15 @@
+namespace: test
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - echo: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN


### PR DESCRIPTION
Should only allow one slash in the template name. If the template namespace exists, template name should not have any slashes.

Related to https://github.com/screwdriver-cd/screwdriver/issues/926#issuecomment-391907638