### PR TITLE
fix(1319): add weightage to buildCluster

### DIFF
--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -42,7 +42,15 @@ const MODEL = {
         .example(true)
         .default(false),
 
-    maintainer: Command.maintainer
+    maintainer: Command.maintainer,
+
+    weightage: Joi
+        .number()
+        .min(1)
+        .max(100)
+        .description('Weight percentage for build cluster')
+        .example(20)
+        .default(100)
 };
 
 module.exports = {
@@ -62,7 +70,7 @@ module.exports = {
      */
     get: Joi.object(mutate(MODEL, [
         'id', 'name', 'scmContext', 'scmOrganizations', 'isActive',
-        'managedByScrewdriver', 'maintainer'
+        'managedByScrewdriver', 'maintainer', 'weightage'
     ], [
         'description'
     ])).label('Get BuildCluster'),
@@ -74,7 +82,8 @@ module.exports = {
      * @type {Joi}
      */
     update: Joi.object(mutate(MODEL, [], [
-        'description', 'isActive', 'scmOrganizations', 'managedByScrewdriver', 'maintainer'
+        'description', 'isActive', 'scmOrganizations', 'managedByScrewdriver',
+        'maintainer', 'weightage'
     ])).label('Update BuildCluster'),
 
     /**
@@ -86,7 +95,7 @@ module.exports = {
     create: Joi.object(mutate(MODEL, [
         'name', 'scmOrganizations', 'managedByScrewdriver', 'maintainer'
     ], [
-        'description', 'isActive'
+        'description', 'isActive', 'weightage'
     ])).label('Create Build'),
 
     /**

--- a/test/data/buildCluster.create.full.yaml
+++ b/test/data/buildCluster.create.full.yaml
@@ -5,3 +5,4 @@ scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false
 maintainer: foo@bar.com
+weightage: 50

--- a/test/data/buildCluster.get.yaml
+++ b/test/data/buildCluster.get.yaml
@@ -7,3 +7,4 @@ scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false
 maintainer: foo@bar.com
+weightage: 50

--- a/test/data/buildCluster.update.yaml
+++ b/test/data/buildCluster.update.yaml
@@ -4,3 +4,4 @@ scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false
 maintainer: foo@bar.com
+weightage: 50

--- a/test/data/buildCluster.yaml
+++ b/test/data/buildCluster.yaml
@@ -6,3 +6,4 @@ scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false
 maintainer: foo@bar.com
+weightage: 50


### PR DESCRIPTION
add weightage to buildCluster based on the new design https://github.com/screwdriver-cd/screwdriver/pull/1357

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1319