### PR TITLE
fix: Remove Joi alternatives from template model

### DIFF
--- a/models/template.js
+++ b/models/template.js
@@ -19,7 +19,11 @@ const MODEL = {
 
     config: Template.config,
     namespace: Template.namespace,
-    name: Template.name,
+    name: Joi
+        .string()
+        .max(64)
+        .description('Template name')
+        .example('nodejs/lib'),
     version: Template.version,
     description: Template.description,
     maintainer: Template.maintainer,

--- a/models/templateTag.js
+++ b/models/templateTag.js
@@ -9,7 +9,11 @@ const MODEL = {
         .description('Identifier of this template tag')
         .example(123345),
     namespace: Template.namespace,
-    name: Template.name,
+    name: Joi
+        .string()
+        .max(64)
+        .description('Template name')
+        .example('nodejs/lib'),
     tag: Template.templateTag,
     version: Template.exactVersion
 };


### PR DESCRIPTION
Models can't handle Joi alternatives. Hardcoding template name to a string instead.

Seeing this error when trying to run the API locally:
```
TypeError: Cannot read property 'key' of undefined
```

Related to https://github.com/screwdriver-cd/screwdriver/issues/926#issuecomment-391907638