### PR TITLE
fix(1319): allow buildClusterName in executor.start

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -10,6 +10,7 @@ const SCHEMA_START = Joi.object().keys({
     annotations: Annotations.annotations,
     blockedBy: Joi.array().items(jobId),
     buildId,
+    buildClusterName: Joi.reach(models.buildCluster.base, 'name'),
     container: Joi.reach(models.build.base, 'container').required(),
     apiUri: Joi.string().uri().required()
         .label('API URI'),
@@ -20,6 +21,7 @@ const SCHEMA_STOP = Joi.object().keys({
     annotations: Annotations.annotations,
     blockedBy: Joi.array().items(jobId),
     buildId,
+    buildClusterName: Joi.reach(models.buildCluster.base, 'name'),
     jobId
 }).required();
 const SCHEMA_STATUS = Joi.object().keys({

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -5,6 +5,7 @@ blockedBy:
     - 1111
     - 2222
 buildId: 8609
+buildClusterName: sd
 container: node:4
 apiUri: http://localhost:8080
 token: eyJhbGciOiJIUziIsInR5cCI6IkpXVCJ9.eyJ1c2Vybam9obmpvaG5zb24iLCJzY29wZSI6WyJ1c2VyIl0sImlhdCI6MTQ3MDI2NjAwMywiZXhwIjoxNDcwMzA5MjAzfQ.CHaHW2-0wALpWaS4UTXQmSAn_ekMBml-ENEnGhw-9SE

--- a/test/data/executor.stop.yaml
+++ b/test/data/executor.stop.yaml
@@ -1,6 +1,7 @@
 annotations:
     beta.screwdriver.cd/executor: k8s
 buildId: 453264
+buildClusterName: sd
 jobId: 1234
 blockedBy:
   - 111


### PR DESCRIPTION
allow optional buildClusterName in executor.start 

https://github.com/screwdriver-cd/screwdriver/issues/1319