### PR TITLE
feat(1204): Remove default page and count for pagination [1]

### DIFF
--- a/api/pagination.js
+++ b/api/pagination.js
@@ -5,13 +5,11 @@ const Joi = require('joi');
 const MODEL = {
     page: Joi
         .number().integer().min(1)
-        .default(1)
         .description('Page to paginate'),
 
     count: Joi
         .number().integer().min(1)
         .max(50)
-        .default(50)
         .description('Count to paginate'),
 
     sort: Joi

--- a/test/api/pagination.test.js
+++ b/test/api/pagination.test.js
@@ -10,12 +10,13 @@ describe('api pagination', () => {
             assert.isNull(validate('pagination.yaml', api.pagination).error);
         });
 
-        it('defaults both', () => {
+        it('defaults', () => {
             const validatedObject = validate('pagination.defaults.yaml', api.pagination);
 
             assert.isNull(validatedObject.error);
-            assert.equal(validatedObject.value.page, 1);
-            assert.equal(validatedObject.value.count, 50);
+            assert.equal(validatedObject.value.page, undefined);
+            assert.equal(validatedObject.value.count, undefined);
+            assert.equal(validatedObject.value.sort, 'descending');
         });
     });
 });


### PR DESCRIPTION
## Context
The pipeline events page takes a long time to load because we don't have actual pagination. We want to add pagination for getting pipeline events but remove it everywhere else (since the UI doesn't know how to handle pagination for other `list` calls).

## Objective
This PR removes pagination default values for `page` and `count`;

## Related links
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1204