### PR TITLE
fix(1082): [3] add scmContext

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -116,7 +116,8 @@ const PARSE_URL = Joi.object().keys({
 
 const GET_BRANCH_LIST = Joi.object().keys({
     scmUri,
-    token
+    token,
+    scmContext
 }).required();
 
 module.exports = {


### PR DESCRIPTION
## Context
To use scm functions, need to send scmContext to [scm router](https://github.com/screwdriver-cd/scm-router/blob/master/index.js#L124)

## Objective
Add scmContext.

## Reference
[scm router](https://github.com/screwdriver-cd/scm-router/blob/master/index.js#L124)
Related to https://github.com/screwdriver-cd/screwdriver/issues/1082
