### PR TITLE
fix: Add BLOCKED and UNSTABLE statuses

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -113,7 +113,9 @@ const MODEL = {
             'FAILURE',
             'QUEUED', // when the build is created and put into the queue
             'RUNNING', // after the build is created, went through the queue, and has started
-            'SUCCESS'
+            'SUCCESS',
+            'BLOCKED',
+            'UNSTABLE'
         ])
         .description('Current status of the build')
         .example('SUCCESS')


### PR DESCRIPTION
Adding this status for builds that are blocked

Related: 
- https://github.com/screwdriver-cd/screwdriver/issues/653
- https://github.com/screwdriver-cd/screwdriver/issues/1122