### PR TITLE
feat(1440): Add fields for custom Git status [1]

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -88,7 +88,9 @@ const UPDATE_COMMIT_STATUS = Joi.object().keys({
     jobName,
     url: Joi.string().uri().required(),
     pipelineId,
-    scmContext
+    scmContext,
+    context: Joi.string().max(100).optional(),
+    description: Joi.string().max(200).optional()
 }).required();
 
 const GET_FILE = Joi.object().keys({

--- a/test/data/scm.updateCommitStatusFull.yaml
+++ b/test/data/scm.updateCommitStatusFull.yaml
@@ -1,0 +1,10 @@
+scmUri: github.com:12345678:master
+token: thisisatokenthingy
+sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
+buildStatus: SUCCESS
+jobName: main
+url: https://foo.bar
+pipelineId: 123
+scmContext: github:github.com
+context: findbugs
+description: '923 issues found. Previous count: 914 issues.'

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -59,6 +59,11 @@ describe('scm test', () => {
             assert.isNull(validate('scm.updateCommitStatus.yaml', scm.updateCommitStatus).error);
         });
 
+        it('validates with extra optional params (context and description)', () => {
+            assert.isNull(validate('scm.updateCommitStatusFull.yaml',
+                scm.updateCommitStatus).error);
+        });
+
         it('fails', () => {
             assert.isNotNull(validate('empty.yaml', scm.updateCommitStatus).error);
         });


### PR DESCRIPTION
## Context
Users would like to add custom Git statuses for commits.

## Objective
This PR adds `context` and `description` fields to be passed into the `scm.updateCommitStatus` method. The `context` will be the key provided by the user. `description` will be the message they want to show.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1440