### PR TITLE
fix(1204): Make paginate field optional

### DIFF
--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -23,7 +23,7 @@ const SCHEMA_SCAN = Joi.object().keys({
     paginate: Joi.object().keys({
         count: Joi.number().integer().positive().required(),
         page: Joi.number().integer().positive().required()
-    }).required(),
+    }),
     sort: Joi.string().lowercase().valid(['ascending', 'descending']).default('descending')
 });
 


### PR DESCRIPTION
Currently seeing this error in beta.cd.screwdriver.cd: 
```
"child "paginate" fails because ["paginate" is required]"
```

Since we're actually implementing pagination in datastore-sequelize and most calls do not actually expect pagination, we need to make the `paginate` field optional for datastore scans.

Where we're using this schema: https://github.com/screwdriver-cd/datastore-base/blob/master/index.js#L107

Related to https://github.com/screwdriver-cd/screwdriver/issues/1204