### PR TITLE
[DNM] fix(1241): Add branch as optional event field

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -66,7 +66,10 @@ const MODEL = {
             edges: [{ src: '~commit', dest: 'main' }, { src: 'main', dest: 'publish' }]
         }),
     pr: Scm.pr
-        .description('Pull request object that holds information about the pull request')
+        .description('Pull request object that holds information about the pull request'),
+    branch: Joi.string()
+        .label('Branch the commit ran on')
+        .example('master')
 };
 
 const CREATE_MODEL = Object.assign({}, MODEL, {
@@ -101,7 +104,7 @@ module.exports = {
         'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type'
     ], [
         'causeMessage', 'meta', 'parentEventId', 'startFrom', 'workflowGraph', 'pr',
-        'configPipelineSha'
+        'configPipelineSha', 'branch'
     ])).label('Get Event'),
 
     /**
@@ -112,7 +115,7 @@ module.exports = {
      */
     create: Joi.object(mutate(CREATE_MODEL, [], [
         'pipelineId', 'startFrom', 'buildId', 'causeMessage', 'parentBuildId', 'parentEventId',
-        'configPipelineSha', 'meta'
+        'configPipelineSha', 'meta', 'branch'
     ])).label('Create Event'),
 
     /**

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -8,3 +8,4 @@ configPipelineSha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 meta:
   foo: bar
   one: 1
+branch: foo

--- a/test/data/event.get.full.yaml
+++ b/test/data/event.get.full.yaml
@@ -1,5 +1,6 @@
 # Event Get Example
 id: 31751234
+branch: foo
 causeMessage: "arbitrary cause message"
 commit:
     message: Fixing a bug with signing


### PR DESCRIPTION
## Context
Since branch-specific triggers have been added, it would be nice if the UI would also reflect when a trigger was done by a branch-specific trigger. However, the UI doesn't know what branch a job was run on.

## Objective
This PR adds `branch` as an optional field for `events`. This will be needed in the UI.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1241