### PR TITLE
fix(1675): Add causeMessage to executor start [1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,15 +43,15 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^8.0.0",
-    "js-yaml": "^3.12.1",
-    "pg": "^7.12.1",
+    "js-yaml": "^3.13.1",
     "mysql2": "^1.7.0",
-    "sqlite3": "^4.1.0",
+    "pg": "^7.12.1",
     "sequelize": "^5.18.4",
-    "sequelize-cli": "^5.5.1"
+    "sequelize-cli": "^5.5.1",
+    "sqlite3": "^4.1.0"
   },
   "dependencies": {
-    "joi": "^13.7.0",
-    "cron-parser": "^2.7.3"
+    "cron-parser": "^2.13.0",
+    "joi": "^13.7.0"
   }
 }

--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -6,6 +6,7 @@ const Joi = require('joi');
 const models = require('../models');
 const buildId = Joi.reach(models.build.base, 'id').required();
 const eventId = Joi.reach(models.event.base, 'id');
+const causeMessage = Joi.reach(models.event.base, 'causeMessage');
 const jobId = Joi.reach(models.job.base, 'id');
 const jobName = Joi.reach(models.job.base, 'name');
 const jobState = Joi.reach(models.job.base, 'state');
@@ -18,6 +19,7 @@ const SCHEMA_PIPELINE = Joi.object().keys({
 
 const SCHEMA_START = Joi.object().keys({
     build: Joi.object(),
+    causeMessage,
     jobId,
     jobName,
     jobState,

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -4,6 +4,7 @@ jobState: ENABLED
 jobArchived: false
 annotations:
     beta.screwdriver.cd/executor: k8s
+causeMessage: '[force start] Push out hotfix'
 blockedBy:
     - 1111
     - 2222


### PR DESCRIPTION
## Context

Sometimes users want to override their freeze window quickly without changing the screwdriver.yaml.

## Objective

This PR adds a field `causeMessage` to executor start. Users can pass in `[force start]` keywords (similar to [skip ci]) to force a build to start during a freeze window.

_Note: Not sure if `force start` is the best keyword phrase. Open to other ideas: `override frozen`, `ci` (as the opposite of `skip ci`?), etc._

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1675

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
