### PR TITLE
fix(880): Add search to pagination and datastore scan schemas

### DIFF
--- a/api/pagination.js
+++ b/api/pagination.js
@@ -12,6 +12,10 @@ const MODEL = {
         .max(50)
         .description('Count to paginate'),
 
+    search: Joi
+        .string().max(200)
+        .description('Term to search by'),
+
     sort: Joi
         .string().lowercase()
         .valid(['ascending', 'descending'])

--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -24,6 +24,10 @@ const SCHEMA_SCAN = Joi.object().keys({
         count: Joi.number().integer().positive().required(),
         page: Joi.number().integer().positive().required()
     }),
+    search: Joi.object().keys({
+        field: Joi.string().max(100).required(),
+        term: Joi.string().max(200).required()
+    }),
     sort: Joi.string().lowercase().valid(['ascending', 'descending']).default('descending'),
     sortBy: Joi.string().max(100)
 });

--- a/test/api/pagination.test.js
+++ b/test/api/pagination.test.js
@@ -10,6 +10,10 @@ describe('api pagination', () => {
             assert.isNull(validate('pagination.yaml', api.pagination).error);
         });
 
+        it('all keys', () => {
+            assert.isNull(validate('paginationFull.yaml', api.pagination).error);
+        });
+
         it('defaults', () => {
             const validatedObject = validate('pagination.defaults.yaml', api.pagination);
 

--- a/test/data/datastore.paginateFull.yaml
+++ b/test/data/datastore.paginateFull.yaml
@@ -1,0 +1,9 @@
+table: 'jobs'
+paginate:
+    page: 1
+    count: 2
+search:
+    field: 'scmRepo'
+    term: '%name%screwdriver-cd/screwdriver%'
+sortBy: 'scmRepo'
+sort: ascending

--- a/test/data/pagination.yaml
+++ b/test/data/pagination.yaml
@@ -1,4 +1,3 @@
 page: 3
 count: 30
 sort: 'ascending'
-sortBy: 'scmRepo.name'

--- a/test/data/paginationFull.yaml
+++ b/test/data/paginationFull.yaml
@@ -1,0 +1,5 @@
+page: 3
+count: 30
+sort: 'ascending'
+sortBy: 'scmRepo.name'
+search: 'screwdriver-cd/screwdriver'

--- a/test/plugins/datastore.test.js
+++ b/test/plugins/datastore.test.js
@@ -50,6 +50,10 @@ describe('datastore test', () => {
             assert.isNull(validate('datastore.paginate.yaml', datastore.scan).error);
         });
 
+        it('validates the update with all keys', () => {
+            assert.isNull(validate('datastore.paginateFull.yaml', datastore.scan).error);
+        });
+
         it('fails the update', () => {
             assert.isNotNull(validate('empty.yaml', datastore.scan).error);
         });


### PR DESCRIPTION
## Context
Since we're adding pagination for pipelines, we can no longer have search functionality stored in the UI. We need to move this logic to the datastore.

## Objective
This PR adds search schemas for the datastore and pagination API calls.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/880