### PR TITLE
fix(1271): Allow multiple search fields

### DIFF
--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -17,6 +17,7 @@ const SCHEMA_SAVE = Joi.object().keys({
     table,
     params: Joi.object().unknown(true).min(1).required()
 });
+const SCHEMA_SEARCH_FIELD = Joi.string().max(100).required();
 const SCHEMA_SCAN = Joi.object().keys({
     table,
     params: Joi.object(),
@@ -25,7 +26,10 @@ const SCHEMA_SCAN = Joi.object().keys({
         page: Joi.number().integer().positive().required()
     }),
     search: Joi.object().keys({
-        field: Joi.string().max(100).required(),
+        field: Joi.alternatives().try(
+            Joi.array().items(SCHEMA_SEARCH_FIELD),
+            SCHEMA_SEARCH_FIELD
+        ),
         keyword: Joi.string().max(200).required()
     }),
     sort: Joi.string().lowercase().valid(['ascending', 'descending']).default('descending'),

--- a/test/data/datastore.search.multipleFields.yaml
+++ b/test/data/datastore.search.multipleFields.yaml
@@ -1,0 +1,9 @@
+table: 'jobs'
+paginate:
+    page: 1
+    count: 2
+search:
+    field: ['namespace', 'name', 'description']
+    keyword: '%screwdriver%'
+sortBy: 'name'
+sort: ascending

--- a/test/plugins/datastore.test.js
+++ b/test/plugins/datastore.test.js
@@ -50,6 +50,10 @@ describe('datastore test', () => {
             assert.isNull(validate('datastore.paginate.yaml', datastore.scan).error);
         });
 
+        it('validates the update with multiple search fields', () => {
+            assert.isNull(validate('datastore.search.multipleFields.yaml', datastore.scan).error);
+        });
+
         it('validates the update with all keys', () => {
             assert.isNull(validate('datastore.paginateFull.yaml', datastore.scan).error);
         });


### PR DESCRIPTION
## Context
There are many improvements to be made on the templates/commands pages. It would be nice if we had built-in search capabilities. 
The redesign would allow users to search by keyword such as `nodejs` through all template `name`, `namespace`, and `description` fields. This requires datastore support (multiple field search).

## Objective
This PR adds support for multiple field search queries.

Example:
```
{
  search: {
    field: ['namespace', 'name', 'description'],
    keyword: '%nodejs%'
  }
}
```
Returns all results with "nodejs" in the `namespace`, `name`, or `description`.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1271