### PR TITLE
fix(1114): Allow loglines to have sort query

### DIFF
--- a/api/loglines.js
+++ b/api/loglines.js
@@ -12,11 +12,16 @@ const SCHEMA_QUERY = Joi.object().keys({
     from: Joi.number().integer()
         .min(0)
         .default(0)
-        .description('Starting Line Number'),
+        .description('Starting line Number'),
     pages: Joi.number().integer()
         .min(1)
         .default(10)
-        .description('Max pages sent per request')
+        .description('Max pages sent per request'),
+    sort: Joi
+        .string().lowercase()
+        .valid(['ascending', 'descending'])
+        .default('ascending')
+        .description('Sorting option for lines')
 }).label('Query Parameters');
 
 const SCHEMA_LOGLINE = Joi.object().keys({

--- a/models/build.js
+++ b/models/build.js
@@ -29,9 +29,9 @@ const STEP = {
         .isoDate()
         .description('When this step stopped running')
         .example('2017-01-06T01:49:51.676057192Z'),
-    pages: Joi
+    lines: Joi
         .number().integer()
-        .description('Number of Step log pages')
+        .description('Number of Step log lines')
         .example(100)
 };
 const MODEL = {
@@ -106,7 +106,7 @@ const MODEL = {
     steps: Joi
         .array().items(
             Joi.object(
-                mutate(STEP, ['name'], ['code', 'startTime', 'endTime', 'command', 'pages'])
+                mutate(STEP, ['name'], ['code', 'startTime', 'endTime', 'command', 'lines'])
             ).description('Step metadata'))
         .description('List of steps'),
 
@@ -200,7 +200,7 @@ module.exports = {
         'startTime',
         'endTime',
         'command',
-        'pages'
+        'lines'
     ])).label('Get Step Metadata'),
 
     /**
@@ -213,7 +213,7 @@ module.exports = {
         'code',
         'startTime',
         'endTime',
-        'pages'
+        'lines'
     ])).label('Update Step Metadata'),
 
     /**

--- a/test/data/loglines.query.yaml
+++ b/test/data/loglines.query.yaml
@@ -1,2 +1,3 @@
 from: 455
 pages: 100
+sort: descending

--- a/test/data/step.get.yaml
+++ b/test/data/step.get.yaml
@@ -2,4 +2,4 @@ name: sd-setup
 code: 0
 startTime: "2038-01-19T03:15:08.131Z"
 endTime: "2038-01-19T03:15:08.532Z"
-pages: 100
+lines: 100

--- a/test/data/step.update.yaml
+++ b/test/data/step.update.yaml
@@ -1,4 +1,4 @@
 code: 0
 startTime: "2038-01-19T03:15:08.131Z"
 endTime: "2038-01-19T03:15:08.532Z"
-pages: 101
+lines: 101


### PR DESCRIPTION
Also change step value `pages` to `lines`

Related to https://github.com/screwdriver-cd/screwdriver/issues/1114