### PR TITLE
fix: [1] add refType param in getCommitRefSha

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -80,6 +80,7 @@ const GET_COMMIT_REF_SHA = Joi.object().keys({
     owner: Joi.string().required(),
     repo: Joi.string().required(),
     ref: Joi.string().required(),
+    refType: Joi.string().required(),
     scmContext
 }).required();
 

--- a/test/data/scm.getCommitRefSha.yaml
+++ b/test/data/scm.getCommitRefSha.yaml
@@ -2,4 +2,5 @@ token: 'thisisatokenthingy'
 owner: 'owner'
 repo: 'repo'
 ref: '0.0.1'
+refType: 'heads'
 scmContext: github:github.com


### PR DESCRIPTION
## Context
`getCommitRefSha` function can't get `sha` correctly when tag name and branch name are same.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
This PR adds `refType` param so that you can distinguish
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
[scm_github PR](https://github.com/screwdriver-cd/scm-github/pull/138)
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
