### PR TITLE
feat(1830): build cache2disk [ DONT MERGE - may not need if buildCluster is part of pipeline annotations ]

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -9,7 +9,17 @@ const regex = require('./regex');
 const template = require('./template');
 const workflowGraph = require('./workflowGraph');
 const parameters = require('./parameters');
+const scmContext = require('./scmContext');
 
 module.exports = {
-    annotations, base, command, commandFormat, job, regex, template, workflowGraph, parameters
+    annotations,
+    base,
+    command,
+    commandFormat,
+    job,
+    regex,
+    template,
+    workflowGraph,
+    parameters,
+    scmContext
 };

--- a/config/scmContext.js
+++ b/config/scmContext.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Joi = require('joi');
+
+const SCM_CONTEXT_STRING = Joi
+    .string()
+    .max(128)
+    .required()
+    .description('The SCM in which the repository exists')
+    .example('github:github.com');
+
+module.exports = {
+    name: SCM_CONTEXT_STRING
+};

--- a/migrations/20191105-add_buildClusterName_column_to_pipelines.js
+++ b/migrations/20191105-add_buildClusterName_column_to_pipelines.js
@@ -1,0 +1,14 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}pipelines`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.addColumn(table, 'baseBranch', {
+            type: Sequelize.STRING(50)
+        });
+    }
+};

--- a/migrations/20191105-add_buildClusterName_column_to_pipelines.js
+++ b/migrations/20191105-add_buildClusterName_column_to_pipelines.js
@@ -7,7 +7,7 @@ const table = `${prefix}pipelines`;
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {
-        await queryInterface.addColumn(table, 'baseBranch', {
+        await queryInterface.addColumn(table, 'buildClusterName', {
             type: Sequelize.STRING(50)
         });
     }

--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -3,7 +3,7 @@
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Command = require('../config/command');
-const scmContext = Joi.reach(require('./pipeline').base, 'scmContext');
+const ScmContext = require('../config/scmContext');
 const scmOrganization = Joi
     .string().max(100)
     .description('SCM organization name')
@@ -26,7 +26,7 @@ const MODEL = {
         .description('Description of the build cluster')
         .example('Build cluster for iOS team'),
 
-    scmContext,
+    scmContext: ScmContext.name,
 
     scmOrganizations: Joi.array().items(scmOrganization),
 

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -8,6 +8,8 @@ const Scm = require('../core/scm');
 const WorkflowGraph = require('../config/workflowGraph');
 const Parameters = require('../config/parameters');
 const mutate = require('../lib/mutate');
+const ScmContext = require('../config/scmContext');
+const buildClusterName = Joi.reach(require('./buildCluster').base, 'name');
 
 const CREATE_MODEL = {
     checkoutUrl: Joi
@@ -34,12 +36,9 @@ const MODEL = {
         .example('github.com:123456:master')
         .example('github.com:123456:master:src/app/component'),
 
-    scmContext: Joi
-        .string().max(128)
-        .description('The SCM in which the repository exists')
-        .example('github:github.com'),
-
     scmRepo: Scm.repo,
+
+    scmContext: ScmContext.name,
 
     createTime: Joi
         .string()
@@ -76,7 +75,9 @@ const MODEL = {
     prChain: Base.prChain
         .description('Configuration of chainPR'),
 
-    parameters: Parameters.parameters
+    parameters: Parameters.parameters,
+
+    buildClusterName
 };
 
 module.exports = {
@@ -99,7 +100,7 @@ module.exports = {
     ], [
         'workflowGraph', 'scmRepo', 'annotations', 'lastEventId',
         'configPipelineId', 'childPipelines', 'name', 'prChain',
-        'parameters'
+        'parameters', 'buildClusterName'
     ])).label('Get Pipeline'),
 
     /**

--- a/test/config/scmContext.test.js
+++ b/test/config/scmContext.test.js
@@ -4,9 +4,9 @@ const Joi = require('joi');
 const assert = require('chai').assert;
 const config = require('../../').config;
 
-describe('config parameters', () => {
-    describe('parameters', () => {
-        it('validates parameters', () => {
+describe('config scm context', () => {
+    describe('scm context', () => {
+        it('validates scm context', () => {
             assert.isNull(Joi.validate('github:github.com', config.scmContext.name).error);
         });
     });

--- a/test/config/scmContext.test.js
+++ b/test/config/scmContext.test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const Joi = require('joi');
+const assert = require('chai').assert;
+const config = require('../../').config;
+
+describe('config parameters', () => {
+    describe('parameters', () => {
+        it('validates parameters', () => {
+            assert.isNull(Joi.validate('github:github.com', config.scmContext.name).error);
+        });
+    });
+});

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -25,4 +25,4 @@ childPipelines:
         - git@github.com:org/repo.git
         - https://github.com:org/repo2.git
     startAll: true
-buildClusterName: test
+buildClusterName: east2

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -25,3 +25,4 @@ childPipelines:
         - git@github.com:org/repo.git
         - https://github.com:org/repo2.git
     startAll: true
+buildClusterName: test


### PR DESCRIPTION
## Context

All builds in the pipeline should be automatically sent to the build cluster assigned at pipeline creation time

## Objective

Add buildClusterName column to pipelines table

## References

[1830](https://github.com/screwdriver-cd/screwdriver/issues/1830)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
