### PR TITLE
feat(947): Added a new type field for collection schema

### DIFF
--- a/models/collection.js
+++ b/models/collection.js
@@ -41,7 +41,13 @@ const MODEL = {
 
     pipelineIds: Joi
         .array()
-        .items(Joi.number().integer().positive())
+        .items(Joi.number().integer().positive()),
+
+    type: Joi
+        .string()
+        .max(32)
+        .description('Collection type')
+        .example('default')
 };
 const GET_MODEL = Object.assign({}, MODEL, { pipelines: PIPELINES_MODEL });
 
@@ -64,7 +70,8 @@ module.exports = {
         'id',
         'name',
         'pipelineIds',
-        'pipelines'
+        'pipelines',
+        'type'
     ], [
         'description'
     ])).label('Get collection'),
@@ -77,7 +84,8 @@ module.exports = {
         'id',
         'name',
         'pipelineIds',
-        'userId'
+        'userId',
+        'type'
     ], [
         'description'
     ]))).label('List collections for requesting user'),
@@ -89,7 +97,8 @@ module.exports = {
      * @type {Joi}
      */
     create: Joi.object(mutate(MODEL, [
-        'name'
+        'name',
+        'type'
     ], [
         'description',
         'pipelineIds'


### PR DESCRIPTION
## Context
Would be nice if there's a default collection where a user can find all pipelines they create.

## Objective
This pull requests adds a new "type" field to collection schema

## References
Related to [947](https://github.com/screwdriver-cd/screwdriver/issues/947)

## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
