### PR TITLE
feat(1082): add commit trigger regex

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -48,6 +48,8 @@ module.exports = {
     EXTERNAL_TRIGGER: /^~sd@(\d+):([\w-]+)$/,
     // Can be ~pr, ~commit, or ~commit:branchName, or ~sd@123:component
     TRIGGER: /^~(sd@\d+:[\w-]+|pr|commit(:.+)?)$/,
+    // Can be ~commit or ~commit:master
+    COMMIT_TRIGGER: /^~commit(:.+)?$/,
     // IEEE Std 1003.1-2001
     // Environment names contain uppercase letters, digits, and underscore
     // They cannot start with digits

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -34,6 +34,18 @@ describe('config regex', () => {
         });
     });
 
+    describe('commit trigger', () => {
+        it('checks good trigger', () => {
+            assert.isTrue(config.regex.TRIGGER.test('~commit'));
+            assert.isTrue(config.regex.TRIGGER.test('~commit:master'));
+        });
+
+        it('fails on bad trigger', () => {
+            assert.isFalse(config.regex.TRIGGER.test('~'));
+            assert.isFalse(config.regex.TRIGGER.test('~commit:'));
+        });
+    });
+
     describe('commands', () => {
         it('checks good command namespaces', () => {
             assert.isTrue(config.regex.COMMAND_NAMESPACE.test('chefdk'));


### PR DESCRIPTION
## Context
To check commit trigger or not. This will be used at [here](https://github.com/screwdriver-cd/models/blob/master/lib/eventFactory.js#L24).

## Objective 
Add COMMIT_TRIGGER regex.

## References
Related to screwdriver-cd/screwdriver#1082