### PR TITLE
fix: remove default values from buildcluster and banner

### DIFF
--- a/models/banner.js
+++ b/models/banner.js
@@ -18,8 +18,7 @@ const MODEL = {
     isActive: Joi
         .boolean()
         .description('Flag if the banner is active')
-        .example(true)
-        .default(false),
+        .example(true),
 
     createTime: Joi
         .string()
@@ -42,7 +41,6 @@ const MODEL = {
         .max(32)
         .description('Type/Severity of the banner message')
         .example('info')
-        .default('info')
 };
 
 module.exports = {

--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -33,14 +33,12 @@ const MODEL = {
     isActive: Joi
         .boolean()
         .description('Flag if the the build cluster is active')
-        .example(true)
-        .default(true),
+        .example(true),
 
     managedByScrewdriver: Joi
         .boolean()
         .description('Flag if the cluster is managed by screwdriver team')
-        .example(true)
-        .default(false),
+        .example(true),
 
     maintainer: Command.maintainer,
 
@@ -50,7 +48,6 @@ const MODEL = {
         .max(100)
         .description('Weight percentage for build cluster')
         .example(20)
-        .default(100)
 };
 
 module.exports = {


### PR DESCRIPTION
- these default values will be auto apply even when users try to update other fields.
- and for create, we have logic to set the default in models already:
https://github.com/screwdriver-cd/models/blob/master/lib/bannerFactory.js#L38
https://github.com/screwdriver-cd/models/blob/master/lib/buildClusterFactory.js#L41