### PR TITLE
feat(675): Implement schema for freezeWindows

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -32,7 +32,8 @@ const SCHEMA_JOB_PERMUTATION = Joi.object()
         blockedBy: Job.blockedBy,
         secrets: Job.secrets,
         settings: Job.settings,
-        sourcePaths: Job.sourcePaths
+        sourcePaths: Job.sourcePaths,
+        freezeWindows: Job.freezeWindows
     }).label('Job permutation');
 
 const SCHEMA_JOB_PERMUTATIONS = Joi.array().items(SCHEMA_JOB_PERMUTATION)

--- a/config/cronExpression.js
+++ b/config/cronExpression.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const cronParser = require('cron-parser');
+const Joi = require('joi');
+
+const sdCron = Joi.extend(joi => ({
+    base: joi.string(),
+    name: 'string',
+    language: {
+        cron: 'Cron expression for freeze windows'
+    },
+    rules: [
+        {
+            name: 'cron',
+            validate(params, value, state, options) {
+                try {
+                    const fields = value.trim().split(/\s+/);
+
+                    if (fields.length !== 5) {
+                        throw new Error(`${value} does not have exactly 5 fields`);
+                    }
+
+                    if (fields[2] !== '?' && fields[4] !== '?') {
+                        throw new Error(`${value} cannot contain both days of month and week`);
+                    }
+
+                    const newCronExp = `${fields[0]} ${fields[1]} ` +
+                        `${fields[2] === '?' ? '*' : fields[2]} ` +
+                        `${fields[3]} ${fields[4] === '?' ? '*' : fields[4]}`;
+
+                    cronParser.parseExpression(newCronExp);
+                } catch (err) {
+                    return this.createError(
+                        'string.cron', { v: value, err: err.message }, state, options);
+                }
+
+                return value;
+            }
+        }
+    ]
+}));
+
+module.exports = sdCron;

--- a/config/job.js
+++ b/config/job.js
@@ -3,6 +3,7 @@
 const Annotations = require('./annotations');
 const Joi = require('joi');
 const Regex = require('./regex');
+const Cron = require('./cronExpression');
 
 const SPECIFIC_BRANCH_POS = 4;
 
@@ -121,6 +122,7 @@ const SCHEMA_TEMPLATE = Joi.string().regex(Regex.FULL_TEMPLATE_NAME);
 const SCHEMA_TRIGGER = sdJoi.string().regex(Regex.TRIGGER).branchFilter();
 const SCHEMA_INTERNAL_TRIGGER = Joi.string().regex(Regex.INTERNAL_TRIGGER); // ~main, ~jobOne
 const SCHEMA_EXTERNAL_TRIGGER = Joi.string().regex(Regex.EXTERNAL_TRIGGER); // ~sd@123:main
