### PR TITLE
fix(757): allow only update statusMessage

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -139,10 +139,8 @@ module.exports = {
      * @property update
      * @type {Joi}
      */
-    update: Joi.object(mutate(MODEL, [
-        'status'
-    ], [
-        'meta', 'statusMessage'
+    update: Joi.object(mutate(MODEL, [], [
+        'status', 'meta', 'statusMessage'
     ])).label('Update Build'),
 
     /**

--- a/test/data/build.update.optional.yaml
+++ b/test/data/build.update.optional.yaml
@@ -1,0 +1,2 @@
+# Build Update Example
+statusMessage: 'Build failed to start due to infrastructure error'

--- a/test/models/build.test.js
+++ b/test/models/build.test.js
@@ -30,6 +30,10 @@ describe('model build', () => {
             assert.isNull(validate('build.update.yaml', models.build.update).error);
         });
 
+        it('validates the update with only statusMessage', () => {
+            assert.isNull(validate('build.update.optional.yaml', models.build.update).error);
+        });
+
         it('fails the update', () => {
             assert.isNotNull(validate('empty.yaml', models.build.update).error);
         });


### PR DESCRIPTION
We added a function to update build status message in executors but that is not allowed currently. Make status optional to allow that.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/757