### PR TITLE
fix(880): Add optional pipeline name

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -27,11 +27,13 @@ const SCHEMA_USER = Joi.object().keys({
         .example('https://avatars.githubusercontent.com/u/622065?v=3')
 }).label('SCM User');
 
+const REPO_NAME = Joi.string()
+    .required()
+    .label('Organization and repository name')
+    .example('screwdriver-cd/screwdriver');
+
 const SCHEMA_REPO = Joi.object().keys({
-    name: Joi.string()
-        .required()
-        .label('Organization and repository name')
-        .example('screwdriver-cd/screwdriver'),
+    name: REPO_NAME,
 
     branch: Joi.string()
         .required()
@@ -155,6 +157,7 @@ module.exports = {
     command: SCHEMA_COMMAND,
     commit: SCHEMA_COMMIT,
     repo: SCHEMA_REPO,
+    repoName: REPO_NAME,
     user: SCHEMA_USER,
     hook: SCHEMA_HOOK,
     pr: SCHEMA_PR

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -23,6 +23,8 @@ const MODEL = {
         .description('Identifier of this pipeline')
         .example(123345),
 
+    name: Scm.repoName.optional(),
+
     scmUri: Joi
         .string().regex(Regex.SCM_URI).max(128)
         .description('Unique identifier for the application')
@@ -82,7 +84,7 @@ module.exports = {
         'id', 'scmUri', 'scmContext', 'createTime', 'admins'
     ], [
         'workflowGraph', 'scmRepo', 'annotations', 'lastEventId',
-        'configPipelineId', 'childPipelines'
+        'configPipelineId', 'childPipelines', 'name'
     ])).label('Get Pipeline'),
 
     /**

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
-    "eslint-config-screwdriver": "^3.0.0",
+    "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^3.0.0",
     "js-yaml": "^3.12.0"
   },

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -1,5 +1,6 @@
 # Pipeline Get Example
 id: 12742
+name: screwdriver-cd/screwdriver
 scmUri: github.com:12345678:master
 scmContext: github:github.com
 createTime: "2017-04-11"


### PR DESCRIPTION
## Context
It's hard to do operations in the UI based on the pipeline name when it is stored in a JSON string in the DB under `scmRepo`.

## Objective
This PR adds a pipeline `name` field at the root level of a pipeline.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/880