### PR TITLE
fix(1412): allow timeKey in scan

### DIFF
--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -37,7 +37,8 @@ const SCHEMA_SCAN = Joi.object().keys({
     exclude: Joi.array().items(Joi.string().max(100)).max(100),
     groupBy: Joi.array().items(Joi.string().max(100)).max(100),
     startTime: Joi.string().isoDate(),
-    endTime: Joi.string().isoDate()
+    endTime: Joi.string().isoDate(),
+    timeKey: Joi.string()
 });
 
 module.exports = {

--- a/test/data/datastore.groupBy.yaml
+++ b/test/data/datastore.groupBy.yaml
@@ -1,3 +1,4 @@
 table: templates
 exclude: [config]
 groupBy: [namespace, name]
+timeKey: 'startTime'


### PR DESCRIPTION
Need to allow this for step metrics: https://github.com/screwdriver-cd/models/blob/master/lib/build.js#L302
Related: https://github.com/screwdriver-cd/screwdriver/issues/1412