### PR TITLE
fix: Update executor.start schema

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -5,7 +5,14 @@ const Job = require('../config/job');
 const Joi = require('joi');
 const models = require('../models');
 const buildId = Joi.reach(models.build.base, 'id').required();
+const eventId = Joi.reach(models.event.base, 'id');
 const jobId = Joi.reach(models.job.base, 'id');
+
+const SCHEMA_PIPELINE = Joi.object().keys({
+    id: Joi.reach(models.pipeline.base, 'id').required(),
+    scmContext: Joi.reach(models.pipeline.base, 'scmContext').required()
+}).unknown();
+
 const SCHEMA_START = Joi.object().keys({
     build: Joi.object(),
     jobId,
@@ -13,6 +20,9 @@ const SCHEMA_START = Joi.object().keys({
     blockedBy: Joi.array().items(jobId),
     freezeWindows: Job.freezeWindows,
     buildId,
+    eventId,
+    tokenGen: Joi.func(),
+    pipeline: SCHEMA_PIPELINE,
     buildClusterName: Joi.reach(models.buildCluster.base, 'name'),
     container: Joi.reach(models.build.base, 'container').required(),
     apiUri: Joi.string().uri().required()

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -8,8 +8,16 @@ freezeWindows:
     - "* * ? * 1"
     - "0-59 0-23 * 1 ?"
 buildId: 8609
+eventId: 5
 buildClusterName: sd
 container: node:4
 apiUri: http://localhost:8080
 token: eyJhbGciOiJIUziIsInR5cCI6IkpXVCJ9.eyJ1c2Vybam9obmpvaG5zb24iLCJzY29wZSI6WyJ1c2VyIl0sImlhdCI6MTQ3MDI2NjAwMywiZXhwIjoxNDcwMzA5MjAzfQ.CHaHW2-0wALpWaS4UTXQmSAn_ekMBml-ENEnGhw-9SE
 build: {}
+pipeline:
+    id: 1
+    configPipelineId: 2
+    scmUri: github:1234:master
+    scmContext: http://mock
+    admin: admin
+    token: asdf

--- a/test/helper.js
+++ b/test/helper.js
@@ -13,11 +13,16 @@ module.exports = {
      * @method validate
      * @param  {String} filename Filename located in test/data
      * @param  {Joi}    schema   Join schema to validate against
+     * @param  {Object} extend   Object to extend the parsed object with
      * @return {JoiResult}       Result from Joi.Validate
      */
-    validate: (filename, schema) => {
+    validate: (filename, schema, extend) => {
         const exampleFile = path.join(DATA_DIR, filename);
         const example = yaml.safeLoad(fs.readFileSync(exampleFile).toString());
+
+        if (extend !== undefined) {
+            Object.assign(example, extend);
+        }
 
         return joi.validate(example, schema);
     }

--- a/test/plugins/executor.test.js
+++ b/test/plugins/executor.test.js
@@ -7,7 +7,9 @@ const validate = require('../helper').validate;
 describe('executor test', () => {
     describe('start', () => {
         it('validates the start', () => {
-            assert.isNull(validate('executor.start.yaml', executor.start).error);
+            assert.isNull(validate('executor.start.yaml', executor.start, {
+                tokenGen: () => {}
+            }).error);
         });
 
         it('validates the start with no annotations', () => {


### PR DESCRIPTION
https://github.com/screwdriver-cd/executor-queue/pull/40 pulls in changes to executor-queue and the new start() function has additional parameters for freeze windows.

This PR updates the schema to accommodate for changes to executor.start() parameters.