### PR TITLE
fix(880): Allow uppercase in sortBy [1]

### DIFF
--- a/api/pagination.js
+++ b/api/pagination.js
@@ -19,7 +19,7 @@ const MODEL = {
         .description('Sorting option'),
 
     sortBy: Joi
-        .string().lowercase().max(100)
+        .string().max(100)
         .description('Field to sort by')
 };
 

--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -25,7 +25,7 @@ const SCHEMA_SCAN = Joi.object().keys({
         page: Joi.number().integer().positive().required()
     }),
     sort: Joi.string().lowercase().valid(['ascending', 'descending']).default('descending'),
-    sortBy: Joi.string().lowercase().max(100)
+    sortBy: Joi.string().max(100)
 });
 
 module.exports = {

--- a/test/data/pagination.yaml
+++ b/test/data/pagination.yaml
@@ -1,4 +1,4 @@
 page: 3
 count: 30
 sort: 'ascending'
-sortBy: 'name'
+sortBy: 'scmRepo.name'


### PR DESCRIPTION
Should allow upper and lowercase letters for `sortBy` (eg: `scmRepo.name`)

Related to https://github.com/screwdriver-cd/screwdriver/issues/880