### PR TITLE
fix(823): [1] add core/extra triggers regex

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -51,6 +51,10 @@ module.exports = {
     // Can be ~pr, ~commit, ~release, ~tag or ~commit:branchName, or ~sd@123:component
     // Note: if you modify this regex, you must modify `sdJoi` definition in the `config/job.js`
     TRIGGER: /^~(sd@\d+:[\w-]+|(pr|commit|release|tag)(:(.+))?)$/,
+    // Triggers which always create event
+    CORE_TRIGGER: /^~(pr|commit)(:(.+))?$/,
+    // Triggers which does not create empty events
+    EXTRA_TRIGGER: /^~(release|tag)(:(.+))?$/,
     // Can be ~pr or ~pr:branchName
     PR_TRIGGER: /^~pr(:.+)?$/,
     // Can be ~commit or ~commit:branchName

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -48,6 +48,34 @@ describe('config regex', () => {
         });
     });
 
+    describe('core trigger', () => {
+        it('checks good trigger', () => {
+            assert.isTrue(config.regex.CORE_TRIGGER.test('~commit'));
+            assert.isTrue(config.regex.CORE_TRIGGER.test('~commit:master'));
+            assert.isTrue(config.regex.CORE_TRIGGER.test('~pr'));
+            assert.isTrue(config.regex.CORE_TRIGGER.test('~pr:master'));
+        });
+
+        it('fails on bad trigger', () => {
+            assert.isFalse(config.regex.CORE_TRIGGER.test('~tag'));
+            assert.isFalse(config.regex.CORE_TRIGGER.test('~release'));
+        });
+    });
+
+    describe('extra trigger', () => {
+        it('checks good trigger', () => {
+            assert.isTrue(config.regex.EXTRA_TRIGGER.test('~tag'));
+            assert.isTrue(config.regex.EXTRA_TRIGGER.test('~tag:master'));
+            assert.isTrue(config.regex.EXTRA_TRIGGER.test('~release'));
+            assert.isTrue(config.regex.EXTRA_TRIGGER.test('~release:master'));
+        });
+
+        it('fails on bad trigger', () => {
+            assert.isFalse(config.regex.EXTRA_TRIGGER.test('~commit'));
+            assert.isFalse(config.regex.EXTRA_TRIGGER.test('~pr'));
+        });
+    });
+
     describe('commit trigger', () => {
         it('checks good trigger', () => {
             assert.isTrue(config.regex.TRIGGER.test('~commit'));


### PR DESCRIPTION
## Objective
To achieve [this PR](https://github.com/screwdriver-cd/screwdriver/pull/1621) in API, we need to define `CORE_TRIGGERS` and `EXTRA_TRIGGERS`.

`CORE_TRIGGERS` -> triggers which can make empty events
`EXTRA_TRIGGERS` -> triggers which cannot make empty events

This time we don't use `CORE_TRIGGERS` but we defined for future.

## References
https://github.com/screwdriver-cd/screwdriver/issues/823#issuecomment-489999734

## OtherPRs
[2] https://github.com/screwdriver-cd/screwdriver/pull/1621