### PR TITLE
fix(1317): allow duplicate steps for get templates

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -108,7 +108,8 @@ const SCHEMA_DESCRIPTION = Joi.string().max(100).optional();
 const SCHEMA_IMAGE = Joi.string().regex(Regex.IMAGE_NAME);
 const SCHEMA_SETTINGS = Joi.object().optional();
 const SCHEMA_STEP = Joi.alternatives().try(SCHEMA_STEP_STRING, SCHEMA_STEP_OBJECT);
-const SCHEMA_STEPS = Joi.array().items(SCHEMA_STEP).min(1).unique((a, b) => {
+const SCHEMA_STEPS = Joi.array().items(SCHEMA_STEP).min(1);
+const SCHEMA_STEPS_NO_DUPS = Joi.array().items(SCHEMA_STEP).min(1).unique((a, b) => {
     if (typeof a === 'string' || typeof b === 'string') {
         return false;
     }
@@ -155,6 +156,22 @@ const SCHEMA_JOB = Joi.object()
         template: SCHEMA_TEMPLATE
     })
     .default({});
+const SCHEMA_JOB_NO_DUP_STEPS = Joi.object()
+    .keys({
+        annotations: Annotations.annotations,
+        description: SCHEMA_DESCRIPTION,
+        environment: SCHEMA_ENVIRONMENT,
+        image: SCHEMA_IMAGE,
+        matrix: SCHEMA_MATRIX,
+        requires: SCHEMA_REQUIRES,
+        blockedBy: SCHEMA_BLOCKEDBY,
+        secrets: SCHEMA_SECRETS,
+        settings: SCHEMA_SETTINGS,
+        sourcePaths: SCHEMA_SOURCEPATHS,
+        steps: SCHEMA_STEPS_NO_DUPS,
+        template: SCHEMA_TEMPLATE
+    })
+    .default({});
 
 /**
  * Various components of a Job
@@ -166,6 +183,7 @@ module.exports = {
     environment: SCHEMA_ENVIRONMENT,
     image: SCHEMA_IMAGE,
     job: SCHEMA_JOB,
+    jobNoDupSteps: SCHEMA_JOB_NO_DUP_STEPS,
     matrix: SCHEMA_MATRIX,
     requires: SCHEMA_REQUIRES,
     blockedBy: SCHEMA_BLOCKEDBY,

--- a/config/template.js
+++ b/config/template.js
@@ -92,5 +92,6 @@ module.exports = {
     description: TEMPLATE_DESCRIPTION,
     maintainer: TEMPLATE_MAINTAINER,
     config: Job.job,
+    configNoDupSteps: Job.jobNoDupSteps,
     images: TEMPLATE_IMAGES
 };

--- a/models/template.js
+++ b/models/template.js
@@ -35,6 +35,8 @@ const MODEL = {
         .example('2038-01-19T03:14:08.131Z')
 };
 
+const CREATE_MODEL = Object.assign({}, MODEL, { config: Template.configNoDupSteps });
+
 module.exports = {
     /**
      * All the available properties of Template
@@ -60,7 +62,7 @@ module.exports = {
      * @property create
      * @type {Joi}
      */
-    create: Joi.object(mutate(MODEL, [
+    create: Joi.object(mutate(CREATE_MODEL, [
         'config', 'name', 'version', 'description', 'maintainer'
     ], ['labels', 'namespace', 'images'])).label('Create Template'),
 

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -55,10 +55,6 @@ describe('config job', () => {
         it('validates steps', () => {
             assert.isNull(validate('config.job.steps.yaml', config.job.steps).error);
         });
-
-        it('return error for bad steps', () => {
-            assert.isNotNull(validate('config.job.steps.bad.yaml', config.job.steps).error);
-        });
     });
 
     describe('secrets', () => {

--- a/test/data/config.job.steps.bad.yaml
+++ b/test/data/config.job.steps.bad.yaml
@@ -1,4 +1,0 @@
-- ls
-- pwd
-- init: npm install
-- init: npm test

--- a/test/data/template.createWithDupSteps.yaml
+++ b/test/data/template.createWithDupSteps.yaml
@@ -1,0 +1,19 @@
+# Template CREATE Example
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+labels:
+    - stable
+    - test
+    - beta
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - test: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/data/template.getWithDupSteps.yaml
+++ b/test/data/template.getWithDupSteps.yaml
@@ -1,0 +1,22 @@
+# Template GET Example
+id: 123234135
+createTime: '2017-01-06T01:49:50.384359267Z'
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+pipelineId: 8765
+labels:
+    - stable
+    - test
+    - beta
+config:
+  image: node:6
+  steps:
+    - install: npm install
+    - test: npm test
+    - test: echo $FOO
+  environment:
+    FOO: bar
+  secrets:
+     - NPM_TOKEN

--- a/test/models/template.test.js
+++ b/test/models/template.test.js
@@ -24,11 +24,20 @@ describe('model template', () => {
         it('fails the create', () => {
             assert.isNotNull(validate('empty.yaml', models.template.create).error);
         });
+
+        it('fails the create with duplicate steps', () => {
+            assert.isNotNull(validate('template.createWithDupSteps.yaml',
+                models.template.create).error);
+        });
     });
 
     describe('get', () => {
         it('validates the get', () => {
             assert.isNull(validate('template.get.yaml', models.template.get).error);
+        });
+
+        it('validates the get with duplicate steps', () => {
+            assert.isNull(validate('template.getWithDupSteps.yaml', models.template.get).error);
         });
 
         it('validates the get with namespace', () => {


### PR DESCRIPTION
The previous [PR](https://github.com/screwdriver-cd/data-schema/pull/293) enforce no duplicates steps on all the schema which breaks some current templates with duplicate steps.

This PR will allow duplicate steps for `GET` schema(list also use this), and only enforce it for `CREATE` for backward compatibility. 

References:
https://github.com/screwdriver-cd/screwdriver/issues/1317

