### PR TITLE
fix(1082): [6] add regex validation of commit branch filter.

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -4,6 +4,8 @@ const Annotations = require('./annotations');
 const Joi = require('joi');
 const Regex = require('./regex');
 
+const SPECIFIC_BRANCH_POS = 3;
+
 // ref. https://github.com/hapijs/joi/blob/v13.3.0/API.md#extendextension
 const sdJoi = Joi.extend(joi => ({
     base: joi.string(),
@@ -15,10 +17,9 @@ const sdJoi = Joi.extend(joi => ({
         {
             name: 'commitBranch',
             validate(params, value, state, options) {
-                const specificBranchPos = 3;
                 const matched = Regex.TRIGGER.exec(value);
                 // e.g. value = ~commit:/^user-.*$/ => brFilter = /^user-.*$/
-                const brFilter = matched[specificBranchPos];
+                const brFilter = matched[SPECIFIC_BRANCH_POS];
 
                 // branch regex filter
                 if (typeof brFilter !== 'undefined' && /^\/.+\/$/.test(brFilter)) {

--- a/config/job.js
+++ b/config/job.js
@@ -15,13 +15,15 @@ const sdJoi = Joi.extend(joi => ({
         {
             name: 'commitBranch',
             validate(params, value, state, options) {
-                const regexPos = 3;
+                const specificBranchPos = 3;
                 const matched = Regex.TRIGGER.exec(value);
-                const brFilter = matched[regexPos];
+                // e.g. value = ~commit:/^user-.*$/ => brFilter = /^user-.*$/
+                const brFilter = matched[specificBranchPos];
 
                 // branch regex filter
                 if (typeof brFilter !== 'undefined' && /^\/.+\/$/.test(brFilter)) {
                     try {
+                        // e.g. /^user-.*$/ => ^user-.*$
                         const filterRegex = brFilter.substr(1, brFilter.length - 2);
                         /* eslint-disable no-unused-vars */
                         // compile for syntax validation

--- a/config/job.js
+++ b/config/job.js
@@ -15,8 +15,9 @@ const sdJoi = Joi.extend(joi => ({
         {
             name: 'commitBranch',
             validate(params, value, state, options) {
+                const regexPos = 3;
                 const matched = Regex.TRIGGER.exec(value);
-                const brFilter = matched[3];
+                const brFilter = matched[regexPos];
 
                 // branch regex filter
                 if (typeof brFilter !== 'undefined' && /^\/.+\/$/.test(brFilter)) {

--- a/config/regex.js
+++ b/config/regex.js
@@ -47,7 +47,8 @@ module.exports = {
     // External trigger like ~sd@123:component
     EXTERNAL_TRIGGER: /^~sd@(\d+):([\w-]+)$/,
     // Can be ~pr, ~commit, or ~commit:branchName, or ~sd@123:component
-    TRIGGER: /^~(sd@\d+:[\w-]+|pr|commit(:.+)?)$/,
+    // Note: if you modify this regex, you must modify `sdJoi` definition in the `config/job.js`
+    TRIGGER: /^~(sd@\d+:[\w-]+|pr|commit(:(.+))?)$/,
     // IEEE Std 1003.1-2001
     // Environment names contain uppercase letters, digits, and underscore
     // They cannot start with digits

--- a/config/regex.js
+++ b/config/regex.js
@@ -49,7 +49,7 @@ module.exports = {
     // Can be ~pr, ~commit, or ~commit:branchName, or ~sd@123:component
     // Note: if you modify this regex, you must modify `sdJoi` definition in the `config/job.js`
     TRIGGER: /^~(sd@\d+:[\w-]+|pr|commit(:(.+))?)$/,
-    // Can be ~commit or ~commit:master
+    // Can be ~commit or ~commit:branchName
     COMMIT_TRIGGER: /^~commit(:.+)?$/,
     // IEEE Std 1003.1-2001
     // Environment names contain uppercase letters, digits, and underscore

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -22,6 +22,11 @@ describe('config job', () => {
             assert.isNotNull(validate('config.job.jobv2.bad.yaml', config.job.job).error);
         });
 
+        it('returns error for requires with bad commit branch regex', () => {
+            assert.isNotNull(
+                validate('config.job.jobv2.badCommitBrRegex.yaml', config.job.job).error);
+        });
+
         it('validates a job with blockedBy', () => {
             assert.isNull(validate('config.job.blockedBy.yaml', config.job.job).error);
         });

--- a/test/data/config.job.jobv2.badCommitBrRegex.yaml
+++ b/test/data/config.job.jobv2.badCommitBrRegex.yaml
@@ -10,4 +10,4 @@ steps:
     - init: npm install
     - test: npm test
     - publish: npm publish
-requires: [ ~commit, ~commit:staging, ~commit:/^user-.*$/ ]
+requires: [ ~commit, ~commit:staging, ~commit:/*/ ]


### PR DESCRIPTION
## Context

SCM Branch-specific jobs

## Objective

This PR adds  regex validation of commit branch filter (e.g. `/^user-.*$/`).

## References

- [Design PR](https://github.com/screwdriver-cd/screwdriver/pull/1092)
- https://github.com/screwdriver-cd/screwdriver/issues/1082