### PR TITLE
fix: Allow empty string for causeMessage

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -20,7 +20,7 @@ const MODEL = {
         .description('Identifier of the parent event')
         .example(123344),
     causeMessage: Joi
-        .string().max(512).truncate()
+        .string().max(512).truncate().allow('')
         .description('Message that describes why the event was created')
         .example('Merge pull request #26 from screwdriver-cd/data-schema'),
     commit: Scm.commit


### PR DESCRIPTION
## Context

Sometimes causeMessage is not set.

## Objective

This PR allows empty string for causeMessage.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1675

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
