### PR TITLE
fix: [1] convert prChain to chainPR

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -65,9 +65,12 @@ const MODEL = {
         .description('Configuration of child pipelines'),
 
     // This property is set from the `chainPR` annotation.
-    // We preserve its property name for the current Models and UI implementations.
+    // We don't change this property name because `alter table` will be needed
+    // in existing DB table and moreover UI still uses this property name.
+    // We will add `chainPR` property setter/getter method to pipeline model instead
+    // in order to convert the `prChain` to `chainPR`.
     prChain: Base.prChain
-        .description('Configuration of prChain')
+        .description('Configuration of chainPR')
 };
 
 module.exports = {


### PR DESCRIPTION
## Context
Now there are orthographical variants like 'prChain' and 'chainPR' .
We want to unify these to `chainPR`.

## Objective
Add `chainPR` setter/getter method to pipeline model in order to convert the `prChain` to `chainPR`.
We don't change `prChain` property itself because it is already used in data-schema and it takes too much cost to change this.

## References
https://github.com/screwdriver-cd/workflow-parser/pull/21
https://github.com/screwdriver-cd/models/pull/371
https://github.com/screwdriver-cd/screwdriver/pull/1593