### PR TITLE
fix(1319): add validation schema for getOrgPermission

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -57,6 +57,13 @@ const GET_PERMISSIONS = Joi.object().keys({
     scmRepo: Scm.repo.optional()
 }).required();
 
+const GET_ORG_PERMISSIONS = Joi.object().keys({
+    token,
+    scmContext,
+    organization: Joi.string().required(),
+    username
+}).required();
+
 const GET_COMMIT_SHA = Joi.object().keys({
     scmUri,
     token,
@@ -150,6 +157,14 @@ module.exports = {
      * @type {Joi}
      */
     getPermissions: GET_PERMISSIONS,
+
+    /**
+     * Properties for Scm Base that will be passed for the getOrgPermissions method
+     *
+     * @property getOrgPermissions
+     * @type {Joi}
+     */
+    getOrgPermissions: GET_ORG_PERMISSIONS,
 
     /**
      * Properties for Scm Base that will be passed for the getCommitSha method

--- a/test/data/scm.getOrgPermissions.yaml
+++ b/test/data/scm.getOrgPermissions.yaml
@@ -1,0 +1,4 @@
+username: foo
+token: 'thisisatokenthingy'
+scmContext: github:github.com
+organization: screwdriver-cd

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -20,6 +20,16 @@ describe('scm test', () => {
         });
     });
 
+    describe('getOrgPermissions', () => {
+        it('validates', () => {
+            assert.isNull(validate('scm.getOrgPermissions.yaml', scm.getOrgPermissions).error);
+        });
+
+        it('fails', () => {
+            assert.isNotNull(validate('empty.yaml', scm.getOrgPermissions).error);
+        });
+    });
+
     describe('getCommitSha', () => {
         it('validates', () => {
             assert.isNull(validate('scm.getCommitSha.yaml', scm.getCommitSha).error);


### PR DESCRIPTION
add validation schema for getOrgPermission

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1319