### PR TITLE
feat(677): modify command.habitat schema

### DIFF
--- a/config/commandFormat.js
+++ b/config/commandFormat.js
@@ -13,7 +13,7 @@ const HABITAT_MODE = Joi
 const HABITAT_FILE = Joi
     .string()
     .description('File path of the Habitat artifact')
-    .example('./foobar.hart')
+    .example('./foobar.hart');
 
 const HABITAT_PACKAGE = Joi
     .string()

--- a/config/commandFormat.js
+++ b/config/commandFormat.js
@@ -10,6 +10,11 @@ const HABITAT_MODE = Joi
     .description('Mode of the Habitat command')
     .example('remote');
 
+const HABITAT_FILE = Joi
+    .string()
+    .description('File path of the Habitat artifact')
+    .example('./foobar.hart')
+
 const HABITAT_PACKAGE = Joi
     .string()
     .description('Package of the Habitat command')
@@ -23,6 +28,8 @@ const HABITAT_COMMAND = Joi
 const SCHEMA_HABITAT = Joi.object()
     .keys({
         mode: HABITAT_MODE,
+        file: HABITAT_FILE
+            .when('mode', { is: 'local', then: Joi.required() }),
         package: HABITAT_PACKAGE,
         command: HABITAT_COMMAND
     })
@@ -64,6 +71,7 @@ const SCHEMA_BINARY = Joi.object()
 module.exports = {
     habitat: SCHEMA_HABITAT,
     habitatMode: HABITAT_MODE,
+    habitatFile: HABITAT_FILE,
     habitatPackage: HABITAT_PACKAGE,
     habitatCommand: HABITAT_COMMAND,
     docker: SCHEMA_DOCKER,

--- a/test/config/commandFormat.test.js
+++ b/test/config/commandFormat.test.js
@@ -6,8 +6,13 @@ const validate = require('../helper').validate;
 
 describe('config commandFormat', () => {
     describe('habitat', () => {
-        it('validates safely', () => {
-            assert.isNull(validate('config.commandFormat.habitat.yaml',
+        it('remote mode validates safely', () => {
+            assert.isNull(validate('config.commandFormat.habitat.remote.yaml',
+                config.commandFormat.habitat).error);
+        });
+
+        it('local mode validates safely', () => {
+            assert.isNull(validate('config.commandFormat.habitat.local.yaml',
                 config.commandFormat.habitat).error);
         });
 

--- a/test/data/config.commandFormat.habitat.local.yaml
+++ b/test/data/config.commandFormat.habitat.local.yaml
@@ -1,0 +1,4 @@
+mode: local
+file: ./foobar.hart
+package: core/git/2.14.1
+command: git

--- a/test/data/config.commandFormat.habitat.remote.yaml
+++ b/test/data/config.commandFormat.habitat.remote.yaml
@@ -1,6 +1,3 @@
 mode: remote
 package: core/git/2.14.1
-# If local
-# mode: local
-# package: ./foobar.hart
 command: git


### PR DESCRIPTION
## Context
Habitat artifact (e.g. `foobar.hart`) does not have own pakcage infomation (e.g. `foo/bar/1.2.3`).
We need to have both package infomation and artifact path for habitat local mode.

## Objective
Add `file` property to `command.habitat` schema which is required when `command.habitat.mode` is local.

## Reference
https://github.com/screwdriver-cd/sd-cmd/pull/22#discussion_r191665209
https://github.com/screwdriver-cd/screwdriver/issues/677