### PR TITLE
feat(614): [1] Revert 252 revert 250 pipeline token

### DIFF
--- a/models/token.js
+++ b/models/token.js
@@ -130,5 +130,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: ['hash', 'userId']
+    indexes: ['hash', 'userId', 'pipelineId']
 };

--- a/models/token.js
+++ b/models/token.js
@@ -27,6 +27,13 @@ const MODEL = {
         .positive()
         .description('User ID'),
 
+    pipelineId: Joi
+        .number()
+        .integer()
+        .positive()
+        .description('Pipeline ID')
+        .example(123345),
+
     name: Joi
         .string()
         .max(128)
@@ -54,7 +61,7 @@ module.exports = {
      * @property base
      * @type {Joi}
      */
-    base: Joi.object(MODEL).label('Token'),
+    base: Joi.object(MODEL).without('userId', 'pipelineId').label('Token'),
 
     /**
      * Properties for token that will come back during a GET request

--- a/test/data/token.invalid.yaml
+++ b/test/data/token.invalid.yaml
@@ -1,0 +1,8 @@
+# Invalid Token Example
+userId: 1234
+pipelineId: 1234
+hash: 'aHashedTokenValueMustBe86CharactersLong_______________________________________________'
+id: 1111
+name: 'Auth token'
+description: 'A token for authentication'
+lastUsed: '2038-01-19T03:14:08.131Z'

--- a/test/data/token.pipeline.yaml
+++ b/test/data/token.pipeline.yaml
@@ -1,0 +1,7 @@
+# Pipeline Token Example
+pipelineId: 1234
+hash: 'aHashedTokenValueMustBe86CharactersLong_______________________________________________'
+id: 1111
+name: 'Auth token'
+description: 'A token for authentication'
+lastUsed: '2038-01-19T03:14:08.131Z'

--- a/test/models/token.test.js
+++ b/test/models/token.test.js
@@ -5,9 +5,21 @@ const models = require('../../').models;
 const validate = require('../helper').validate;
 
 describe('token template', () => {
-    describe('base', () => {
-        it('validates the base', () => {
+    describe('user token', () => {
+        it('validates the user token', () => {
             assert.isNull(validate('token.yaml', models.token.base).error);
+        });
+    });
+
+    describe('pipeline token', () => {
+        it('validates the pipeline token', () => {
+            assert.isNull(validate('token.pipeline.yaml', models.token.base).error);
+        });
+    });
+
+    describe('invalid token', () => {
+        it('validates the token which have both userId and pipelineId', () => {
+            assert.isNotNull(validate('token.invalid.yaml', models.token.base).error);
         });
     });
 


### PR DESCRIPTION
## Context
To implement pipeline API token.

## Objective
It is almost same changes as https://github.com/screwdriver-cd/data-schema/pull/250 which we reverted last time.

Before making this change I had to modify the API side. It's merged in [this PR](https://github.com/screwdriver-cd/screwdriver/pull/1107).
So I want to revert this again.

This PR conains a [new commit](https://github.com/screwdriver-cd/data-schema/pull/257/commits/fa4f9c1b3e293a71dbb881b68fdef1d22ca5060d) to add index for `pipelineId` from [original PR](https://github.com/screwdriver-cd/data-schema/pull/250).

## References
https://github.com/screwdriver-cd/screwdriver/issues/614