### PR TITLE
feat(1455): Add rootDir for pipeline create and update (1)

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -67,6 +67,7 @@ module.exports = {
     // eslint-disable-next-line max-len
     CHECKOUT_URL: /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)?(#[^\s]+)?$/,
     // scmUri. For example: github.com:abc-123:master or bitbucket.org:{123}:master
+    // Optionally, can have rootDir. For example: github.com:abc-123:master:src/app/component
     SCM_URI: /^([^:]+):([^:]+):([^:]+)(?::([^:]+))?$/,
     // Image aliases can only contain A-Z,a-z,0-9,-,_
     IMAGE_ALIAS: /^[\w-]+$/

--- a/config/regex.js
+++ b/config/regex.js
@@ -67,7 +67,7 @@ module.exports = {
     // eslint-disable-next-line max-len
     CHECKOUT_URL: /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)?(#[^\s]+)?$/,
     // scmUri. For example: github.com:abc-123:master or bitbucket.org:{123}:master
-    SCM_URI: /^([^:]+):([^:]+):([^:]+)$/,
+    SCM_URI: /^([^:]+):([^:]+):([^:]+)(?::([^:]+))?$/,
     // Image aliases can only contain A-Z,a-z,0-9,-,_
     IMAGE_ALIAS: /^[\w-]+$/
 };

--- a/core/scm.js
+++ b/core/scm.js
@@ -34,6 +34,10 @@ const REPO_NAME = Joi.string()
     .label('Organization and repository name')
     .example('screwdriver-cd/screwdriver');
 
+const ROOT_DIR = Joi.string().max(100).allow('').optional()
+    .description('Root directory (relative to checkoutUrl)')
+    .example('src/app/component');
+
 const SCHEMA_REPO = Joi.object().keys({
     name: REPO_NAME,
 
@@ -46,7 +50,9 @@ const SCHEMA_REPO = Joi.object().keys({
         .uri()
         .required()
         .label('Link to Repository')
-        .example('https://github.com/screwdriver-cd/screwdriver/tree/master')
+        .example('https://github.com/screwdriver-cd/screwdriver/tree/master'),
+
+    rootDir: ROOT_DIR
 }).label('SCM Repository');
 
 const SCHEMA_COMMAND = Joi.object().keys({
@@ -189,6 +195,7 @@ module.exports = {
     commit: SCHEMA_COMMIT,
     repo: SCHEMA_REPO,
     repoName: REPO_NAME,
+    rootDir: ROOT_DIR,
     user: SCHEMA_USER,
     hook: SCHEMA_HOOK,
     pr: SCHEMA_PR

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -31,7 +31,8 @@ const MODEL = {
     scmUri: Joi
         .string().regex(Regex.SCM_URI).max(128)
         .description('Unique identifier for the application')
-        .example('github.com:123456:master'),
+        .example('github.com:123456:master')
+        .example('github.com:123456:master:src/app/component'),
 
     scmContext: Joi
         .string().max(128)

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -104,8 +104,8 @@ module.exports = {
      * @property create
      * @type {Joi}
      */
-    create: Joi.object(mutate(CREATE_MODEL, [], [
-        'checkoutUrl', 'rootDir'
+    create: Joi.object(mutate(CREATE_MODEL, ['checkoutUrl'], [
+        'rootDir'
     ])).label('Create Pipeline'),
 
     /**

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -8,13 +8,16 @@ const Scm = require('../core/scm');
 const WorkflowGraph = require('../config/workflowGraph');
 const mutate = require('../lib/mutate');
 
-const CHECKOUT_URL = {
+const CREATE_MODEL = {
     checkoutUrl: Joi
         .string().regex(Regex.CHECKOUT_URL)
         .description('Checkout url for the application')
         .example('git@github.com:screwdriver-cd/data-schema.git#master')
         .example('https://github.com/screwdriver-cd/data-schema.git#master')
-        .required()
+        .required(),
+    rootDir: Joi.string().max(100).allow('').optional()
+        .description('Root directory (relative to checkoutUrl)')
+        .example('src/app/component')
 };
 
 const MODEL = {
@@ -101,7 +104,9 @@ module.exports = {
      * @property create
      * @type {Joi}
      */
-    create: Joi.object(CHECKOUT_URL).label('Create Pipeline'),
+    create: Joi.object(mutate(CREATE_MODEL, [], [
+        'checkoutUrl', 'rootDir'
+    ])).label('Create Pipeline'),
 
     /**
      * Properties for Pipeline that will be passed during an UPDATE request
@@ -109,7 +114,9 @@ module.exports = {
      * @property update
      * @type {Joi}
      */
-    update: Joi.object(CHECKOUT_URL).label('Update Pipeline'),
+    update: Joi.object(mutate(CREATE_MODEL, [], [
+        'checkoutUrl', 'rootDir'
+    ])).label('Update Pipeline'),
 
     /**
      * List of fields that determine a unique row

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -15,9 +15,8 @@ const CREATE_MODEL = {
         .example('git@github.com:screwdriver-cd/data-schema.git#master')
         .example('https://github.com/screwdriver-cd/data-schema.git#master')
         .required(),
-    rootDir: Joi.string().max(100).allow('').optional()
-        .description('Root directory (relative to checkoutUrl)')
-        .example('src/app/component')
+
+    rootDir: Scm.rootDir
 };
 
 const MODEL = {

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -11,7 +11,9 @@ const hook = core.scm.hook.required();
 const jobName = Joi.reach(models.job.base, 'name').optional();
 const pipelineId = Joi.reach(models.pipeline.base, 'id').optional();
 const prNum = Joi.reach(core.scm.hook, 'prNum').allow(null).optional();
+const rootDir = Scm.rootDir.optional();
 const scmContext = Joi.reach(models.pipeline.base, 'scmContext').optional();
+const scmRepo = Scm.repo.optional();
 const scmUri = Joi.reach(models.pipeline.base, 'scmUri').required();
 const sha = Joi.reach(models.build.base, 'sha').required();
 const token = Joi.reach(models.user.base, 'token').required();
@@ -54,7 +56,7 @@ const GET_PERMISSIONS = Joi.object().keys({
     scmUri,
     token,
     scmContext,
-    scmRepo: Scm.repo.optional()
+    scmRepo
 }).required();
 
 const GET_ORG_PERMISSIONS = Joi.object().keys({
@@ -69,7 +71,7 @@ const GET_COMMIT_SHA = Joi.object().keys({
     token,
     prNum,
     scmContext,
-    scmRepo: Scm.repo.optional()
+    scmRepo
 }).required();
 
 const GET_COMMIT_REF_SHA = Joi.object().keys({
@@ -107,7 +109,7 @@ const GET_FILE = Joi.object().keys({
     path: Joi.string().required(),
     ref: Joi.string().optional(),
     scmContext,
-    scmRepo: Scm.repo.optional()
+    scmRepo
 }).required();
 
 const GET_CHANGED_FILES_INPUT = Joi.object().keys({
@@ -133,7 +135,7 @@ const DECORATE_URL = Joi.object().keys({
     scmUri,
     token,
     scmContext,
-    scmRepo: Scm.repo.optional()
+    scmRepo
 }).required();
 
 const DECORATE_COMMIT = Joi.object().keys({
@@ -151,6 +153,7 @@ const DECORATE_AUTHOR = Joi.object().keys({
 
 const PARSE_URL = Joi.object().keys({
     checkoutUrl,
+    rootDir,
     token,
     scmContext
 }).required();

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -49,7 +49,8 @@ const GET_CHECKOUT_COMMAND = Joi.object().keys({
     commitBranch: Joi.string().optional(),
     manifest: Joi.string().optional(),
     parentConfig: PARENT_CONFIG.optional(),
-    scmContext
+    scmContext,
+    rootDir
 }).required();
 
 const GET_PERMISSIONS = Joi.object().keys({

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -344,12 +344,13 @@ describe('config regex', () => {
     describe('scmUri', () => {
         it('checks good scmUri', () => {
             assert.isTrue(config.regex.SCM_URI.test('github.com:abc-123:master'));
+            assert.isTrue(config.regex.SCM_URI.test('github.com:abc-123:master:src/app/component'));
             assert.isTrue(config.regex.SCM_URI.test('bitbucket.org:d2lam/{123}:master'));
         });
 
         it('fails on bad scmUri', () => {
             assert.isFalse(config.regex.SCM_URI.test('github.com:master'));
-            assert.isFalse(config.regex.SCM_URI.test('github.com:master:a:b'));
+            assert.isFalse(config.regex.SCM_URI.test('github.com:master:a:b:c'));
             assert.isFalse(config.regex.SCM_URI.test('bitbucket.org:{123}'));
         });
     });

--- a/test/data/pipeline.create.yaml
+++ b/test/data/pipeline.create.yaml
@@ -1,2 +1,3 @@
 # Pipeline Create Example
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
+rootDir: src/app/component

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -10,6 +10,7 @@ scmRepo:
     name: screwdriver-cd/screwdriver
     branch: master
     url: https://github.com/screwdriver-cd/screwdriver/tree/master
+    rootDir: src/app/component
 annotations:
     screwdriver.cd/executor.resource:
         - XCODE8

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -1,7 +1,7 @@
 # Pipeline Get Example
 id: 12742
 name: screwdriver-cd/screwdriver
-scmUri: github.com:12345678:master
+scmUri: github.com:12345678:master:src/app/component
 scmContext: github:github.com
 createTime: "2017-04-11"
 admins:

--- a/test/data/pipeline.update.yaml
+++ b/test/data/pipeline.update.yaml
@@ -1,2 +1,3 @@
 # Pipeline Create Example
 checkoutUrl: git@github.com:screwdriver-cd/data-schema.git#branch
+rootDir: src/app/test

--- a/test/data/scm.decorateUrlWithScmRepo.yaml
+++ b/test/data/scm.decorateUrlWithScmRepo.yaml
@@ -5,3 +5,4 @@ scmRepo:
     branch: master
     url: https://github.com/org/name/tree/master
     name: org/name
+    rootDir: src/app/component

--- a/test/data/scm.getCheckoutCommand.yaml
+++ b/test/data/scm.getCheckoutCommand.yaml
@@ -5,6 +5,7 @@ repo: data-schema
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 scmContext: github:github.com
 manifest: git@github.com:org/repo.git/default.xml
+rootDir: src/app/component
 parentConfig:
   branch: master
   host: github

--- a/test/data/scm.parseUrl.yaml
+++ b/test/data/scm.parseUrl.yaml
@@ -1,3 +1,4 @@
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
 token: 'thisisatokenthingy'
 scmContext: github:github.com
+rootDir: src/app/component


### PR DESCRIPTION
## Context
Would be nice if users could put screwdriver.yaml not at root.

## Objective
This PR adds `rootDir` to pipeline create/update, `scmRepo`, and scm method `parseUrl`

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1455