### PR TITLE
feat(1082): [7] allow set commit branch

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -36,6 +36,7 @@ const GET_CHECKOUT_COMMAND = Joi.object().keys({
     repo: Joi.string().required(),
     sha: Joi.string().required(),
     prRef: Joi.string().optional(),
+    commitBranch: Joi.string().optional(),
     manifest: Joi.string().optional(),
     scmContext
 }).required();


### PR DESCRIPTION
## Context
When specific branch jobs are triggered, we have to clone from the branch.

## Objective
Allow to send commitBranch to getCheckoutCommand.

## Reference
Related to screwdriver-cd/screwdriver#1082