### PR TITLE
feat(1132): Add parent config schema to getCheckoutCommand

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -29,6 +29,12 @@ const ADD_WEBHOOK = Joi.object().keys({
     scmContext
 }).required();
 
+const PARENT_CONFIG = Joi.object().keys({
+    branch: Joi.string().required(),
+    host: Joi.string().required(),
+    org: Joi.string().required(),
+    repo: Joi.string().required()
+});
 const GET_CHECKOUT_COMMAND = Joi.object().keys({
     branch: Joi.string().required(),
     host: Joi.string().required(),
@@ -38,6 +44,7 @@ const GET_CHECKOUT_COMMAND = Joi.object().keys({
     prRef: Joi.string().optional(),
     commitBranch: Joi.string().optional(),
     manifest: Joi.string().optional(),
+    parentConfig: PARENT_CONFIG.optional(),
     scmContext
 }).required();
 

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -33,7 +33,8 @@ const PARENT_CONFIG = Joi.object().keys({
     branch: Joi.string().required(),
     host: Joi.string().required(),
     org: Joi.string().required(),
-    repo: Joi.string().required()
+    repo: Joi.string().required(),
+    sha: Joi.string().required()
 });
 const GET_CHECKOUT_COMMAND = Joi.object().keys({
     branch: Joi.string().required(),

--- a/test/data/scm.getCheckoutCommand.yaml
+++ b/test/data/scm.getCheckoutCommand.yaml
@@ -10,3 +10,4 @@ parentConfig:
   host: github
   org: screwdriver-cd
   repo: parentRepo
+  sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f

--- a/test/data/scm.getCheckoutCommand.yaml
+++ b/test/data/scm.getCheckoutCommand.yaml
@@ -5,3 +5,8 @@ repo: data-schema
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 scmContext: github:github.com
 manifest: git@github.com:org/repo.git/default.xml
+parentConfig:
+  branch: master
+  host: github
+  org: screwdriver-cd
+  repo: parentRepo


### PR DESCRIPTION
## Context
In order for an `scm` to clone the parent repository of a child pipeline, it must have information on the parent pipeline. 

This configuration will be used by `getSetupCommand` of `scm-base`.

## Objective
Include `PARENT_CONFIG` schema in `GET_CHECKOUT_COMMAND`.

## Reference
https://github.com/screwdriver-cd/screwdriver/issues/1132