### PR TITLE
fix(1824): add missing unique keys and update id column type

### DIFF
--- a/migrations/20190919-initdb-banners.js
+++ b/migrations/20190919-initdb-banners.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 message: {
                     type: Sequelize.STRING(512)

--- a/migrations/20190919-initdb-buildClusters.js
+++ b/migrations/20190919-initdb-buildClusters.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 name: {
                     type: Sequelize.STRING(50)

--- a/migrations/20190919-initdb-builds.js
+++ b/migrations/20190919-initdb-builds.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 environment: {
                     type: Sequelize.TEXT

--- a/migrations/20190919-initdb-collections.js
+++ b/migrations/20190919-initdb-collections.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 userId: {
                     type: Sequelize.DOUBLE

--- a/migrations/20190919-initdb-commandTags.js
+++ b/migrations/20190919-initdb-commandTags.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 namespace: {
                     type: Sequelize.STRING(64)

--- a/migrations/20190919-initdb-commands.js
+++ b/migrations/20190919-initdb-commands.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 namespace: {
                     type: Sequelize.STRING(64)

--- a/migrations/20190919-initdb-events.js
+++ b/migrations/20190919-initdb-events.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 causeMessage: {
                     type: Sequelize.STRING(512)

--- a/migrations/20190919-initdb-jobs.js
+++ b/migrations/20190919-initdb-jobs.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 name: {
                     type: Sequelize.STRING(110)

--- a/migrations/20190919-initdb-pipelines.js
+++ b/migrations/20190919-initdb-pipelines.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 scmUri: {
                     type: Sequelize.STRING(128)

--- a/migrations/20190919-initdb-secrets.js
+++ b/migrations/20190919-initdb-secrets.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 pipelineId: {
                     type: Sequelize.DOUBLE

--- a/migrations/20190919-initdb-steps.js
+++ b/migrations/20190919-initdb-steps.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 buildId: {
                     type: Sequelize.DOUBLE

--- a/migrations/20190919-initdb-templateTags.js
+++ b/migrations/20190919-initdb-templateTags.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 name: {
                     type: Sequelize.STRING(64)

--- a/migrations/20190919-initdb-templates.js
+++ b/migrations/20190919-initdb-templates.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 labels: {
                     type: Sequelize.TEXT

--- a/migrations/20190919-initdb-tokens.js
+++ b/migrations/20190919-initdb-tokens.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 hash: {
                     type: Sequelize.STRING(86)

--- a/migrations/20190919-initdb-triggers.js
+++ b/migrations/20190919-initdb-triggers.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 src: {
                     type: Sequelize.STRING(64)

--- a/migrations/20190919-initdb-users.js
+++ b/migrations/20190919-initdb-users.js
@@ -13,7 +13,7 @@ module.exports = {
                     allowNull: false,
                     autoIncrement: true,
                     primaryKey: true,
-                    type: Sequelize.INTEGER
+                    type: Sequelize.INTEGER.UNSIGNED
                 },
                 username: {
                     type: Sequelize.STRING(128)

--- a/migrations/20191111-add_uniquekey_to_collections.js
+++ b/migrations/20191111-add_uniquekey_to_collections.js
@@ -9,17 +9,13 @@ module.exports = {
     // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
         try {
-            await queryInterface.removeConstraint(table, `${table}_userId_name_key`);
-            // eslint-disable-next-line no-empty
-        } catch (e) {}
-        await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addConstraint(table, ['userId', 'name'],
                 {
                     name: `${table}_userId_name_key`,
-                    type: 'unique',
-                    transaction
+                    type: 'unique'
                 }
             );
-        });
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
     }
 };

--- a/migrations/20191111-add_uniquekey_to_collections.js
+++ b/migrations/20191111-add_uniquekey_to_collections.js
@@ -8,6 +8,10 @@ const table = `${prefix}collections`;
 module.exports = {
     // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
+        try {
+            await queryInterface.removeConstraint(table, `${table}_userId_name_key`);
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
         await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addConstraint(table, ['userId', 'name'],
                 {

--- a/migrations/20191111-add_uniquekey_to_collections.js
+++ b/migrations/20191111-add_uniquekey_to_collections.js
@@ -1,0 +1,21 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}collections`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.addConstraint(table, ['userId', 'name'],
+                {
+                    name: `${table}_userId_name_key`,
+                    type: 'unique',
+                    transaction
+                }
+            );
+        });
+    }
+};

--- a/migrations/20191111-add_uniquekey_to_commandTags.js
+++ b/migrations/20191111-add_uniquekey_to_commandTags.js
@@ -8,6 +8,10 @@ const table = `${prefix}commandTags`;
 module.exports = {
     // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
+        try {
+            await queryInterface.removeConstraint(table, `${table}_namespace_name_tag_key`);
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
         await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addConstraint(table, ['namespace', 'name', 'tag'],
                 {

--- a/migrations/20191111-add_uniquekey_to_commandTags.js
+++ b/migrations/20191111-add_uniquekey_to_commandTags.js
@@ -1,0 +1,21 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}commandTags`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.addConstraint(table, ['namespace', 'name', 'tag'],
+                {
+                    name: `${table}_namespace_name_tag_key`,
+                    type: 'unique',
+                    transaction
+                }
+            );
+        });
+    }
+};

--- a/migrations/20191111-add_uniquekey_to_commandTags.js
+++ b/migrations/20191111-add_uniquekey_to_commandTags.js
@@ -9,17 +9,13 @@ module.exports = {
     // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
         try {
-            await queryInterface.removeConstraint(table, `${table}_namespace_name_tag_key`);
-            // eslint-disable-next-line no-empty
-        } catch (e) {}
-        await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addConstraint(table, ['namespace', 'name', 'tag'],
                 {
                     name: `${table}_namespace_name_tag_key`,
-                    type: 'unique',
-                    transaction
+                    type: 'unique'
                 }
             );
-        });
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
     }
 };

--- a/migrations/20191111-add_uniquekey_to_commands.js
+++ b/migrations/20191111-add_uniquekey_to_commands.js
@@ -8,6 +8,10 @@ const table = `${prefix}commands`;
 module.exports = {
     // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
+        try {
+            await queryInterface.removeConstraint(table, `${table}_namespace_version_name_key`);
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
         await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addConstraint(table, ['namespace', 'version', 'name'],
                 {

--- a/migrations/20191111-add_uniquekey_to_commands.js
+++ b/migrations/20191111-add_uniquekey_to_commands.js
@@ -1,0 +1,21 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}commands`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.addConstraint(table, ['namespace', 'version', 'name'],
+                {
+                    name: `${table}_namespace_version_name_key`,
+                    type: 'unique',
+                    transaction
+                }
+            );
+        });
+    }
+};

--- a/migrations/20191111-add_uniquekey_to_commands.js
+++ b/migrations/20191111-add_uniquekey_to_commands.js
@@ -9,17 +9,13 @@ module.exports = {
     // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
         try {
-            await queryInterface.removeConstraint(table, `${table}_namespace_version_name_key`);
-            // eslint-disable-next-line no-empty
-        } catch (e) {}
-        await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addConstraint(table, ['namespace', 'version', 'name'],
                 {
                     name: `${table}_namespace_version_name_key`,
-                    type: 'unique',
-                    transaction
+                    type: 'unique'
                 }
             );
-        });
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
     }
 };


### PR DESCRIPTION
## Context

sequelize-cli migration files are 1. missing unique keys in collections, commands, commandTags tables and 2. ID column in MySQL is int(11) instead of int(10) unsigned 

## Objective

This PR addresses missing unique keys in collections, commands, commandTags tables, and ID column type change from Integer to Integer.UNSIGNED for MySQL

## References

[1824](https://github.com/screwdriver-cd/screwdriver/issues/1824)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
