### PR TITLE
fix: fix error message for external trigger

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -11,13 +11,18 @@ const sdJoi = Joi.extend(joi => ({
     base: joi.string(),
     name: 'string',
     language: {
-        commitBranch: 'needs to be a commit branch string/regex'
+        commitBranch: 'invalid trigger format'
     },
     rules: [
         {
             name: 'commitBranch',
             validate(params, value, state, options) {
                 const matched = Regex.TRIGGER.exec(value);
+
+                if (!matched) {
+                    return this.createError('string.commitBranch', { v: value }, state, options);
+                }
+
                 // e.g. value = ~commit:/^user-.*$/ => brFilter = /^user-.*$/
                 const brFilter = matched[SPECIFIC_BRANCH_POS];
 

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -18,6 +18,15 @@ describe('config job', () => {
             assert.isNull(validate('config.job.jobv2.externalrequires.yaml', config.job.job).error);
         });
 
+        it('validates a job with bad requires from an external pipeline', () => {
+            const result = validate('config.job.jobv2.externalrequires.bad.yaml', config.job.job);
+
+            assert.isNotNull(result.error);
+            assert.match(result.error,
+                // eslint-disable-next-line no-useless-escape
+                /^.*\"requires" with value "~sd@123" fails to match the required pattern.*$/);
+        });
+
         it('returns error for requires with bad commit branch regex', () => {
             assert.isNotNull(
                 validate('config.job.jobv2.badCommitBrRegex.yaml', config.job.job).error);

--- a/test/data/config.job.jobv2.externalrequires.bad.yaml
+++ b/test/data/config.job.jobv2.externalrequires.bad.yaml
@@ -1,0 +1,4 @@
+image: node:6
+steps:
+    - init: npm install
+requires: ~sd@123


### PR DESCRIPTION
Previously, if it fails all checks, config-parser will give:
```
"command": "echo \"TypeError: Cannot read property '3' of null\"; exit 1"
  "name": "config-parse-error"
```

Now, with this change, it will give:
```
"command": "echo \"ValidationError: child \"jobs\" fails because [child \"test-or\" fails because [child \"requires\" fails because [\"requires\" at position 2 fails because [\"2\" with value \"~sd@123main\" fails to match the required pattern: /^~([\\w-]+)$/, \"2\" with value \"~sd@123main\" fails to match the required pattern: /^[\\w-]+$/, \"2\" with value \"~sd@123main\" fails to match the required pattern: /^~(sd@\\d+:[\\w-]+|pr|commit(:(.+))?)$/, \"2\" invalid trigger format], \"requires\" must be a string, \"requires\" must be a string, \"requires\" must be a string]]]\"; exit 1"
"name": "config-parse-error"
```