### PR TITLE
fix: increasing SourcePath char limit to 1024

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -141,7 +141,7 @@ const SCHEMA_FREEZEWINDOWS = Joi.alternatives().try(
     Joi.array().items(SCHEMA_CRON_EXPRESSION),
     SCHEMA_CRON_EXPRESSION
 );
-const SCHEMA_SOURCEPATH = Joi.string().max(100).optional();
+const SCHEMA_SOURCEPATH = Joi.string().max(1024).optional();
 const SCHEMA_SOURCEPATHS = Joi.alternatives().try(
     Joi.array().items(SCHEMA_SOURCEPATH),
     SCHEMA_SOURCEPATH


### PR DESCRIPTION

## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Currently the filename limit for SourcePath is set to 100 and thus validation fails when we try to use a filename which is greater than 100 characters.  Requesting an increase to 1024 characters.
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
PR fixes the filename character limit

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
