### PR TITLE
feat(823): [1] add ~release and ~tag trigger

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -48,13 +48,17 @@ module.exports = {
     INTERNAL_TRIGGER: /^~([\w-]+)$/,
     // External trigger like ~sd@123:component
     EXTERNAL_TRIGGER: /^~sd@(\d+):([\w-]+)$/,
-    // Can be ~pr, ~commit, or ~commit:branchName, or ~sd@123:component
+    // Can be ~pr, ~commit, ~release, ~tag or ~commit:branchName, or ~sd@123:component
     // Note: if you modify this regex, you must modify `sdJoi` definition in the `config/job.js`
-    TRIGGER: /^~(sd@\d+:[\w-]+|(pr|commit)(:(.+))?)$/,
+    TRIGGER: /^~(sd@\d+:[\w-]+|(pr|commit|release|tag)(:(.+))?)$/,
     // Can be ~pr or ~pr:branchName
     PR_TRIGGER: /^~pr(:.+)?$/,
     // Can be ~commit or ~commit:branchName
     COMMIT_TRIGGER: /^~commit(:.+)?$/,
+    // Can be ~release or ~release:branchName
+    RELEASE_TRIGGER: /^~release(:.+)?$/,
+    // Can be ~tag or ~tag:branchName
+    TAG_TRIGGER: /^~tag(:.+)?$/,
     // IEEE Std 1003.1-2001
     // Environment names contain uppercase letters, digits, and underscore
     // They cannot start with digits

--- a/core/scm.js
+++ b/core/scm.js
@@ -99,7 +99,7 @@ const SCHEMA_HOOK = Joi.object().keys({
     action: Joi.string()
         .when('type', { is: 'pr',
             then: Joi.valid(['opened', 'reopened', 'closed', 'synchronized']) })
-        .when('type', { is: 'repo', then: Joi.valid('push') })
+        .when('type', { is: 'repo', then: Joi.valid(['push', 'release', 'create']) })
         .when('type', { is: 'ping', then: Joi.allow('').optional(), otherwise: Joi.required() })
         .label('Action of the event'),
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^6.0.0",
+    "jenkins-mocha": "^7.0.0",
     "js-yaml": "^3.12.1"
   },
   "dependencies": {

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -62,6 +62,34 @@ describe('config regex', () => {
         });
     });
 
+    describe('release trigger', () => {
+        it('checks good trigger', () => {
+            assert.isTrue(config.regex.TRIGGER.test('~release'));
+            assert.isTrue(config.regex.TRIGGER.test('~release:master'));
+            assert.isTrue(config.regex.RELEASE_TRIGGER.test('~release'));
+            assert.isTrue(config.regex.RELEASE_TRIGGER.test('~release:master'));
+        });
+
+        it('fails on bad trigger', () => {
+            assert.isFalse(config.regex.TRIGGER.test('~release:'));
+            assert.isFalse(config.regex.COMMIT_TRIGGER.test('~release:'));
+        });
+    });
+
+    describe('tag trigger', () => {
+        it('checks good trigger', () => {
+            assert.isTrue(config.regex.TRIGGER.test('~tag'));
+            assert.isTrue(config.regex.TRIGGER.test('~tag:master'));
+            assert.isTrue(config.regex.TAG_TRIGGER.test('~tag'));
+            assert.isTrue(config.regex.TAG_TRIGGER.test('~tag:master'));
+        });
+
+        it('fails on bad trigger', () => {
+            assert.isFalse(config.regex.TRIGGER.test('~tag:'));
+            assert.isFalse(config.regex.TAG_TRIGGER.test('~tag:'));
+        });
+    });
+
     describe('commands', () => {
         it('checks good command namespaces', () => {
             assert.isTrue(config.regex.COMMAND_NAMESPACE.test('chefdk'));

--- a/test/core/scm.test.js
+++ b/test/core/scm.test.js
@@ -58,6 +58,14 @@ describe('scm core', () => {
             assert.isNull(validate('scm.hook.ping.yaml', core.scm.hook).error);
         });
 
+        it('validates the release hook', () => {
+            assert.isNull(validate('scm.hook.release.yaml', core.scm.hook).error);
+        });
+
+        it('validates the tag hook', () => {
+            assert.isNull(validate('scm.hook.tag.yaml', core.scm.hook).error);
+        });
+
         it('fails the commit', () => {
             assert.isNotNull(validate('empty.yaml', core.scm.hook).error);
         });

--- a/test/data/scm.hook.release.yaml
+++ b/test/data/scm.hook.release.yaml
@@ -1,0 +1,9 @@
+# SCM release hook example
+action: release
+branch: master
+checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
+hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
+scmContext: github:github.com
+sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
+type: repo
+username: stjohnjohnson

--- a/test/data/scm.hook.tag.yaml
+++ b/test/data/scm.hook.tag.yaml
@@ -1,0 +1,9 @@
+# SCM tag Hook example
+action: create
+branch: master
+checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
+hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
+scmContext: github:github.com
+sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
+type: repo
+username: stjohnjohnson


### PR DESCRIPTION
This PR allows to use `~release` and `~tag` as a trigger.

- `release` event name is `release`
    - https://developer.github.com/v3/activity/events/types/#releaseevent
- `tag` event name is `create`
    - https://developer.github.com/v3/activity/events/types/#createevent
    - A creating branch event is also `create` so we need filtering in the parse phase

Related: https://github.com/screwdriver-cd/screwdriver/issues/823