### PR TITLE
fix(937): Add startAll flag and scmUrls to childPipelines object

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -49,7 +49,7 @@ const SCHEMA_OUTPUT = Joi.object()
         annotations: Annotations.annotations,
         errors: Joi.array().items(Joi.string()).optional(),
         jobs: SCHEMA_JOBS,
-        scmUrls: Base.scmUrls,
+        childPipelines: Base.childPipelines,
         workflowGraph: WorkflowGraph.workflowGraph
     })
     .label('Execution information');

--- a/config/base.js
+++ b/config/base.js
@@ -13,13 +13,20 @@ const SCHEMA_JOBS = Joi.object()
 const SCHEMA_SHARED = Job.job;
 const SCHEMA_SCM_URL = Joi.string().regex(Regex.CHECKOUT_URL);
 const SCHEMA_SCM_URLS = Joi.array().items(SCHEMA_SCM_URL).min(1);
+const SCHEMA_CHILD_PIPELINES = Joi.object()
+    .keys({
+        scmUrls: SCHEMA_SCM_URLS,
+        startAll: Joi.boolean()
+    })
+    .requiredKeys('scmUrls')
+    .unknown(false);
 const SCHEMA_CONFIG = Joi.object()
     .keys({
         version: Joi.number().integer().min(1).max(50),
         annotations: Annotations.annotations,
         jobs: SCHEMA_JOBS,
         shared: SCHEMA_SHARED,
-        scmUrls: SCHEMA_SCM_URLS
+        childPipelines: SCHEMA_CHILD_PIPELINES
     })
     .requiredKeys('jobs')
     .unknown(false);
@@ -31,6 +38,6 @@ const SCHEMA_CONFIG = Joi.object()
 module.exports = {
     jobs: SCHEMA_JOBS,
     shared: SCHEMA_SHARED,
-    scmUrls: SCHEMA_SCM_URLS,
+    childPipelines: SCHEMA_CHILD_PIPELINES,
     config: SCHEMA_CONFIG
 };

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -59,8 +59,8 @@ const MODEL = {
         .description('Identifier of pipeline containing external configuration')
         .example(123),
 
-    scmUrls: Base.scmUrls
-        .description('List of SCM URLs that use this pipeline as an external configuration')
+    childPipelines: Base.childPipelines
+        .description('Configuration of child pipelines')
 };
 
 module.exports = {
@@ -82,7 +82,7 @@ module.exports = {
         'id', 'scmUri', 'scmContext', 'createTime', 'admins'
     ], [
         'workflowGraph', 'scmRepo', 'annotations', 'lastEventId',
-        'configPipelineId', 'scmUrls'
+        'configPipelineId', 'childPipelines'
     ])).label('Get Pipeline'),
 
     /**

--- a/test/api/validator.test.js
+++ b/test/api/validator.test.js
@@ -30,9 +30,9 @@ describe('api validator', () => {
             assert.isNull(validate('validator.erroroutput.yaml', api.validator.output).error);
         });
 
-        it('validates output with scmUrls', () => {
+        it('validates output with childPipelines', () => {
             assert.isNull(
-                validate('validator-with-scmUrls.output.yaml', api.validator.output).error);
+                validate('validator-with-childPipelines.output.yaml', api.validator.output).error);
         });
     });
 });

--- a/test/config/base.test.js
+++ b/test/config/base.test.js
@@ -23,9 +23,10 @@ describe('config base', () => {
         });
     });
 
-    describe('scmUrls', () => {
-        it('validates a list of scmUrls', () => {
-            assert.isNull(validate('config.base.scmUrls.yaml', config.base.scmUrls).error);
+    describe('childPipelines', () => {
+        it('validates the childPipelines object', () => {
+            assert.isNull(validate('config.base.childPipelines.yaml',
+                config.base.childPipelines).error);
         });
     });
 });

--- a/test/data/config.base.childPipelines.yaml
+++ b/test/data/config.base.childPipelines.yaml
@@ -1,0 +1,4 @@
+scmUrls:
+    - git@github.com:org/repo.git
+    - https://git@github.com:org/repo2.git
+startAll: true

--- a/test/data/config.base.config.yaml
+++ b/test/data/config.base.config.yaml
@@ -1,8 +1,10 @@
 version: 4
 
-scmUrls:
-  - git@github.com:org/repo.git
-  - https://git@github.com:org/repo2.git
+childPipelines:
+    scmUrls:
+      - git@github.com:org/repo.git
+      - https://git@github.com:org/repo2.git
+    startAll: true
 
 shared:
     environment:

--- a/test/data/config.base.scmUrls.yaml
+++ b/test/data/config.base.scmUrls.yaml
@@ -1,2 +1,0 @@
-- git@github.com:org/repo.git
-- https://git@github.com:org/repo2.git

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -17,6 +17,8 @@ annotations:
     beta.screwdriver.cd/auto_pr_builds: fork-only
 lastEventId: 31135214
 configPipelineId: 123
-scmUrls:
-    - git@github.com:org/repo.git
-    - https://github.com:org/repo2.git
+childPipelines:
+    scmUrls:
+        - git@github.com:org/repo.git
+        - https://github.com:org/repo2.git
+    startAll: true

--- a/test/data/validator-with-childPipelines.output.yaml
+++ b/test/data/validator-with-childPipelines.output.yaml
@@ -1,5 +1,7 @@
-scmUrls:
-    - git@github.com:org/repo.git
+childPipelines:
+    scmUrls:
+        - git@github.com:org/repo.git
+    startAll: true
 
 jobs:
   main:


### PR DESCRIPTION
## Context
Beyond just listing `scmUrls` we want to enable additional configuration within the `screwdriver.yaml` for  config pipelines. For instance, we want to include a `startAll` flag to determine whether to start all child pipelines whenever  the config pipeline starts.

## Objective
Encompass `scmUrls` and `startAll` into an object named `childPipelines`.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/937
