### PR TITLE
fix(1339): add parameters for parameterized builds

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -33,7 +33,8 @@ const SCHEMA_JOB_PERMUTATION = Joi.object()
         secrets: Job.secrets,
         settings: Job.settings,
         sourcePaths: Job.sourcePaths,
-        freezeWindows: Job.freezeWindows
+        freezeWindows: Job.freezeWindows,
+        parameters: Job.parameters
     }).label('Job permutation');
 
 const SCHEMA_JOB_PERMUTATIONS = Joi.array().items(SCHEMA_JOB_PERMUTATION)

--- a/config/job.js
+++ b/config/job.js
@@ -101,7 +101,8 @@ const SCHEMA_PARAMETERS_OBJECT = Joi.object({
 
 const SCHEMA_PARAMETERS = Joi.object()
     .pattern(Joi.any(),
-        Joi.alternatives().try(SCHEMA_PARAMETERS_STRING, SCHEMA_PARAMETERS_OBJECT));
+        Joi.alternatives().try(SCHEMA_PARAMETERS_STRING, SCHEMA_PARAMETERS_OBJECT))
+    .default({});
 const SCHEMA_JOBNAME = Joi.string().max(100).regex(Regex.JOB_NAME);
 const SCHEMA_STEP_STRING = Joi.string();
 const SCHEMA_STEP_OBJECT = Joi.object()

--- a/config/job.js
+++ b/config/job.js
@@ -88,9 +88,9 @@ const SCHEMA_ENVIRONMENT = Joi.object()
     });
 const SCHEMA_PARAMETERS_STRING = Joi.string();
 const SCHEMA_PARAMETERS_OBJECT = Joi.object({
-        value: Joi.string().required(),
-        description: Joi.string(),
-    })
+    value: Joi.string().required(),
+    description: Joi.string()
+})
     .options({
         language: {
             object: {
@@ -99,7 +99,10 @@ const SCHEMA_PARAMETERS_OBJECT = Joi.object({
             }
         }
     });
-const SCHEMA_PARAMETERS = Joi.alternatives().try(SCHEMA_PARAMETERS_STRING, SCHEMA_PARAMETERS_OBJECT);
+
+const SCHEMA_PARAMETERS = Joi.object()
+    .pattern(Joi.any(),
+        Joi.alternatives().try(SCHEMA_PARAMETERS_STRING, SCHEMA_PARAMETERS_OBJECT));
 const SCHEMA_JOBNAME = Joi.string().max(100).regex(Regex.JOB_NAME);
 const SCHEMA_STEP_STRING = Joi.string();
 const SCHEMA_STEP_OBJECT = Joi.object()

--- a/config/job.js
+++ b/config/job.js
@@ -86,6 +86,20 @@ const SCHEMA_ENVIRONMENT = Joi.object()
             }
         }
     });
+const SCHEMA_PARAMETERS_STRING = Joi.string();
+const SCHEMA_PARAMETERS_OBJECT = Joi.object({
+        value: Joi.string().required(),
+        description: Joi.string(),
+    })
+    .options({
+        language: {
+            object: {
+                allowUnknown: 'only supports uppercase letters, digits, and underscore (cannot '
+                + 'start with digit)'
+            }
+        }
+    });
+const SCHEMA_PARAMETERS = Joi.alternatives().try(SCHEMA_PARAMETERS_STRING, SCHEMA_PARAMETERS_OBJECT);
 const SCHEMA_JOBNAME = Joi.string().max(100).regex(Regex.JOB_NAME);
 const SCHEMA_STEP_STRING = Joi.string();
 const SCHEMA_STEP_OBJECT = Joi.object()
@@ -104,7 +118,6 @@ const SCHEMA_STEP_OBJECT = Joi.object()
             }
         }
     });
-
 const SCHEMA_DESCRIPTION = Joi.string().max(100).optional();
 const SCHEMA_IMAGE = Joi.string().regex(Regex.IMAGE_NAME);
 const SCHEMA_SETTINGS = Joi.object().optional();
@@ -151,6 +164,7 @@ const SCHEMA_JOB = Joi.object()
         annotations: Annotations.annotations,
         description: SCHEMA_DESCRIPTION,
         environment: SCHEMA_ENVIRONMENT,
+        parameters: SCHEMA_PARAMETERS,
         image: SCHEMA_IMAGE,
         matrix: SCHEMA_MATRIX,
         requires: SCHEMA_REQUIRES,
@@ -189,6 +203,7 @@ module.exports = {
     annotations: Annotations.annotations,
     description: SCHEMA_DESCRIPTION,
     environment: SCHEMA_ENVIRONMENT,
+    parameters: SCHEMA_PARAMETERS,
     image: SCHEMA_IMAGE,
     job: SCHEMA_JOB,
     jobNoDupSteps: SCHEMA_JOB_NO_DUP_STEPS,

--- a/config/job.js
+++ b/config/job.js
@@ -94,8 +94,7 @@ const SCHEMA_PARAMETERS_OBJECT = Joi.object({
     .options({
         language: {
             object: {
-                allowUnknown: 'only supports uppercase letters, digits, and underscore (cannot '
-                + 'start with digit)'
+                allowUnknown: 'only supports string or key: { value, description } pair as values'
             }
         }
     });

--- a/models/build.js
+++ b/models/build.js
@@ -16,8 +16,6 @@ const MODEL = {
 
     environment: Job.environment,
 
-    parameters: Job.parameters,
-
     eventId: Joi
         .number().integer().positive()
         .description('Identifier of the parent event')
@@ -71,8 +69,7 @@ const MODEL = {
         .isoDate()
         .description('When this build stopped running'),
 
-    parameters: Joi
-        .object()
+    parameters: Job.parameters
         .description('Input parameters that defined this build'),
 
     meta: Joi

--- a/models/build.js
+++ b/models/build.js
@@ -16,6 +16,8 @@ const MODEL = {
 
     environment: Job.environment,
 
+    parameters: Job.parameters,
+
     eventId: Joi
         .number().integer().positive()
         .description('Identifier of the parent event')

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -119,7 +119,7 @@ describe('config job', () => {
     });
 
     describe('parameters', () => {
-        it.only('validates parameters', () => {
+        it('validates parameters', () => {
             assert.isNull(validate('config.job.parameters.yaml', config.job.parameters).error);
         });
     });

--- a/test/config/job.test.js
+++ b/test/config/job.test.js
@@ -117,4 +117,10 @@ describe('config job', () => {
                 .error);
         });
     });
+
+    describe('parameters', () => {
+        it.only('validates parameters', () => {
+            assert.isNull(validate('config.job.parameters.yaml', config.job.parameters).error);
+        });
+    });
 });

--- a/test/data/config.job.parameters.yaml
+++ b/test/data/config.job.parameters.yaml
@@ -1,0 +1,5 @@
+# Job Parameters Example
+auth_strategy: simple
+user:
+    value: sd-bot
+    description: User running build


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Add additional in `screwdriver.yaml` to take `parameters` as input, that allows users to use it later in their builds to customize the pipeline building process

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR add parameters validator for `config.job`

i.e.
```
shared:
    image: node:8

jobs:
    main:
        requires: [~pr, ~commit]
        steps:
            - test: echo ok
        parameters:
            auth_strategy: simple
            user:
                value: sd-bot
                description: User running build
```


## References
https://github.com/screwdriver-cd/screwdriver/issues/1339
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
