### PR TITLE
fix(1058): Allow creator to be passed into event create (1)

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -6,7 +6,8 @@ const Regex = require('../config/regex');
 const SCHEMA_USER = Joi.object().keys({
     url: Joi.string()
         .uri()
-        .required()
+        .allow('')
+        .optional()
         .label('Link to Profile')
         .example('https://github.com/stjohnjohnson'),
 
@@ -22,7 +23,8 @@ const SCHEMA_USER = Joi.object().keys({
 
     avatar: Joi.string()
         .uri()
-        .required()
+        .allow('')
+        .optional()
         .label('Link to Avatar')
         .example('https://avatars.githubusercontent.com/u/622065?v=3')
 }).label('SCM User');

--- a/models/event.js
+++ b/models/event.js
@@ -118,7 +118,7 @@ module.exports = {
      */
     create: Joi.object(mutate(CREATE_MODEL, [], [
         'pipelineId', 'startFrom', 'buildId', 'causeMessage', 'parentBuildId', 'parentEventId',
-        'configPipelineSha', 'meta', 'prNum'
+        'configPipelineSha', 'meta', 'prNum', 'creator'
     ])).label('Create Event'),
 
     /**

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -3,6 +3,9 @@ startFrom: main
 parentBuildId: 123
 parentEventId: 123456
 pipelineId: 1235123
+creator:
+    name: sd:scheduler
+    username: sd-buildbot
 causeMessage: 'Restarted since publish job failed'
 configPipelineSha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 meta:


### PR DESCRIPTION
## Context
When an event is started by a periodic build, it can be hard for users to know if the build was started manually by a user, through a commit, or by Screwdriver automatically.

## Objective
This PR allows `creator` to be passed into event create. Since `creator` has some extra urls that the scheduler will not have information for, this PR also makes `url` and `avatar` links optional.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1058