### PR TITLE
fix: add an optional committer field to commit

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -70,6 +70,10 @@ const SCHEMA_COMMIT = Joi.object().keys({
         .required()
         .label('Author of the commit'),
 
+    committer: SCHEMA_USER
+        .optional()
+        .label('Committer of the commit'),
+
     url: Joi.string()
         .uri()
         .required()


### PR DESCRIPTION
For a commit, author and committer may not be the same person. Add an optional field to record the committer.

Related to https://github.com/screwdriver-cd/screwdriver/issues/1437