+const SCHEMA_CRON_EXPRESSION = Cron.string().cron();
 const SCHEMA_REQUIRES_VALUE = Joi.alternatives().try(
     SCHEMA_INTERNAL_TRIGGER, SCHEMA_JOBNAME, SCHEMA_TRIGGER);
 const SCHEMA_REQUIRES = Joi.alternatives().try(
@@ -134,6 +136,10 @@ const SCHEMA_BLOCKEDBY_VALUE = Joi.alternatives().try(
 const SCHEMA_BLOCKEDBY = Joi.alternatives().try(
     Joi.array().items(SCHEMA_BLOCKEDBY_VALUE),
     SCHEMA_BLOCKEDBY_VALUE
+);
+const SCHEMA_FREEZEWINDOWS = Joi.alternatives().try(
+    Joi.array().items(SCHEMA_CRON_EXPRESSION),
+    SCHEMA_CRON_EXPRESSION
 );
 const SCHEMA_SOURCEPATH = Joi.string().max(100).optional();
 const SCHEMA_SOURCEPATHS = Joi.alternatives().try(
@@ -149,6 +155,7 @@ const SCHEMA_JOB = Joi.object()
         matrix: SCHEMA_MATRIX,
         requires: SCHEMA_REQUIRES,
         blockedBy: SCHEMA_BLOCKEDBY,
+        freezeWindows: SCHEMA_FREEZEWINDOWS,
         secrets: SCHEMA_SECRETS,
         settings: SCHEMA_SETTINGS,
         sourcePaths: SCHEMA_SOURCEPATHS,
@@ -165,6 +172,7 @@ const SCHEMA_JOB_NO_DUP_STEPS = Joi.object()
         matrix: SCHEMA_MATRIX,
         requires: SCHEMA_REQUIRES,
         blockedBy: SCHEMA_BLOCKEDBY,
+        freezeWindows: SCHEMA_FREEZEWINDOWS,
         secrets: SCHEMA_SECRETS,
         settings: SCHEMA_SETTINGS,
         sourcePaths: SCHEMA_SOURCEPATHS,
@@ -187,6 +195,7 @@ module.exports = {
     matrix: SCHEMA_MATRIX,
     requires: SCHEMA_REQUIRES,
     blockedBy: SCHEMA_BLOCKEDBY,
+    freezeWindows: SCHEMA_FREEZEWINDOWS,
     secret: SCHEMA_SECRET,
     secrets: SCHEMA_SECRETS,
     settings: SCHEMA_SETTINGS,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "js-yaml": "^3.12.1"
   },
   "dependencies": {
-    "joi": "^13.7.0"
+    "joi": "^13.7.0",
+    "cron-parser": "^2.7.3"
   }
 }

--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Annotations = require('../config/annotations');
+const Job = require('../config/job');
 const Joi = require('joi');
 const models = require('../models');
 const buildId = Joi.reach(models.build.base, 'id').required();
@@ -10,6 +11,7 @@ const SCHEMA_START = Joi.object().keys({
     jobId,
     annotations: Annotations.annotations,
     blockedBy: Joi.array().items(jobId),
+    freezeWindows: Job.freezeWindows,
     buildId,
     buildClusterName: Joi.reach(models.buildCluster.base, 'name'),
     container: Joi.reach(models.build.base, 'container').required(),
@@ -21,6 +23,7 @@ const SCHEMA_START = Joi.object().keys({
 const SCHEMA_STOP = Joi.object().keys({
     annotations: Annotations.annotations,
     blockedBy: Joi.array().items(jobId),
+    freezeWindows: Job.freezeWindows,
     buildId,
     buildClusterName: Joi.reach(models.buildCluster.base, 'name'),
     jobId

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -40,6 +40,14 @@ describe('config job', () => {
             assert.isNotNull(validate('config.job.blockedBy.bad.yaml', config.job.job).error);
         });
 
+        it('validates a job with freezeWindows', () => {
+            assert.isNull(validate('config.job.freezeWindows.yaml', config.job.job).error);
+        });
+
+        it('returns error for bad freezeWindows format', () => {
+            assert.isNotNull(validate('config.job.freezeWindows.bad.yaml', config.job.job).error);
+        });
+
         it('validates a description', () => {
             assert.isNull(validate('config.job.description.yaml', config.job.job).error);
         });

--- a/test/data/config.job.freezeWindows.bad.yaml
+++ b/test/data/config.job.freezeWindows.bad.yaml
@@ -1,0 +1,5 @@
+image: node:6
+steps:
+    - publish: npm publish
+requires: ~commit
+freezeWindows: "* * 1 * 1"

--- a/test/data/config.job.freezeWindows.yaml
+++ b/test/data/config.job.freezeWindows.yaml
@@ -1,0 +1,7 @@
+image: node:6
+steps:
+    - publish: npm publish
+requires: ~commit
+freezeWindows:
+    - "* * ? * 1"
+    - "0-59 0-23 * 1 ?"

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -4,6 +4,9 @@ annotations:
 blockedBy:
     - 1111
     - 2222
+freezeWindows:
+    - "* * ? * 1"
+    - "0-59 0-23 * 1 ?"
 buildId: 8609
 buildClusterName: sd
 container: node:4

--- a/test/data/executor.stop.yaml
+++ b/test/data/executor.stop.yaml
@@ -6,3 +6,6 @@ jobId: 1234
 blockedBy:
   - 111
   - 222
+freezeWindows:
+  - "* * ? * 1"
+  - "0-59 0-23 * 1 ?"


### PR DESCRIPTION
Allow `freezeWindows` to job config. It's an array of job names, similar to requires
Also add blockedBy to executor start. This will be an array of job Ids.

The PR adds support for `freezeWindows` in the job config and executor plugin.

For example:

```
 image: node:6                                                                                                                 
 steps:
     - publish: npm publish
 requires: ~commit
 freezeWindows:
     - "* * ? * 1"
     - "0-59 0-23 * 1 ?"
```

Related issue: https://github.com/screwdriver-cd/screwdriver/issues/675