### PR TITLE
fix(1090): Add createTime to templates, commands, and tags [1]

### DIFF
--- a/models/command.js
+++ b/models/command.js
@@ -11,6 +11,13 @@ const MODEL = {
         .description('Identifier of this command')
         .example(123345),
 
+    createTime: Joi
+        .string()
+        .isoDate()
+        .max(32)
+        .description('When this command was created')
+        .example('2038-01-19T03:14:08.131Z'),
+
     namespace: Command.namespace,
     name: Command.name,
     version: Command.version,
@@ -50,7 +57,8 @@ module.exports = {
     ], [
         'habitat',
         'docker',
-        'binary'
+        'binary',
+        'createTime'
     ])).label('Get Command'),
 
     /**

--- a/models/commandTag.js
+++ b/models/commandTag.js
@@ -8,6 +8,12 @@ const MODEL = {
         .number().integer().positive()
         .description('Identifier of this command tag')
         .example(123345),
+    createTime: Joi
+        .string()
+        .isoDate()
+        .max(32)
+        .description('When this command tag was created')
+        .example('2038-01-19T03:14:08.131Z'),
     namespace: Command.namespace,
     name: Command.name,
     tag: Command.commandTag,

--- a/models/template.js
+++ b/models/template.js
@@ -11,6 +11,13 @@ const MODEL = {
         .description('Identifier of this template')
         .example(123345),
 
+    createTime: Joi
+        .string()
+        .isoDate()
+        .max(32)
+        .description('When this template was created')
+        .example('2038-01-19T03:14:08.131Z'),
+
     labels: Joi
         .array()
         .items(Joi.string())
@@ -48,7 +55,7 @@ module.exports = {
      */
     get: Joi.object(mutate(MODEL, [
         'id', 'labels', 'config', 'name', 'version', 'description', 'maintainer', 'pipelineId'
-    ], ['namespace', 'images'])).label('Get Template'),
+    ], ['namespace', 'images', 'createTime'])).label('Get Template'),
 
     /**
      * Properties for template that will be passed during a CREATE request

--- a/models/templateTag.js
+++ b/models/templateTag.js
@@ -8,6 +8,12 @@ const MODEL = {
         .number().integer().positive()
         .description('Identifier of this template tag')
         .example(123345),
+    createTime: Joi
+        .string()
+        .isoDate()
+        .max(32)
+        .description('When this template tag was created')
+        .example('2038-01-19T03:14:08.131Z'),
     namespace: Template.namespace,
     name: Joi
         .string()

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^3.0.0",
-    "js-yaml": "^3.11.0"
+    "js-yaml": "^3.12.0"
   },
   "dependencies": {
-    "joi": "^13.0.0"
+    "joi": "^13.4.0"
   }
 }

--- a/test/data/command.get.yaml
+++ b/test/data/command.get.yaml
@@ -1,5 +1,6 @@
 # Command Get Example
 id: 123234135
+createTime: '2017-01-06T01:49:50.384359267Z'
 namespace: foo
 name: bar
 version: '1.0'

--- a/test/data/template.get.yaml
+++ b/test/data/template.get.yaml
@@ -1,5 +1,6 @@
 # Template GET Example
 id: 123234135
+createTime: '2017-01-06T01:49:50.384359267Z'
 name: test/template
 version: "1.3"
 description: Template for testing


### PR DESCRIPTION
Add createTime to templates, commands, and tags so we can show when a version was published

Related to https://github.com/screwdriver-cd/screwdriver/issues/1090