### PR TITLE
fix: add "trusted" column to template and command

### DIFF
--- a/models/command.js
+++ b/models/command.js
@@ -26,7 +26,9 @@ const MODEL = {
         .max(32)
         .description('When this command was created')
         .example('2038-01-19T03:14:08.131Z'),
-    usage: Command.usage
+    usage: Command.usage,
+    trusted: Joi.boolean()
+        .description('Mark whether command is trusted')
 };
 
 module.exports = {
@@ -58,7 +60,8 @@ module.exports = {
         'docker',
         'binary',
         'createTime',
-        'usage'
+        'usage',
+        'trusted'
     ])).label('Get Command'),
 
     /**

--- a/models/template.js
+++ b/models/template.js
@@ -32,7 +32,9 @@ const MODEL = {
         .isoDate()
         .max(32)
         .description('When this template was created')
-        .example('2038-01-19T03:14:08.131Z')
+        .example('2038-01-19T03:14:08.131Z'),
+    trusted: Joi.boolean()
+        .description('Mark whether template is trusted')
 };
 
 const CREATE_MODEL = Object.assign({}, MODEL, { config: Template.configNoDupSteps });
@@ -54,7 +56,7 @@ module.exports = {
      */
     get: Joi.object(mutate(MODEL, [
         'id', 'labels', 'name', 'version', 'description', 'maintainer', 'pipelineId'
-    ], ['config', 'namespace', 'images', 'createTime'])).label('Get Template'),
+    ], ['config', 'namespace', 'images', 'createTime', 'trusted'])).label('Get Template'),
 
     /**
      * Properties for template that will be passed during a CREATE request

--- a/test/data/command.get.yaml
+++ b/test/data/command.get.yaml
@@ -18,3 +18,4 @@ habitat:
 #binary:
 #    file: ./foobar.sh
 pipelineId: 8765
+trusted: true

--- a/test/data/template.get.yaml
+++ b/test/data/template.get.yaml
@@ -20,3 +20,4 @@ config:
     FOO: bar
   secrets:
      - NPM_TOKEN
+trusted: true


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

To mark certain template and command as trusted, we need to modify the existing schema to include additional column on the db table

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

add `trusted` column to template's and command's schema

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/1427

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
