### PR TITLE
[1] fix(1220): Add scmInfo to scm module functions

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -17,7 +17,7 @@ const scmInfo = Joi.object({
     host: Joi.string().required(),
     owner: Joi.string().required(),
     repo: Joi.string().required()
-});
+}).optional();
 const sha = Joi.reach(models.build.base, 'sha').required();
 const token = Joi.reach(models.user.base, 'token').required();
 const type = Joi.reach(core.scm.hook, 'type').required();
@@ -85,7 +85,7 @@ const GET_FILE = Joi.object().keys({
     path: Joi.string().required(),
     ref: Joi.string().optional(),
     scmContext,
-    scmInfo: scmInfo.optional()
+    scmInfo
 }).required();
 
 const GET_CHANGED_FILES_INPUT = Joi.object().keys({
@@ -109,7 +109,7 @@ const DECORATE_URL = Joi.object().keys({
     scmUri,
     token,
     scmContext,
-    scmInfo: scmInfo.optional()
+    scmInfo
 }).required();
 
 const DECORATE_COMMIT = Joi.object().keys({

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -12,6 +12,12 @@ const pipelineId = Joi.reach(models.pipeline.base, 'id').optional();
 const prNum = Joi.reach(core.scm.hook, 'prNum').allow(null).optional();
 const scmContext = Joi.reach(models.pipeline.base, 'scmContext').optional();
 const scmUri = Joi.reach(models.pipeline.base, 'scmUri').required();
+const scmInfo = Joi.object({
+    branch: Joi.string().required(),
+    host: Joi.string().required(),
+    owner: Joi.string().required(),
+    repo: Joi.string().required()
+});
 const sha = Joi.reach(models.build.base, 'sha').required();
 const token = Joi.reach(models.user.base, 'token').required();
 const type = Joi.reach(core.scm.hook, 'type').required();
@@ -78,7 +84,8 @@ const GET_FILE = Joi.object().keys({
     token,
     path: Joi.string().required(),
     ref: Joi.string().optional(),
-    scmContext
+    scmContext,
+    scmInfo: scmInfo.optional()
 }).required();
 
 const GET_CHANGED_FILES_INPUT = Joi.object().keys({
@@ -101,7 +108,8 @@ const PARSE_HOOK = Joi.alternatives().try(
 const DECORATE_URL = Joi.object().keys({
     scmUri,
     token,
-    scmContext
+    scmContext,
+    scmInfo: scmInfo.optional()
 }).required();
 
 const DECORATE_COMMIT = Joi.object().keys({

--- a/test/data/scm.decorateUrlWithScmInfo.yaml
+++ b/test/data/scm.decorateUrlWithScmInfo.yaml
@@ -1,0 +1,8 @@
+scmUri: github.com:12345678:master
+token: 'thisisatokenthingy'
+scmContext: github:github.com
+scmInfo:
+    branch: master
+    host: github.com
+    owner: testowner
+    repo: testrepo

--- a/test/data/scm.getFileWithScmInfo.yaml
+++ b/test/data/scm.getFileWithScmInfo.yaml
@@ -1,0 +1,10 @@
+scmUri: github.com:12345678:master
+token: thisisatokenthingy
+path: screwdriver.yaml
+ref: 46f1a0bd5592a2f9244ca321b129902a06b53e03
+scmContext: github:github.com
+scmInfo:
+    branch: master
+    host: github.com
+    owner: testowner
+    repo: testrepo

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -41,6 +41,10 @@ describe('scm test', () => {
             assert.isNull(validate('scm.getFile.yaml', scm.getFile).error);
         });
 
+        it('validates with optional scmInfo', () => {
+            assert.isNull(validate('scm.getFileWithScmInfo.yaml', scm.getFile).error);
+        });
+
         it('fails', () => {
             assert.isNotNull(validate('empty.yaml', scm.getFile).error);
         });
@@ -74,6 +78,10 @@ describe('scm test', () => {
     describe('decorateUrl', () => {
         it('validates', () => {
             assert.isNull(validate('scm.decorateUrl.yaml', scm.decorateUrl).error);
+        });
+
+        it('validates with optional scmInfo', () => {
+            assert.isNull(validate('scm.decorateUrlWithScmInfo.yaml', scm.decorateUrl).error);
         });
 
         it('fails', () => {


### PR DESCRIPTION
# Context
I found that there are 9 or more `lookupScmUri` calls in models during a single PR event even if it is rarely changed by renaming a repository or switching branches. It should be cached in each pipeline instance.

# Objective
I added an optional `scmInfo` schema to `getFile` and `decorateUrl` function to accept cached scmInfo object provided by pipeline model.
It doesn't change current behavior because of optional keys.

# References
screwdriver-cd/screwdriver#1220