### PR TITLE
feat(1220): Allow passing scmRepo to some functions

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -3,6 +3,7 @@
 const core = require('../core');
 const Joi = require('joi');
 const models = require('../models');
+const Scm = require('../core/scm');
 
 const buildStatus = Joi.reach(models.build.base, 'status').required();
 const checkoutUrl = Joi.reach(models.pipeline.create, 'checkoutUrl').required();
@@ -12,12 +13,6 @@ const pipelineId = Joi.reach(models.pipeline.base, 'id').optional();
 const prNum = Joi.reach(core.scm.hook, 'prNum').allow(null).optional();
 const scmContext = Joi.reach(models.pipeline.base, 'scmContext').optional();
 const scmUri = Joi.reach(models.pipeline.base, 'scmUri').required();
-const scmInfo = Joi.object({
-    branch: Joi.string().required(),
-    host: Joi.string().required(),
-    owner: Joi.string().required(),
-    repo: Joi.string().required()
-}).optional();
 const sha = Joi.reach(models.build.base, 'sha').required();
 const token = Joi.reach(models.user.base, 'token').required();
 const type = Joi.reach(core.scm.hook, 'type').required();
@@ -58,14 +53,16 @@ const GET_CHECKOUT_COMMAND = Joi.object().keys({
 const GET_PERMISSIONS = Joi.object().keys({
     scmUri,
     token,
-    scmContext
+    scmContext,
+    scmRepo: Scm.repo.optional()
 }).required();
 
 const GET_COMMIT_SHA = Joi.object().keys({
     scmUri,
     token,
     prNum,
-    scmContext
+    scmContext,
+    scmRepo: Scm.repo.optional()
 }).required();
 
 const UPDATE_COMMIT_STATUS = Joi.object().keys({
@@ -85,7 +82,7 @@ const GET_FILE = Joi.object().keys({
     path: Joi.string().required(),
     ref: Joi.string().optional(),
     scmContext,
-    scmInfo
+    scmRepo: Scm.repo.optional()
 }).required();
 
 const GET_CHANGED_FILES_INPUT = Joi.object().keys({
@@ -109,7 +106,7 @@ const DECORATE_URL = Joi.object().keys({
     scmUri,
     token,
     scmContext,
-    scmInfo
+    scmRepo: Scm.repo.optional()
 }).required();
 
 const DECORATE_COMMIT = Joi.object().keys({

--- a/test/data/scm.decorateUrlWithScmRepo.yaml
+++ b/test/data/scm.decorateUrlWithScmRepo.yaml
@@ -1,0 +1,7 @@
+scmUri: github.com:12345678:master
+token: 'thisisatokenthingy'
+scmContext: github:github.com
+scmRepo:
+    branch: master
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/data/scm.getCommitShaWithScmRepo.yaml
+++ b/test/data/scm.getCommitShaWithScmRepo.yaml
@@ -1,8 +1,8 @@
 scmUri: github.com:12345678:master
 token: 'thisisatokenthingy'
+prNum: null
 scmContext: github:github.com
-scmInfo:
+scmRepo:
     branch: master
-    host: github.com
-    owner: testowner
-    repo: testrepo
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/data/scm.getFileWithScmRepo.yaml
+++ b/test/data/scm.getFileWithScmRepo.yaml
@@ -3,8 +3,7 @@ token: thisisatokenthingy
 path: screwdriver.yaml
 ref: 46f1a0bd5592a2f9244ca321b129902a06b53e03
 scmContext: github:github.com
-scmInfo:
+scmRepo:
     branch: master
-    host: github.com
-    owner: testowner
-    repo: testrepo
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/data/scm.getPermissionsWithScmRepo.yaml
+++ b/test/data/scm.getPermissionsWithScmRepo.yaml
@@ -1,0 +1,7 @@
+scmUri: github.com:12345678:master
+token: 'thisisatokenthingy'
+scmContext: github:github.com
+scmRepo:
+    branch: master
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -11,6 +11,10 @@ describe('scm test', () => {
             assert.isNull(validate('scm.getPermissions.yaml', scm.getPermissions).error);
         });
 
+        it('validates with scmRepo', () => {
+            assert.isNull(validate('scm.getPermissionsWithScmRepo.yaml', scm.getPermissions).error);
+        });
+
         it('fails', () => {
             assert.isNotNull(validate('empty.yaml', scm.getPermissions).error);
         });
@@ -19,6 +23,10 @@ describe('scm test', () => {
     describe('getCommitSha', () => {
         it('validates', () => {
             assert.isNull(validate('scm.getCommitSha.yaml', scm.getCommitSha).error);
+        });
+
+        it('validates with scmRepo', () => {
+            assert.isNull(validate('scm.getCommitShaWithScmRepo.yaml', scm.getCommitSha).error);
         });
 
         it('fails', () => {
@@ -41,8 +49,8 @@ describe('scm test', () => {
             assert.isNull(validate('scm.getFile.yaml', scm.getFile).error);
         });
 
-        it('validates with optional scmInfo', () => {
-            assert.isNull(validate('scm.getFileWithScmInfo.yaml', scm.getFile).error);
+        it('validates with optional scmRepo', () => {
+            assert.isNull(validate('scm.getFileWithScmRepo.yaml', scm.getFile).error);
         });
 
         it('fails', () => {
@@ -80,8 +88,8 @@ describe('scm test', () => {
             assert.isNull(validate('scm.decorateUrl.yaml', scm.decorateUrl).error);
         });
 
-        it('validates with optional scmInfo', () => {
-            assert.isNull(validate('scm.decorateUrlWithScmInfo.yaml', scm.decorateUrl).error);
+        it('validates with optional scmRepo', () => {
+            assert.isNull(validate('scm.decorateUrlWithScmRepo.yaml', scm.decorateUrl).error);
         });
 
         it('fails', () => {


### PR DESCRIPTION
## Context
I would like to pass cached scmInfo data fetched via lookupScmUri but it's a private function. #273

## Objective
Pass scmRepo instead of scmInfo since lookupScmUri is private function. We can get scmRepo from pipeline model (database).

References
screwdriver-cd/screwdriver#1220