### PR TITLE
fix: [1] add "mediaType" param to GET_COMMIT_REF_SHA

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -80,6 +80,7 @@ const GET_COMMIT_REF_SHA = Joi.object().keys({
     owner: Joi.string().required(),
     repo: Joi.string().required(),
     ref: Joi.string().required(),
+    mediaType: Joi.object().keys({ format: Joi.string().required() }).required(),
     scmContext
 }).required();
 

--- a/test/data/scm.getCommitRefSha.yaml
+++ b/test/data/scm.getCommitRefSha.yaml
@@ -2,4 +2,6 @@ token: 'thisisatokenthingy'
 owner: 'owner'
 repo: 'repo'
 ref: '0.0.1'
+mediaType: 
+  format: '6dcb09b5b57875f334f61aebed695e2e4193db5e'
 scmContext: github:github.com


### PR DESCRIPTION
## Context 
We add `mediaType` param to `GET_COMMIT_REF_SHA` in order to fix deprecation of getCommitRefSha function in [scm-github#137](https://github.com/screwdriver-cd/scm-github/pull/137)
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## References
[octokit doc](https://octokit.github.io/rest.js/#octokit-routes-repos-get-commit)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
