### PR TITLE
fix(880): Add sortBy field [1]

### DIFF
--- a/api/pagination.js
+++ b/api/pagination.js
@@ -16,7 +16,11 @@ const MODEL = {
         .string().lowercase()
         .valid(['ascending', 'descending'])
         .default('descending')
-        .description('Sorting option')
+        .description('Sorting option'),
+
+    sortBy: Joi
+        .string().lowercase().max(100)
+        .description('Field to sort by')
 };
 
 /**

--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -24,7 +24,8 @@ const SCHEMA_SCAN = Joi.object().keys({
         count: Joi.number().integer().positive().required(),
         page: Joi.number().integer().positive().required()
     }),
-    sort: Joi.string().lowercase().valid(['ascending', 'descending']).default('descending')
+    sort: Joi.string().lowercase().valid(['ascending', 'descending']).default('descending'),
+    sortBy: Joi.string().lowercase().max(100)
 });
 
 module.exports = {

--- a/test/data/pagination.yaml
+++ b/test/data/pagination.yaml
@@ -1,3 +1,4 @@
 page: 3
 count: 30
 sort: 'ascending'
+sortBy: 'name'


### PR DESCRIPTION
## Context

Users should be able to specify which field they want to sort by when queries are returned from the DB.

## Objective

This PR adds a `sortBy` field to the datastore and pagination schemas. It can be any string, default will be set in the datastore to `id`.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/880