### PR TITLE
fix: add index

### DIFF
--- a/models/job.js
+++ b/models/job.js
@@ -141,5 +141,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['pipelineId'] }, { fields: ['state'] }]
+    indexes: [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }]
 };

--- a/models/trigger.js
+++ b/models/trigger.js
@@ -56,5 +56,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['src'] }]
+    indexes: [{ fields: ['dest'] }, { fields: ['src'] }]
 };

--- a/test/models/job.test.js
+++ b/test/models/job.test.js
@@ -42,4 +42,52 @@ describe('model job', () => {
             assert.isNotNull(validate('empty.yaml', models.job.update).error);
         });
     });
+
+    describe('keys', () => {
+        it('has the correct keys', () => {
+            const expectedKeys = ['pipelineId', 'name'];
+
+            expectedKeys.forEach((keyName) => {
+                assert.include(models.job.keys, keyName, `Key name ${keyName} not included`);
+            });
+        });
+    });
+
+    describe('allKeys', () => {
+        it('lists all of the fields in the model', () => {
+            const expectedKeys = [
+                'id',
+                'name',
+                'prParentJobId',
+                'description',
+                'pipelineId',
+                'state',
+                'stateChanger',
+                'stateChangeTime',
+                'stateChangeMessage',
+                'archived'
+            ];
+
+            expectedKeys.forEach((keyName) => {
+                assert.include(models.job.allKeys, keyName, `Key name ${keyName} not included`);
+            });
+        });
+    });
+
+    describe('tableName', () => {
+        it('provides the correct table name', () => {
+            assert.strictEqual(models.job.tableName, 'jobs');
+        });
+    });
+
+    describe('indexes', () => {
+        it('defines the correct indexes', () => {
+            const expected = [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }];
+            const indexes = models.job.indexes;
+
+            expected.forEach((indexName) => {
+                assert.include(indexes, indexName, `Index name ${indexName} not included`);
+            });
+        });
+    });
 });

--- a/test/models/trigger.test.js
+++ b/test/models/trigger.test.js
@@ -10,4 +10,45 @@ describe('model trigger', () => {
             assert.isNull(validate('trigger.yaml', models.trigger.base).error);
         });
     });
+
+    describe('keys', () => {
+        it('has the correct keys', () => {
+            const expectedKeys = ['src', 'dest'];
+
+            expectedKeys.forEach((keyName) => {
+                assert.include(models.trigger.keys, keyName, `Key name ${keyName} not included`);
+            });
+        });
+    });
+
+    describe('allKeys', () => {
+        it('lists all of the fields in the model', () => {
+            const expectedKeys = [
+                'id',
+                'src',
+                'dest'
+            ];
+
+            expectedKeys.forEach((keyName) => {
+                assert.include(models.trigger.allKeys, keyName, `Key name ${keyName} not included`);
+            });
+        });
+    });
+
+    describe('tableName', () => {
+        it('provides the correct table name', () => {
+            assert.strictEqual(models.trigger.tableName, 'triggers');
+        });
+    });
+
+    describe('indexes', () => {
+        it('defines the correct indexes', () => {
+            const expected = [{ fields: ['dest'] }, { fields: ['src'] }];
+            const indexes = models.trigger.indexes;
+
+            expected.forEach((indexName) => {
+                assert.include(indexes, indexName, `Index name ${indexName} not included`);
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Context

Improve DB query performance by using an index scan

## Objective

Added index based on the data access pattern from the database metrics

## References

pipelineId and state columns used in where clause query of the jobs table will fire a single index scan

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
