### PR TITLE
fix(653): Only allow ~jobname for blockedBy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+package-lock.json

--- a/config/job.js
+++ b/config/job.js
@@ -79,13 +79,17 @@ const SCHEMA_STEPS = Joi.array().items(SCHEMA_STEP).min(1);
 const SCHEMA_TEMPLATE = Joi.string().regex(Regex.FULL_TEMPLATE_NAME);
 const SCHEMA_JOBNAME = Joi.string().regex(Regex.JOB_NAME);
 const SCHEMA_TRIGGER = Joi.string().regex(Regex.TRIGGER); // ~commit, ~pr, etc.
-const SCHEMA_EXTERNAL_TRIGGER = Joi.string().regex(Regex.EXTERNAL_TRIGGER);
+const SCHEMA_INTERNAL_TRIGGER = Joi.string().regex(Regex.INTERNAL_TRIGGER); // ~main, ~jobOne
+const SCHEMA_EXTERNAL_TRIGGER = Joi.string().regex(Regex.EXTERNAL_TRIGGER); // ~sd@123:main
 const SCHEMA_REQUIRES_VALUE = Joi.alternatives().try(SCHEMA_JOBNAME, SCHEMA_TRIGGER);
 const SCHEMA_REQUIRES = Joi.alternatives().try(
     Joi.array().items(SCHEMA_REQUIRES_VALUE),
     SCHEMA_REQUIRES_VALUE
 );
-const SCHEMA_BLOCKEDBY_VALUE = Joi.alternatives().try(SCHEMA_JOBNAME, SCHEMA_EXTERNAL_TRIGGER);
+const SCHEMA_BLOCKEDBY_VALUE = Joi.alternatives().try(
+    SCHEMA_INTERNAL_TRIGGER,
+    SCHEMA_EXTERNAL_TRIGGER
+);
 const SCHEMA_BLOCKEDBY = Joi.alternatives().try(
     Joi.array().items(SCHEMA_BLOCKEDBY_VALUE),
     SCHEMA_BLOCKEDBY_VALUE

--- a/config/regex.js
+++ b/config/regex.js
@@ -42,6 +42,8 @@ module.exports = {
     JOB_NAME: /^[\w-]+$/,
     // PR JOB Name can only be PR-1 or PR-1:main, group1: PR-prNum, group2: jobName
     PR_JOB_NAME: /^(PR-\d+)(?::([\w-]+))?$/,
+    // Internal trigger like ~component or ~main
+    INTERNAL_TRIGGER: /^~([\w-]+)$/,
     // External trigger like ~sd@123:component
     EXTERNAL_TRIGGER: /^~sd@(\d+):([\w-]+)$/,
     // Can be ~pr, ~commit, or ~commit:branchName, or ~sd@123:component

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -4,6 +4,16 @@ const assert = require('chai').assert;
 const config = require('../../').config;
 
 describe('config regex', () => {
+    describe('internal trigger', () => {
+        it('checks good internal trigger', () => {
+            assert.isTrue(config.regex.INTERNAL_TRIGGER.test('~main'));
+        });
+
+        it('fails on bad internal trigger', () => {
+            assert.isFalse(config.regex.INTERNAL_TRIGGER.test('main'));
+        });
+    });
+
     describe('external trigger', () => {
         it('checks good external trigger', () => {
             assert.isTrue(config.regex.EXTERNAL_TRIGGER.test('~sd@123:main'));

--- a/test/data/config.job.blockedBy.bad.yaml
+++ b/test/data/config.job.blockedBy.bad.yaml
@@ -2,4 +2,4 @@ image: node:6
 steps:
     - publish: npm publish
 requires: ~commit
-blockedBy: 123
+blockedBy: main

--- a/test/data/config.job.blockedBy.yaml
+++ b/test/data/config.job.blockedBy.yaml
@@ -3,6 +3,6 @@ steps:
     - publish: npm publish
 requires: ~commit
 blockedBy:
-    - main
-    - test
+    - ~main
+    - ~test
     - ~sd@123:publish


### PR DESCRIPTION
## Context
Since blockedBy is always using OR logic, we should at least make it consistent with previous workflow syntax by requiring a tilde before all the job names.

## Objective
This PR changes the allowed strings for `blockedBy`.
Before: `<jobName>` and `~sd@<pipelineId>:<jobName>`
After: `~<jobName>` and `~sd@<pipelineId>:<jobName>`.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/653