### PR TITLE
add a fix to allow empty string and empty array for commit author und…

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -193,7 +193,8 @@ const SCHEMA_HOOK = Joi.object().keys({
     username: Joi.reach(SCHEMA_USER, 'username'),
 
     commitAuthors: Joi.array()
-        .items(Joi.string())
+        .items(Joi.string().allow(''))
+        .allow([])
         .optional()
         .label('Commit authors'),
 


### PR DESCRIPTION
## Context

Currently commit author field doesn't accept empty array nor empty string in array

## Objective

change commit author field to accept empty array and empty string

## References

https://github.com/screwdriver-cd/data-schema/pull/351

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
