### PR TITLE
fix: Increase job name max length, add job name length validation to config parser

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -5,13 +5,12 @@ const Job = require('./job');
 const Joi = require('joi');
 const Regex = require('./regex');
 
-const SCHEMA_JOBNAME = Joi.string().regex(Regex.JOB_NAME);
 const SCHEMA_CACHE_VALUE = Joi.string().uri({
     relativeOnly: true
 });
 const SCHEMA_CACHE_LIST = Joi.array().items(SCHEMA_CACHE_VALUE);
 const SCHEMA_CACHE_JOBS = Joi.object()
-    .pattern(SCHEMA_JOBNAME, SCHEMA_CACHE_LIST)
+    .pattern(Job.jobName, SCHEMA_CACHE_LIST)
     .unknown(false);
 const SCHEMA_CACHE = Joi.object({
     event: SCHEMA_CACHE_LIST,
@@ -27,7 +26,7 @@ const SCHEMA_CACHE_PERMUTATION = Joi.object({
 const SCHEMA_PR_CHAIN = Joi.boolean().default(false);
 const SCHEMA_JOBS = Joi.object()
     // Jobs can only be named with A-Z,a-z,0-9,-,_
-    .pattern(Regex.JOB_NAME, Job.job)
+    .pattern(Job.jobName, Job.job)
     // All others are marked as invalid
     .unknown(false);
 const SCHEMA_SHARED = Job.job;

--- a/config/job.js
+++ b/config/job.js
@@ -85,7 +85,7 @@ const SCHEMA_ENVIRONMENT = Joi.object()
             }
         }
     });
-const SCHEMA_JOBNAME = Joi.string().regex(Regex.JOB_NAME);
+const SCHEMA_JOBNAME = Joi.string().max(100).regex(Regex.JOB_NAME);
 const SCHEMA_STEP_STRING = Joi.string();
 const SCHEMA_STEP_OBJECT = Joi.object()
     // Steps can only be named with A-Z,a-z,0-9,-,_
@@ -196,6 +196,6 @@ module.exports = {
     steps: SCHEMA_STEPS,
     template: SCHEMA_TEMPLATE,
     requiresValue: SCHEMA_REQUIRES_VALUE,
-    jobname: SCHEMA_JOBNAME,
+    jobName: SCHEMA_JOBNAME,
     trigger: SCHEMA_TRIGGER
 };

--- a/config/workflowGraph.js
+++ b/config/workflowGraph.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Joi = require('joi');
-const { jobname, requiresValue } = require('../config/job');
+const { jobName, requiresValue } = require('../config/job');
 
 const SCHEMA_WORKFLOW_GRAPH = Joi.object().keys({
     nodes: Joi.array().items(Joi.object().keys({
@@ -9,7 +9,7 @@ const SCHEMA_WORKFLOW_GRAPH = Joi.object().keys({
     }).unknown()),
     edges: Joi.array().items(Joi.object().keys({
         src: requiresValue,
-        dest: jobname
+        dest: jobName
     }).unknown())
 });
 

--- a/models/job.js
+++ b/models/job.js
@@ -13,7 +13,7 @@ const MODEL = {
 
     name: Joi
         .string().regex(/^(PR-[0-9]+:)?[\w-]+$/)
-        .max(50)
+        .max(110)
         .description('Name of the Job')
         .example('main'),
 

--- a/test/config/base.test.js
+++ b/test/config/base.test.js
@@ -15,6 +15,10 @@ describe('config base', () => {
         it('validates a list of jobs', () => {
             assert.isNull(validate('config.base.jobs.yaml', config.base.jobs).error);
         });
+
+        it('throws error for a job with long job name', () => {
+            assert.isNotNull(validate('config.base.jobs.badJobName.yaml', config.base.jobs).error);
+        });
     });
 
     describe('shared', () => {

--- a/test/data/config.base.jobs.badJobName.yaml
+++ b/test/data/config.base.jobs.badJobName.yaml
@@ -1,0 +1,12 @@
+main:
+    image: node:{{NODE_VERSION}}
+    steps:
+        - init: npm install
+        - test: npm test
+
+this-is-a-job-with-waaaaaaaaaaaaaaaaaaaay-too-many-characters-and-there-is-over-one-hundred-which-means-this-test-should-fail:
+    image: node:4
+    steps:
+        - publish: npm publish
+    secrets:
+        - NPM_TOKEN


### PR DESCRIPTION
Users like to have long job names to make them more descriptive.
This PR increase the job name max length.

_Note: Not sure if this is necessary. The right solution might be to encourage use of job `description` field instead. It already exists, it just is not used or shown in the UI._