### PR TITLE
fix(823): [1] fix release trigger related schemas

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -99,7 +99,7 @@ const SCHEMA_HOOK = Joi.object().keys({
     action: Joi.string()
         .when('type', { is: 'pr',
             then: Joi.valid(['opened', 'reopened', 'closed', 'synchronized']) })
-        .when('type', { is: 'repo', then: Joi.valid(['push', 'release', 'create']) })
+        .when('type', { is: 'repo', then: Joi.valid(['push', 'release', 'tag']) })
         .when('type', { is: 'ping', then: Joi.allow('').optional(), otherwise: Joi.required() })
         .label('Action of the event'),
 
@@ -156,6 +156,7 @@ const SCHEMA_HOOK = Joi.object().keys({
         .example('github:github.com'),
 
     sha: Joi.string().hex()
+        .when('action', { is: ['release', 'tag'], then: Joi.allow('').optional() })
         .when('type', { is: 'ping', then: Joi.allow('').optional(), otherwise: Joi.required() })
         .label('Commit SHA')
         .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'),

--- a/core/scm.js
+++ b/core/scm.js
@@ -135,6 +135,11 @@ const SCHEMA_HOOK = Joi.object().keys({
         .optional()
         .label('PR reference of the repository'),
 
+    ref: Joi.string()
+        .allow('')
+        .optional()
+        .label('reference of the repository'),
+
     prSource: Joi.string()
         .allow('')
         .when('type', {

--- a/core/scm.js
+++ b/core/scm.js
@@ -136,8 +136,8 @@ const SCHEMA_HOOK = Joi.object().keys({
         .label('PR reference of the repository'),
 
     ref: Joi.string()
-        .allow('')
-        .optional()
+        .when('action',
+            { is: ['release', 'tag'], then: Joi.required(), otherwise: Joi.allow('').optional() })
         .label('reference of the repository'),
 
     prSource: Joi.string()

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -76,7 +76,8 @@ const GET_COMMIT_REF_SHA = Joi.object().keys({
     token,
     owner: Joi.string().required(),
     repo: Joi.string().required(),
-    ref: Joi.string().required()
+    ref: Joi.string().required(),
+    scmContext
 }).required();
 
 const ADD_PR_COMMENT = Joi.object().keys({

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -72,6 +72,13 @@ const GET_COMMIT_SHA = Joi.object().keys({
     scmRepo: Scm.repo.optional()
 }).required();
 
+const GET_COMMIT_REF_SHA = Joi.object().keys({
+    token,
+    owner: Joi.string().required(),
+    repo: Joi.string().required(),
+    ref: Joi.string().required()
+}).required();
+
 const ADD_PR_COMMENT = Joi.object().keys({
     scmUri,
     token,
@@ -183,6 +190,14 @@ module.exports = {
      * @type {Joi}
      */
     getCommitSha: GET_COMMIT_SHA,
+
+    /**
+     * Properties for Scm Base that will be passed for the getCommitSRefha method
+     *
+     * @property getCommitRefSha
+     * @type {Joi}
+     */
+    getCommitRefSha: GET_COMMIT_REF_SHA,
 
     /**
      * Properties for Scm Base that will be passed for the addPrComment method

--- a/test/data/scm.getCommitRefSha.yaml
+++ b/test/data/scm.getCommitRefSha.yaml
@@ -1,0 +1,4 @@
+token: 'thisisatokenthingy'
+owner: 'owner'
+repo: 'repo'
+ref: '0.0.1'

--- a/test/data/scm.getCommitRefSha.yaml
+++ b/test/data/scm.getCommitRefSha.yaml
@@ -2,3 +2,4 @@ token: 'thisisatokenthingy'
 owner: 'owner'
 repo: 'repo'
 ref: '0.0.1'
+scmContext: github:github.com

--- a/test/data/scm.hook.pr.yaml
+++ b/test/data/scm.hook.pr.yaml
@@ -6,6 +6,7 @@ hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 lastCommitMessage: meow
 prNum: 123
 prRef: reference
+ref: reference
 prTitle: 'Update the README with new information'
 prSource: fork
 scmContext: github:github.com

--- a/test/data/scm.hook.push.yaml
+++ b/test/data/scm.hook.push.yaml
@@ -7,3 +7,4 @@ scmContext: github:github.com
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 type: repo
 username: stjohnjohnson
+ref: reference

--- a/test/data/scm.hook.release.yaml
+++ b/test/data/scm.hook.release.yaml
@@ -6,3 +6,4 @@ hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 scmContext: github:github.com
 type: repo
 username: stjohnjohnson
+ref: super-tag

--- a/test/data/scm.hook.release.yaml
+++ b/test/data/scm.hook.release.yaml
@@ -4,6 +4,5 @@ branch: master
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
 hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 scmContext: github:github.com
-sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 type: repo
 username: stjohnjohnson

--- a/test/data/scm.hook.tag.yaml
+++ b/test/data/scm.hook.tag.yaml
@@ -6,3 +6,4 @@ hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 scmContext: github:github.com
 type: repo
 username: stjohnjohnson
+ref: 0.0.1

--- a/test/data/scm.hook.tag.yaml
+++ b/test/data/scm.hook.tag.yaml
@@ -1,9 +1,8 @@
 # SCM tag Hook example
-action: create
+action: tag
 branch: master
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
 hookId: 81e6bd80-9a2c-11e6-939d-beaa5d9adaf3
 scmContext: github:github.com
-sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 type: repo
 username: stjohnjohnson

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -44,6 +44,16 @@ describe('scm test', () => {
         });
     });
 
+    describe('getCommitRefSha', () => {
+        it('validates', () => {
+            assert.isNull(validate('scm.getCommitRefSha.yaml', scm.getCommitRefSha).error);
+        });
+
+        it('fails', () => {
+            assert.isNotNull(validate('empty.yaml', scm.getCommitRefSha).error);
+        });
+    });
+
     describe('addPrComment', () => {
         it('validates', () => {
             assert.isNull(validate('scm.addPrComment.yaml', scm.addPrComment).error);


### PR DESCRIPTION
This PR fixes these:
- https://github.com/screwdriver-cd/data-schema/commit/1c801112fe395aba2829dcbd9c31f37831d8f2b0 , https://github.com/screwdriver-cd/data-schema/pull/322/commits/a8932bc08d68f50f8083f94b00cb996a2d6d65af : `action` allows to use `tag` instead of `create`
   - Webhooks which are posted by release or tag do not include `sha` information.
   - And we cannot have any token in `parseHooks()` phase so we cannot obtain sha information via SCM API.
   - This PR allows that `sha` is empty when a release or a tag event is posted.
- https://github.com/screwdriver-cd/data-schema/commit/37ebfb66a90ca29d8bb1461dde06be0945850f35 : add ref to SCHEMA_HOOK
    - `ref` will be used after `parseHook()` to get `sha` information in `getCommitRefSha()`
- https://github.com/screwdriver-cd/data-schema/commit/914ba42f0aa422c8ffe8df419d52a0a61bc333d9 : add `scm.getCommitRefSha()` to schema
    - This schema is for using the API: https://octokit.github.io/rest.js/#api-Repos-getCommitRefSha

Related: https://github.com/screwdriver-cd/screwdriver/issues/823