### PR TITLE
[1] feat: Add pr title to the event

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -144,6 +144,11 @@ const SCHEMA_HOOK = Joi.object().keys({
         .optional()
         .label('PR original source'),
 
+    prTitle: Joi.string()
+        .allow('')
+        .optional()
+        .label('PR title'),
+
     scmContext: Joi
         .string().max(128)
         .required()

--- a/test/data/scm.hook.pr.yaml
+++ b/test/data/scm.hook.pr.yaml
@@ -6,6 +6,7 @@ hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 lastCommitMessage: meow
 prNum: 123
 prRef: reference
+prTitle: 'Update the README with new information'
 prSource: fork
 scmContext: github:github.com
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f


### PR DESCRIPTION
## Context
We want to add pr title to the event for using it in notification.

## Objective
Add prTitle to `SCHEMA_HOOK`.

## References
Related PRs:
models https://github.com/screwdriver-cd/models/pull/321
scm-github https://github.com/screwdriver-cd/scm-github/pull/120
screwdriver https://github.com/screwdriver-cd/screwdriver/pull/1456