### PR TITLE
feat(1830): build cache to disk

### DIFF
--- a/migrations/20191104-add_buildCluster_column_to_pipelines.js
+++ b/migrations/20191104-add_buildCluster_column_to_pipelines.js
@@ -1,0 +1,14 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}pipelines`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addColumn(table, 'buildClusterName', {
+            type: Sequelize.STRING(50)
+        });
+    }
+};

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -8,6 +8,7 @@ const Scm = require('../core/scm');
 const WorkflowGraph = require('../config/workflowGraph');
 const Parameters = require('../config/parameters');
 const mutate = require('../lib/mutate');
+const buildClusterName = Joi.reach(require('./buildCluster').base, 'name');
 
 const CREATE_MODEL = {
     checkoutUrl: Joi
@@ -76,7 +77,9 @@ const MODEL = {
     prChain: Base.prChain
         .description('Configuration of chainPR'),
 
-    parameters: Parameters.parameters
+    parameters: Parameters.parameters,
+
+    buildClusterName
 };
 
 module.exports = {
@@ -99,7 +102,7 @@ module.exports = {
     ], [
         'workflowGraph', 'scmRepo', 'annotations', 'lastEventId',
         'configPipelineId', 'childPipelines', 'name', 'prChain',
-        'parameters'
+        'parameters', 'buildClusterName'
     ])).label('Get Pipeline'),
 
     /**


### PR DESCRIPTION
## Context

All builds in the pipeline should be automatically sent to the build cluster assigned at pipeline creation time

## Objective

Add buildClusterName column to pipelines table

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
