### PR TITLE
fix(937): Add scmUrls to validator output schema

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Annotations = require('../config/annotations');
+const Base = require('../config/base');
 const Job = require('../config/job');
 const Joi = require('joi');
 const Regex = require('../config/regex');
@@ -48,6 +49,7 @@ const SCHEMA_OUTPUT = Joi.object()
         annotations: Annotations.annotations,
         errors: Joi.array().items(Joi.string()).optional(),
         jobs: SCHEMA_JOBS,
+        scmUrls: Base.scmUrls,
         workflowGraph: WorkflowGraph.workflowGraph
     })
     .label('Execution information');

--- a/test/api/validator.test.js
+++ b/test/api/validator.test.js
@@ -29,5 +29,10 @@ describe('api validator', () => {
         it('validates basic output with errors', () => {
             assert.isNull(validate('validator.erroroutput.yaml', api.validator.output).error);
         });
+
+        it('validates output with scmUrls', () => {
+            assert.isNull(
+                validate('validator-with-scmUrls.output.yaml', api.validator.output).error);
+        });
     });
 });

--- a/test/data/validator-with-scmUrls.output.yaml
+++ b/test/data/validator-with-scmUrls.output.yaml
@@ -1,0 +1,70 @@
+scmUrls:
+    - git@github.com:org/repo.git
+
+jobs:
+  main:
+  - image: node:4
+    commands:
+      - name: install
+        command: npm install
+      - name: test
+        command: npm test
+      - name: build
+        command: npm run build
+    annotations:
+      beta.screwdriver.cd/auto_pr_builds: fork-only
+    description: "This is a description"
+    environment:
+      NODE_VERSION: 4
+    settings:
+      email: foo@bar.com
+    sourcePaths:
+      - src/A
+      - src/AConfig
+  - image: node:5
+    commands:
+    - name: install
+      command: npm install
+    - name: test
+      command: npm test
+    - name: build
+      command: npm run build
+    annotations:
+      beta.screwdriver.cd/auto_pr_builds: fork-only
+    description: "This is a description"
+    environment:
+      NODE_VERSION: 5
+    settings:
+      email: foo@bar.com
+    sourcePaths:
+      - src/A
+      - src/AConfig
+  - image: node:6
+    commands:
+    - name: install
+      command: npm install
+    - name: test
+      command: npm test
+    - name: build
+      command: npm run build
+    annotations:
+      beta.screwdriver.cd/auto_pr_builds: fork-only
+    description: "This is a description"
+    environment:
+      NODE_VERSION: 6
+    settings:
+      email: foo@bar.com
+    sourcePaths:
+      - src/A
+      - src/AConfig
+    secrets:
+      - ANOTHER_SECRET
+
+  publish:
+  - image: node:4
+    commands:
+    - name: install
+      command: npm publish
+    environment: {}
+    secrets:
+      - NPM_TOKEN


### PR DESCRIPTION
## Context
The validator output schema does not contain `SCHEMA_SCM_URLS`. This will cause the validator endpoint to return 500s if the input contains `scmUrls`.

## Objective
Add `SCHEMA_SCM_URLS` to `SCHEMA_OUTPUT` in the validator

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/937