### PR TITLE
fix(1460): Add build blocked start time [1]

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -106,6 +106,8 @@ const MODEL = {
         .keys({
             queueEnterTime: Joi.string().isoDate()
                 .description('When this build enters queue'),
+            blockedStartTime: Joi.string().isoDate()
+                .description('When this build is blocked'),
             imagePullStartTime: Joi.string().isoDate()
                 .description('When this build starts pulling image'),
             hostname: Joi.string()

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -7,5 +7,6 @@ cause: Commit ccc493 was pushed to master
 status: SUCCESS
 createTime: "2017-04-20"
 stats:
+  blockedStartTime: '2017-01-06T01:49:50.384359267Z'
   queueEnterTime: '2017-01-06T01:49:50.384359267Z'
   imagePullStartTime: '2017-01-06T02:49:50.384359267Z'


### PR DESCRIPTION
Adding `blockedStartTime` to build stats to track gap of time between time when build is enqueued and when it starts running.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1460