### PR TITLE
fix: Pass job to executor.start instead of jobId

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -8,6 +8,11 @@ const buildId = Joi.reach(models.build.base, 'id').required();
 const eventId = Joi.reach(models.event.base, 'id');
 const jobId = Joi.reach(models.job.base, 'id');
 
+const SCHEMA_JOB = Joi.object().keys({
+    id: jobId.required(),
+    name: Joi.reach(models.job.base, 'name').required()
+}).unknown();
+
 const SCHEMA_PIPELINE = Joi.object().keys({
     id: Joi.reach(models.pipeline.base, 'id').required(),
     scmContext: Joi.reach(models.pipeline.base, 'scmContext').required()
@@ -15,7 +20,7 @@ const SCHEMA_PIPELINE = Joi.object().keys({
 
 const SCHEMA_START = Joi.object().keys({
     build: Joi.object(),
-    jobId,
+    job: SCHEMA_JOB,
     annotations: Annotations.annotations,
     blockedBy: Joi.array().items(jobId),
     freezeWindows: Job.freezeWindows,

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -1,4 +1,6 @@
-jobId: 1234
+job:
+    id: 1234
+    name: component
 annotations:
     beta.screwdriver.cd/executor: k8s
 blockedBy:


### PR DESCRIPTION
Related PRs:
https://github.com/screwdriver-cd/executor-queue/pull/41
https://github.com/screwdriver-cd/models/pull/328