### PR TITLE
fix(1070): allow environment to be an array

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -70,7 +70,7 @@ const SCHEMA_SECRET = Joi.string().regex(Regex.ENV_NAME).max(64);
 const SCHEMA_SECRETS = Joi.array()
     .items(SCHEMA_SECRET)
     .min(0);
-const SCHEMA_ENVIRONMENT = Joi.object()
+const SCHEMA_ENVIRONMENT_OBJECT = Joi.object()
     // IEEE Std 1003.1-2001
     // Environment names contain uppercase letters, digits, and underscore
     // They cannot start with digits
@@ -86,6 +86,9 @@ const SCHEMA_ENVIRONMENT = Joi.object()
             }
         }
     });
+const SCHEMA_ENVIRONMENT = Joi.alternatives().try(
+    Joi.array().items(SCHEMA_ENVIRONMENT_OBJECT).min(1),
+    SCHEMA_ENVIRONMENT_OBJECT);
 const SCHEMA_JOBNAME = Joi.string().max(100).regex(Regex.JOB_NAME);
 const SCHEMA_STEP_STRING = Joi.string();
 const SCHEMA_STEP_OBJECT = Joi.object()

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -81,6 +81,10 @@ describe('config job', () => {
         it('validates environment', () => {
             assert.isNull(validate('config.job.environment.yaml', config.job.environment).error);
         });
+        it('validates environment as an array', () => {
+            assert.isNull(validate('config.job.environment.array.yaml',
+                config.job.environment).error);
+        });
     });
 
     describe('image', () => {

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -10,3 +10,5 @@ stats:
   blockedStartTime: '2017-01-06T01:49:50.384359267Z'
   queueEnterTime: '2017-01-06T01:49:50.384359267Z'
   imagePullStartTime: '2017-01-06T02:49:50.384359267Z'
+environment:
+  - FOO: BAR

--- a/test/data/config.job.environment.array.yaml
+++ b/test/data/config.job.environment.array.yaml
@@ -1,0 +1,5 @@
+- NODE_VERSION: 15
+- PLATFORM_COLOR: blue
+- COMPLEX_VALUE1:
+    foo: bar
+- COMPLEX_VALUE2: [1,2,3]


### PR DESCRIPTION
Allow `environment` to be an array

Related: https://github.com/screwdriver-cd/screwdriver/issues/1070