### PR TITLE
fix(1040): relocate images from job config to root of template config

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -62,16 +62,6 @@ const SCHEMA_STEP_OBJECT = Joi.object()
 const SCHEMA_DESCRIPTION = Joi.string().max(100).optional();
 
 const SCHEMA_IMAGE = Joi.string();
-const SCHEMA_IMAGES = Joi.object()
-    .pattern(Regex.IMAGE_ALIAS, SCHEMA_IMAGE)
-    .min(1)
-    .options({
-        language: {
-            object: {
-                allowUnknown: 'only supports the following characters A-Z,a-z,0-9,-,_'
-            }
-        }
-    });
 
 const SCHEMA_SETTINGS = Joi.object().optional();
 const SCHEMA_STEP = Joi.alternatives().try(SCHEMA_STEP_STRING, SCHEMA_STEP_OBJECT);
@@ -101,7 +91,6 @@ const SCHEMA_JOB = Joi.object()
         description: SCHEMA_DESCRIPTION,
         environment: SCHEMA_ENVIRONMENT,
         image: SCHEMA_IMAGE,
-        images: SCHEMA_IMAGES,
         matrix: SCHEMA_MATRIX,
         requires: SCHEMA_REQUIRES,
         blockedBy: SCHEMA_BLOCKEDBY,
@@ -122,7 +111,6 @@ module.exports = {
     description: SCHEMA_DESCRIPTION,
     environment: SCHEMA_ENVIRONMENT,
     image: SCHEMA_IMAGE,
-    images: SCHEMA_IMAGES,
     job: SCHEMA_JOB,
     matrix: SCHEMA_MATRIX,
     requires: SCHEMA_REQUIRES,

--- a/config/template.js
+++ b/config/template.js
@@ -54,6 +54,17 @@ const TEMPLATE_MAINTAINER = Joi
     .description('Maintainer of the Template')
     .example('foo@bar.com');
 
+const TEMPLATE_IMAGES = Joi.object()
+    .pattern(Regex.IMAGE_ALIAS, Job.image)
+    .min(1)
+    .options({
+        language: {
+            object: {
+                allowUnknown: 'only supports the following characters A-Z,a-z,0-9,-,_'
+            }
+        }
+    });
+
 const SCHEMA_TEMPLATE = Joi.object()
     .keys({
         namespace: TEMPLATE_NAMESPACE,
@@ -61,7 +72,8 @@ const SCHEMA_TEMPLATE = Joi.object()
         version: TEMPLATE_VERSION,
         description: TEMPLATE_DESCRIPTION,
         maintainer: TEMPLATE_MAINTAINER,
-        config: Job.job
+        config: Job.job,
+        images: TEMPLATE_IMAGES
     })
     .requiredKeys('name', 'version', 'description', 'maintainer',
         'config', 'config.image', 'config.steps');
@@ -79,5 +91,6 @@ module.exports = {
     exactVersion: TEMPLATE_EXACT_VERSION,
     description: TEMPLATE_DESCRIPTION,
     maintainer: TEMPLATE_MAINTAINER,
-    config: Job.job
+    config: Job.job,
+    images: TEMPLATE_IMAGES
 };

--- a/models/template.js
+++ b/models/template.js
@@ -23,6 +23,7 @@ const MODEL = {
     version: Template.version,
     description: Template.description,
     maintainer: Template.maintainer,
+    images: Template.images,
     pipelineId
 };
 

--- a/test/data/template.yaml
+++ b/test/data/template.yaml
@@ -9,10 +9,10 @@ labels:
     - stable
     - test
     - beta
+images:
+  latest: node:6
+  stable: node:5
 config:
-  images:
-    latest: node:6
-    stable: node:5
   image: node:6
   steps:
     - install: npm install


### PR DESCRIPTION
## Context

The template config directive `images` is template-specific and should not be part of the job config.  Therefore it should be relocated to the root of the template config.


## References

* Issue: https://github.com/screwdriver-cd/screwdriver/issues/1040