### PR TITLE
feat(1010): [1] add prNum to event model.

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -68,7 +68,10 @@ const MODEL = {
             edges: [{ src: '~commit', dest: 'main' }, { src: 'main', dest: 'publish' }]
         }),
     pr: Scm.pr
-        .description('Pull request object that holds information about the pull request')
+        .description('Pull request object that holds information about the pull request'),
+
+    prNum: prNum
+        .description('Pull request number if it is a PR event')
 };
 
 const CREATE_MODEL = Object.assign({}, MODEL, {
@@ -103,7 +106,7 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type'
     ], [
-        'causeMessage', 'meta', 'parentEventId', 'startFrom', 'workflowGraph', 'pr',
+        'causeMessage', 'meta', 'parentEventId', 'startFrom', 'workflowGraph', 'pr', 'prNum',
         'configPipelineSha'
     ])).label('Get Event'),
 

--- a/test/data/event.create.pr.yaml
+++ b/test/data/event.create.pr.yaml
@@ -1,3 +1,4 @@
 # Event Create Example
 startFrom: PR-1:main
 pipelineId: 1235123
+prNum: 1

--- a/test/data/event.get.pr.yaml
+++ b/test/data/event.get.pr.yaml
@@ -1,0 +1,23 @@
+# Event Get Example
+id: 31135214
+commit:
+    message: Fixing a bug with signing
+    author:
+        url: https://github.com/d2lam
+        name: Dao Lam
+        username: d2lam
+        avatar: https://avatars.githubusercontent.com/u/3401924?v=3
+    url: https://github.com/scredriver-cd/screwdriver/commit/46f1a0bd5592a2f9244ca321b129902a06b53e03
+createTime: "2038-01-19T03:14:08.131Z"
+creator:
+    name: St. John Johnson
+    username: stjohnjohnson
+    url: https://github.com/stjohnjohnson
+    avatar: https://avatars.githubusercontent.com/u/622065?v=3
+pipelineId: 354675231876
+sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
+type: pr
+pr:
+    url: https://github.com/scredriver-cd/screwdriver/pull/25
+    title: pr_test
+prNum: 25

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -43,6 +43,10 @@ describe('model event', () => {
             assert.isNull(validate('event.get.full.yaml', models.event.get).error);
         });
 
+        it('validates the get with pr fields', () => {
+            assert.isNull(validate('event.get.pr.yaml', models.event.get).error);
+        });
+
         it('fails the get', () => {
             assert.isNotNull(validate('empty.yaml', models.event.get).error);
         });


### PR DESCRIPTION
## Context
We have to get all the events including which is not PR or have other PR number, because there are no way to get exact event list with pr number in API.

## Objective
Add `prNum` to the event model in order to search with pr number. 

## References
other PR: 
[2] models: https://github.com/screwdriver-cd/models/pull/348
[3] api: https://github.com/screwdriver-cd/screwdriver/pull/1550

Issue: https://github.com/screwdriver-cd/screwdriver/issues/1010