### PR TITLE
fix(823): [1] Add some release fields for SCHEMA_HOOK

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -187,7 +187,24 @@ const SCHEMA_HOOK = Joi.object().keys({
         .required()
         .label('Type of the event'),
 
-    username: Joi.reach(SCHEMA_USER, 'username')
+    username: Joi.reach(SCHEMA_USER, 'username'),
+
+    releaseId: Joi.number()
+        .integer()
+        .positive()
+        .optional()
+        .label('Release id'),
+
+    releaseName: Joi.string()
+        .allow('')
+        .optional()
+        .label('Name of the event'),
+
+    releaseAuthor: Joi.string()
+        .allow('')
+        .optional()
+        .label('Author of the event')
+
 }).label('SCM Hook');
 
 module.exports = {

--- a/core/scm.js
+++ b/core/scm.js
@@ -189,9 +189,8 @@ const SCHEMA_HOOK = Joi.object().keys({
 
     username: Joi.reach(SCHEMA_USER, 'username'),
 
-    releaseId: Joi.number()
-        .integer()
-        .positive()
+    releaseId: Joi.string()
+        .allow('')
         .optional()
         .label('Release id'),
 

--- a/test/data/scm.hook.release.yaml
+++ b/test/data/scm.hook.release.yaml
@@ -7,3 +7,6 @@ scmContext: github:github.com
 type: repo
 username: stjohnjohnson
 ref: super-tag
+releaseId: 11248890
+releaseName: super-release
+releaseAuthor: stjohnjohnson

--- a/test/data/scm.hook.release.yaml
+++ b/test/data/scm.hook.release.yaml
@@ -7,6 +7,6 @@ scmContext: github:github.com
 type: repo
 username: stjohnjohnson
 ref: super-tag
-releaseId: 11248890
+releaseId: '11248890'
 releaseName: super-release
 releaseAuthor: stjohnjohnson


### PR DESCRIPTION
## Context
SD can execute release/tag trigger, but it can't provide release/tag info(ex. name).
SD user want to get release/tag info.

## Objective
Add some release fields to SCHEMA_HOOK.
Please see reference to confirm details.

## References
https://github.com/screwdriver-cd/screwdriver/issues/823#issuecomment-490014132