### PR TITLE
fix(1747): adding commit authors to hook schema

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -192,6 +192,11 @@ const SCHEMA_HOOK = Joi.object().keys({
 
     username: Joi.reach(SCHEMA_USER, 'username'),
 
+    commitAuthors: Joi.array()
+        .items(Joi.string())
+        .optional()
+        .label('Commit authors'),
+
     releaseId: Joi.string()
         .allow('')
         .optional()

--- a/test/core/scm.test.js
+++ b/test/core/scm.test.js
@@ -64,6 +64,14 @@ describe('scm core', () => {
             assert.isNull(validate('scm.hook.push.yaml', core.scm.hook).error);
         });
 
+        it('fails the push hook because commiter author is not array', () => {
+            assert.isNotNull(validate('scm.hook.push.invalid-commiters.yaml', core.scm.hook).error);
+        });
+
+        it('fails the push hook because commiter author is not an array of string', () => {
+            assert.isNotNull(validate('scm.hook.push.invalid-array.yaml', core.scm.hook).error);
+        });
+
         it('validates the ping hook', () => {
             assert.isNull(validate('scm.hook.ping.yaml', core.scm.hook).error);
         });

--- a/test/data/scm.hook.push.invalid-array.yaml
+++ b/test/data/scm.hook.push.invalid-array.yaml
@@ -1,4 +1,4 @@
-# SCM Hook example
+# Invalid SCM Hook commitAuthors 
 action: push
 branch: master
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
@@ -8,4 +8,4 @@ sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 type: repo
 username: stjohnjohnson
 ref: reference
-commitAuthors: ['john1', 'john2']
+commitAuthors: [1,2]

--- a/test/data/scm.hook.push.invalid-commiters.yaml
+++ b/test/data/scm.hook.push.invalid-commiters.yaml
@@ -1,4 +1,4 @@
-# SCM Hook example
+# Invalid SCM Hook commitAuthors 
 action: push
 branch: master
 checkoutUrl: git@github.com:screwdriver-cd/data-model.git#master
@@ -8,4 +8,4 @@ sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 type: repo
 username: stjohnjohnson
 ref: reference
-commitAuthors: ['john1', 'john2']
+commitAuthors: john1


### PR DESCRIPTION
## Context

Currently there's a mismatch in v3 and v4 ci skip logic. To change v4 ci skip logic to match v3 we need an additional field.

## Objective

This PR add an optional field to hook schema

## References

https://github.com/screwdriver-cd/screwdriver/issues/1747

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
