### PR TITLE
fix(1412): allow startTime endTime in scan

### DIFF
--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -35,7 +35,9 @@ const SCHEMA_SCAN = Joi.object().keys({
     sort: Joi.string().lowercase().valid(['ascending', 'descending']).default('descending'),
     sortBy: Joi.string().max(100),
     exclude: Joi.array().items(Joi.string().max(100)).max(100),
-    groupBy: Joi.array().items(Joi.string().max(100)).max(100)
+    groupBy: Joi.array().items(Joi.string().max(100)).max(100),
+    startTime: Joi.string().isoDate(),
+    endTime: Joi.string().isoDate()
 });
 
 module.exports = {

--- a/test/data/datastore.startTime.yaml
+++ b/test/data/datastore.startTime.yaml
@@ -1,0 +1,3 @@
+table: templates
+startTime: '2019-01-20T22:28:35.039Z'
+endTime: '2019-01-24T22:28:35.039Z'

--- a/test/plugins/datastore.test.js
+++ b/test/plugins/datastore.test.js
@@ -62,6 +62,10 @@ describe('datastore test', () => {
             assert.isNull(validate('datastore.groupBy.yaml', datastore.scan).error);
         });
 
+        it('validates the startTime and endTime options', () => {
+            assert.isNull(validate('datastore.startTime.yaml', datastore.scan).error);
+        });
+
         it('fails the update', () => {
             assert.isNotNull(validate('empty.yaml', datastore.scan).error);
         });


### PR DESCRIPTION
Need to allow startTime and endTime in scan schema

Related: https://github.com/screwdriver-cd/screwdriver/issues/1412