### PR TITLE
fix: allow template tag name to use dot

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -10,7 +10,7 @@ module.exports = {
     // Command names can only be named with A-Z,a-z,0-9,-,_
     COMMAND_NAME: /^[\w-]+$/,
     // Command tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_,.
-    COMMAND_TAG_NAME: /^[a-zA-Z][\w-\.]+$/,
+    COMMAND_TAG_NAME: /^[a-zA-Z][\w-.]+$/,
     // Full name of command and version. Can be <COMMAND_NAMESPACE>/<COMMAND_NAME>@<VERSION> or <COMMAND_NAMESPACE>/<COMMAND_NAME>@<COMMAND_TAG_NAME>
     // Example: chefdk/knife@1.2.3 or chefdk/knife@stable
     // Only <COMMAND_NAMESPACE>/<COMMAND_NAME> or <COMMAND_NAMESPACE>/<COMMAND_NAME> is also acceptable
@@ -23,7 +23,7 @@ module.exports = {
     // Templates can only be named with A-Z,a-z,0-9,-,_ if namespace exists
     TEMPLATE_NAME_NO_SLASH: /^[\w-]+$/,
     // Template tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_,.
-    TEMPLATE_TAG_NAME: /^[a-zA-Z][\w-\.]+$/,
+    TEMPLATE_TAG_NAME: /^[a-zA-Z][\w-.]+$/,
     // Version can only have up to 2 decimals, like 1.2.3
     // It can also be just major or major and minor versions, like 1 or 1.2
     VERSION: /^(\d+)(\.\d+)?(\.\d+)?$/,

--- a/config/regex.js
+++ b/config/regex.js
@@ -9,8 +9,8 @@ module.exports = {
     COMMAND_NAMESPACE: /^[\w-]+$/,
     // Command names can only be named with A-Z,a-z,0-9,-,_
     COMMAND_NAME: /^[\w-]+$/,
-    // Command tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_
-    COMMAND_TAG_NAME: /^[a-zA-Z][\w-.]+$/,
+    // Command tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_,.
+    COMMAND_TAG_NAME: /^[a-zA-Z][\w-\.]+$/,
     // Full name of command and version. Can be <COMMAND_NAMESPACE>/<COMMAND_NAME>@<VERSION> or <COMMAND_NAMESPACE>/<COMMAND_NAME>@<COMMAND_TAG_NAME>
     // Example: chefdk/knife@1.2.3 or chefdk/knife@stable
     // Only <COMMAND_NAMESPACE>/<COMMAND_NAME> or <COMMAND_NAMESPACE>/<COMMAND_NAME> is also acceptable
@@ -22,8 +22,8 @@ module.exports = {
     TEMPLATE_NAME_ALLOW_SLASH: /^(?:([\w-]+)\/)?([\w-]+)$/,
     // Templates can only be named with A-Z,a-z,0-9,-,_ if namespace exists
     TEMPLATE_NAME_NO_SLASH: /^[\w-]+$/,
-    // Template tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_
-    TEMPLATE_TAG_NAME: /^[a-zA-Z][\w-]+$/,
+    // Template tags must start with an alpha character (A-Z,a-z) and can only contain A-Z,a-z,0-9,-,_,.
+    TEMPLATE_TAG_NAME: /^[a-zA-Z][\w-\.]+$/,
     // Version can only have up to 2 decimals, like 1.2.3
     // It can also be just major or major and minor versions, like 1 or 1.2
     VERSION: /^(\d+)(\.\d+)?(\.\d+)?$/,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^7.0.0",
+    "jenkins-mocha": "^8.0.0",
     "js-yaml": "^3.12.1"
   },
   "dependencies": {

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -200,6 +200,14 @@ describe('config regex', () => {
         it('fails on bad template names', () => {
             assert.isFalse(config.regex.TEMPLATE_NAME_NO_SLASH.test('run all the things'));
         });
+
+        it('checks good template tag names', () => {
+            assert.isTrue(config.regex.TEMPLATE_TAG_NAME.test('stable'));
+        });
+
+        it('checks good template dotted tag names', () => {
+            assert.isTrue(config.regex.TEMPLATE_TAG_NAME.test('v1.2.3'));
+        });
     });
 
     describe('versions', () => {


### PR DESCRIPTION
## Context
There seems to be no reason we can't allow to use dot for template tag name.

## Objective
Allow template tag name to use dot

## References
https://github.com/screwdriver-cd/data-schema/pull/342

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
