### PR TITLE
[1] feat(1270): add stats to build model

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -110,6 +110,7 @@ const MODEL = {
             hostname: Joi.string()
                 .description('Where this build is run')
         })
+        .unknown(true) // allow other fields
         .description('Stats for this build'),
 
     buildClusterName

--- a/models/build.js
+++ b/models/build.js
@@ -100,6 +100,18 @@ const MODEL = {
         .description('Status message to describe status of the build')
         .example('Build failed due to infrastructure error'),
 
+    stats: Joi
+        .object()
+        .keys({
+            queueTime: Joi.string().isoDate()
+                .description('When this build enters queue'),
+            imagePullTime: Joi.string().isoDate()
+                .description('When this build starts pulling image'),
+            hostname: Joi.string()
+                .description('Where this build is run')
+        })
+        .description('Stats for this build'),
+
     buildClusterName
 };
 
@@ -133,7 +145,7 @@ module.exports = {
     ], [
         'container', 'parentBuildId', 'sha', 'startTime', 'endTime',
         'meta', 'parameters', 'steps', 'commit', 'eventId', 'environment',
-        'statusMessage', 'buildClusterName'
+        'statusMessage', 'stats', 'buildClusterName'
     ])).label('Get Build'),
 
     /**
@@ -143,7 +155,7 @@ module.exports = {
      * @type {Joi}
      */
     update: Joi.object(mutate(MODEL, [], [
-        'status', 'meta', 'statusMessage'
+        'status', 'meta', 'statusMessage', 'stats'
     ])).label('Update Build'),
 
     /**
@@ -155,7 +167,8 @@ module.exports = {
     create: Joi.object(mutate(MODEL, [
         'jobId'
     ], [
-        'meta'
+        'meta',
+        'stats'
     ])).label('Create Build'),
 
     /**

--- a/models/build.js
+++ b/models/build.js
@@ -103,9 +103,9 @@ const MODEL = {
     stats: Joi
         .object()
         .keys({
-            queueTime: Joi.string().isoDate()
+            queueEnterTime: Joi.string().isoDate()
                 .description('When this build enters queue'),
-            imagePullTime: Joi.string().isoDate()
+            imagePullStartTime: Joi.string().isoDate()
                 .description('When this build starts pulling image'),
             hostname: Joi.string()
                 .description('Where this build is run')

--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -6,6 +6,7 @@ const models = require('../models');
 const buildId = Joi.reach(models.build.base, 'id').required();
 const jobId = Joi.reach(models.job.base, 'id');
 const SCHEMA_START = Joi.object().keys({
+    build: Joi.object(),
     jobId,
     annotations: Annotations.annotations,
     blockedBy: Joi.array().items(jobId),

--- a/test/data/build.create.yaml
+++ b/test/data/build.create.yaml
@@ -1,2 +1,3 @@
 # Build Create Example
 jobId: 213452
+stats: {}

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -7,5 +7,5 @@ cause: Commit ccc493 was pushed to master
 status: SUCCESS
 createTime: "2017-04-20"
 stats:
-  queueTime: '2017-01-06T01:49:50.384359267Z'
-  imagePullTime: '2017-01-06T02:49:50.384359267Z'
+  queueEnterTime: '2017-01-06T01:49:50.384359267Z'
+  imagePullStartTime: '2017-01-06T02:49:50.384359267Z'

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -6,3 +6,6 @@ number: 1473900790309
 cause: Commit ccc493 was pushed to master
 status: SUCCESS
 createTime: "2017-04-20"
+stats:
+  queueTime: '2017-01-06T01:49:50.384359267Z'
+  imagePullTime: '2017-01-06T02:49:50.384359267Z'

--- a/test/data/build.update.yaml
+++ b/test/data/build.update.yaml
@@ -3,3 +3,5 @@ status: FAILURE
 statusMessage: 'Build failed to start due to infrastructure error'
 meta:
     yes: no
+stats:
+  queueTime: '2017-01-06T01:49:50.384359267Z'

--- a/test/data/build.update.yaml
+++ b/test/data/build.update.yaml
@@ -4,5 +4,5 @@ statusMessage: 'Build failed to start due to infrastructure error'
 meta:
     yes: no
 stats:
-  queueTime: '2017-01-06T01:49:50.384359267Z'
+  queueEnterTime: '2017-01-06T01:49:50.384359267Z'
   test: true

--- a/test/data/build.update.yaml
+++ b/test/data/build.update.yaml
@@ -5,3 +5,4 @@ meta:
     yes: no
 stats:
   queueTime: '2017-01-06T01:49:50.384359267Z'
+  test: true

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -9,3 +9,4 @@ buildClusterName: sd
 container: node:4
 apiUri: http://localhost:8080
 token: eyJhbGciOiJIUziIsInR5cCI6IkpXVCJ9.eyJ1c2Vybam9obmpvaG5zb24iLCJzY29wZSI6WyJ1c2VyIl0sImlhdCI6MTQ3MDI2NjAwMywiZXhwIjoxNDcwMzA5MjAzfQ.CHaHW2-0wALpWaS4UTXQmSAn_ekMBml-ENEnGhw-9SE
+build: {}


### PR DESCRIPTION
Allow optional build field in executor start and add stats to build model

Related: https://github.com/screwdriver-cd/screwdriver/issues/1270