### PR TITLE
feat(1113): Add meta as optional field to create builds and events

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -179,6 +179,8 @@ module.exports = {
      */
     create: Joi.object(mutate(MODEL, [
         'jobId'
+    ], [
+        'meta'
     ])).label('Create Build'),
 
     /**

--- a/models/event.js
+++ b/models/event.js
@@ -112,7 +112,7 @@ module.exports = {
      */
     create: Joi.object(mutate(CREATE_MODEL, [], [
         'pipelineId', 'startFrom', 'buildId', 'causeMessage', 'parentBuildId', 'parentEventId',
-        'configPipelineSha'
+        'configPipelineSha', 'meta'
     ])).label('Create Event'),
 
     /**

--- a/test/data/build.create.full.yaml
+++ b/test/data/build.create.full.yaml
@@ -1,0 +1,5 @@
+# Build Create Example
+jobId: 213452
+meta:
+  foo: bar
+  one: 1

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -5,3 +5,6 @@ parentEventId: 123456
 pipelineId: 1235123
 causeMessage: 'Restarted since publish job failed'
 configPipelineSha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
+meta:
+  foo: bar
+  one: 1

--- a/test/models/build.test.js
+++ b/test/models/build.test.js
@@ -16,6 +16,10 @@ describe('model build', () => {
             assert.isNull(validate('build.create.yaml', models.build.create).error);
         });
 
+        it('validates the create with optional fields', () => {
+            assert.isNull(validate('build.create.full.yaml', models.build.create).error);
+        });
+
         it('fails the create', () => {
             assert.isNotNull(validate('empty.yaml', models.build.create).error);
         });


### PR DESCRIPTION
## Context
Allow user to pass in `meta` when creating an `event` or `build`.

## Objective
Make `meta` an optional parameter for the `create` schema of `event` and `build`.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/1113