### PR TITLE
feat(1355): Add PR comment schema [1]

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -72,6 +72,14 @@ const GET_COMMIT_SHA = Joi.object().keys({
     scmRepo: Scm.repo.optional()
 }).required();
 
+const ADD_PR_COMMENT = Joi.object().keys({
+    scmUri,
+    token,
+    prNum,
+    comment: Joi.string().required(),
+    scmContext
+}).required();
+
 const UPDATE_COMMIT_STATUS = Joi.object().keys({
     scmUri,
     token,
@@ -173,6 +181,14 @@ module.exports = {
      * @type {Joi}
      */
     getCommitSha: GET_COMMIT_SHA,
+
+    /**
+     * Properties for Scm Base that will be passed for the addPrComment method
+     *
+     * @property addPrComment
+     * @type {Joi}
+     */
+    addPrComment: ADD_PR_COMMENT,
 
     /**
      * Properties for Scm Base that will be passed for the updateCommitStatus method

--- a/test/data/scm.addPrComment.yaml
+++ b/test/data/scm.addPrComment.yaml
@@ -1,0 +1,5 @@
+scmUri: github.com:12345678:master
+token: 'thisisatokenthingy'
+prNum: null
+scmContext: github:github.com
+comment: 'my, what a fine PR'

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -44,6 +44,16 @@ describe('scm test', () => {
         });
     });
 
+    describe('addPrComment', () => {
+        it('validates', () => {
+            assert.isNull(validate('scm.addPrComment.yaml', scm.addPrComment).error);
+        });
+
+        it('fails', () => {
+            assert.isNotNull(validate('empty.yaml', scm.addPrComment).error);
+        });
+    });
+
     describe('updateCommitStatus', () => {
         it('validates', () => {
             assert.isNull(validate('scm.updateCommitStatus.yaml', scm.updateCommitStatus).error);


### PR DESCRIPTION
## Context
It would be nice for users to be able to comment back on PRs through a build with relevant metadata.

## Objective
This PR adds a schema for adding a PR comment.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1355