### PR TITLE
[1] fix(1755): Add branch info to event schema

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -69,9 +69,12 @@ const MODEL = {
         }),
     pr: Scm.pr
         .description('Pull request object that holds information about the pull request'),
-
     prNum: prNum
-        .description('Pull request number if it is a PR event')
+        .description('Pull request number if it is a PR event'),
+    baseBranch: Joi
+        .string()
+        .description('build base branch')
+        .example('develop')
 };
 
 const CREATE_MODEL = Object.assign({}, MODEL, {
@@ -107,7 +110,7 @@ module.exports = {
         'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type'
     ], [
         'causeMessage', 'meta', 'parentEventId', 'startFrom', 'workflowGraph', 'pr', 'prNum',
-        'configPipelineSha'
+        'configPipelineSha', 'baseBranch'
     ])).label('Get Event'),
 
     /**
@@ -118,7 +121,7 @@ module.exports = {
      */
     create: Joi.object(mutate(CREATE_MODEL, [], [
         'pipelineId', 'startFrom', 'buildId', 'causeMessage', 'parentBuildId', 'parentEventId',
-        'configPipelineSha', 'meta', 'prNum', 'creator'
+        'configPipelineSha', 'meta', 'prNum', 'creator', 'baseBranch'
     ])).label('Create Event'),
 
     /**

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -11,3 +11,4 @@ configPipelineSha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 meta:
   foo: bar
   one: 1
+baseBranch: 'develop'


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
To use branch info in the restarted build and triggered build, I added branch info to event schema.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add branch info to event schema.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1755
https://github.com/screwdriver-cd/screwdriver/issues/1760

Related PRs:
https://github.com/screwdriver-cd/models/pull/396
https://github.com/screwdriver-cd/scm-base/pull/72
https://github.com/screwdriver-cd/screwdriver/pull/1770

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
