### PR TITLE
fix(1432): Add job disable meta fields

### DIFF
--- a/models/job.js
+++ b/models/job.js
@@ -43,6 +43,22 @@ const MODEL = {
         .example('ENABLED')
         .default('ENABLED'),
 
+    stateChanger: Joi
+        .string()
+        .max(128)
+        .description('Username for who changed the state'),
+
+    stateChangeTime: Joi
+        .string()
+        .isoDate()
+        .description('When the state of the job was changed'),
+
+    stateChangeMessage: Joi
+        .string()
+        .max(512)
+        .description('Reason why disabling or enabling job')
+        .example('Testing out new feature change in beta only'),
+
     archived: Joi
         .boolean()
         .description('Flag if the job is archived')
@@ -77,7 +93,8 @@ module.exports = {
     ], [
         'description', 'permutations', 'archived', 'prParentJobId',
         // possible extended fields for pull/merge request info from scm
-        'username', 'title', 'createTime'
+        'username', 'title', 'createTime', 'stateChanger', 'stateChangeTime',
+        'stateChangeMessage'
     ])).label('Get Job'),
 
     /**
@@ -87,7 +104,8 @@ module.exports = {
      * @type {Joi}
      */
     update: Joi.object(mutate(MODEL, [], [
-        'state'
+        'state', 'stateChanger', 'stateChangeTime',
+        'stateChangeMessage'
     ])).label('Update Job'),
 
     /**

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^6.0.0",
-    "js-yaml": "^3.12.0"
+    "js-yaml": "^3.12.1"
   },
   "dependencies": {
-    "joi": "^13.5.2"
+    "joi": "^13.7.0"
   }
 }

--- a/test/data/job.state.get.yaml
+++ b/test/data/job.state.get.yaml
@@ -1,0 +1,14 @@
+# Job Get Example
+id: 675979578
+name: PR-1:main
+description: build and test the code
+pipelineId: 76857568576
+state: DISABLED
+archived: false
+prParentJobId: 9876
+username: whatever
+title: update stuff
+createTime: '2011-01-26T19:01:12Z'
+stateChanger: 'd2lam'
+stateChangeTime: '2011-01-26T19:01:12Z'
+stateChangeMessage: 'Testing out new feature change in beta only'

--- a/test/data/job.state.update.yaml
+++ b/test/data/job.state.update.yaml
@@ -1,0 +1,4 @@
+state: 'ENABLED'
+stateChanger: 'd2lam'
+stateChangeTime: '2011-01-26T19:01:12Z'
+stateChangeMessage: 'Testing out new feature change in beta only'

--- a/test/models/job.test.js
+++ b/test/models/job.test.js
@@ -20,6 +20,10 @@ describe('model job', () => {
             assert.isNull(validate('job.pr.get.yaml', models.job.get).error);
         });
 
+        it('validates the get with job state fields', () => {
+            assert.isNull(validate('job.state.get.yaml', models.job.get).error);
+        });
+
         it('fails the get for empty yaml', () => {
             assert.isNotNull(validate('empty.yaml', models.job.get).error);
         });
@@ -28,6 +32,10 @@ describe('model job', () => {
     describe('update', () => {
         it('validates the update', () => {
             assert.isNull(validate('job.update.yaml', models.job.update).error);
+        });
+
+        it('validates the update with job state fields', () => {
+            assert.isNull(validate('job.state.update.yaml', models.job.update).error);
         });
 
         it('fails the update', () => {


### PR DESCRIPTION
## Context
Users want to know when why and by whom their job was disabled/enabled.

## Objective
This PR adds fields for more information about job state.
_Note: not sure if there are better names for these fields._
`stateChangedBy`?

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1432