### PR TITLE
fix(1596): Increase max length of command usage

### DIFF
--- a/config/command.js
+++ b/config/command.js
@@ -47,7 +47,7 @@ const COMMAND_DESCRIPTION = Joi
 
 const COMMAND_USAGE = Joi
     .string()
-    .max(1024)
+    .max(4096)
     .allow('')
     .description('Usage and arguments of the command')
     .example('sd_cmd exec foo/bar@1 -h <host> -d <domain>');


### PR DESCRIPTION
Increase max length of command usage message to 4096 characters

Related to https://github.com/screwdriver-cd/screwdriver/issues/1596