### PR TITLE
fix: remove the default build status value

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -92,8 +92,7 @@ const MODEL = {
             'UNSTABLE'
         ])
         .description('Current status of the build')
-        .example('SUCCESS')
-        .default('QUEUED'),
+        .example('SUCCESS'),
 
     statusMessage: Joi
         .string()


### PR DESCRIPTION
otherwise when we try to update the statusMessage by itself, it will set the status as QUEUED and try to update that too.

When we create the build we have the initial status value already: https://github.com/screwdriver-cd/models/blob/master/lib/buildFactory.js#L193