### PR TITLE
feat(1881): build cluster to support multple scm conexts

### DIFF
--- a/migrations/20191214-rename_scmContext-buildClusters.js
+++ b/migrations/20191214-rename_scmContext-buildClusters.js
@@ -1,0 +1,32 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}buildClusters`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        try {
+            await queryInterface.sequelize.query('SET SQL_MODE = CONCAT(@@SQL_MODE, ' +
+                '\',ANSI_QUOTES\')');
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
+
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.changeColumn(table, 'scmContext', Sequelize.TEXT('medium'),
+                { transaction });
+            await queryInterface.renameColumn(table, 'scmContext', 'scmContexts',
+                { transaction });
+            await queryInterface.sequelize.query(`UPDATE "${table}"
+                SET "scmContexts" = CONCAT('["', "scmContexts", '"]')`,
+            { transaction });
+        });
+
+        try {
+            await queryInterface.sequelize.query('SET SQL_MODE = REPLACE(@@SQL_MODE, ' +
+                '\'ANSI_QUOTES\', \'\')');
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
+    }
+};

--- a/migrations/20191214-rename_scmContext-buildClusters.js
+++ b/migrations/20191214-rename_scmContext-buildClusters.js
@@ -9,7 +9,7 @@ module.exports = {
     up: async (queryInterface, Sequelize) => {
         try {
             await queryInterface.sequelize.query('SET SQL_MODE = CONCAT(@@SQL_MODE, ' +
-                '\',ANSI_QUOTES\')');
+                '\',ANSI_QUOTES,PIPES_AS_CONCAT\')');
             // eslint-disable-next-line no-empty
         } catch (e) {}
 
@@ -19,13 +19,19 @@ module.exports = {
             await queryInterface.renameColumn(table, 'scmContext', 'scmContexts',
                 { transaction });
             await queryInterface.sequelize.query(`UPDATE "${table}"
-                SET "scmContexts" = CONCAT('["', "scmContexts", '"]')`,
+                SET "scmContexts" = '["' ||  "scmContexts" || '"]' `,
             { transaction });
         });
 
         try {
             await queryInterface.sequelize.query('SET SQL_MODE = REPLACE(@@SQL_MODE, ' +
                 '\'ANSI_QUOTES\', \'\')');
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
+
+        try {
+            await queryInterface.sequelize.query('SET SQL_MODE = REPLACE(@@SQL_MODE, ' +
+                '\'PIPES_AS_CONCAT\', \'\')');
             // eslint-disable-next-line no-empty
         } catch (e) {}
     }

--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -26,7 +26,7 @@ const MODEL = {
         .description('Description of the build cluster')
         .example('Build cluster for iOS team'),
 
-    scmContext,
+    scmContexts: Joi.array().items(scmContext),
 
     scmOrganizations: Joi.array().items(scmOrganization),
 
@@ -66,7 +66,7 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(mutate(MODEL, [
-        'id', 'name', 'scmContext', 'scmOrganizations', 'isActive',
+        'id', 'name', 'scmContexts', 'scmOrganizations', 'isActive',
         'managedByScrewdriver', 'maintainer', 'weightage'
     ], [
         'description'
@@ -90,7 +90,7 @@ module.exports = {
      * @type {Joi}
      */
     create: Joi.object(mutate(MODEL, [
-        'name', 'scmOrganizations', 'managedByScrewdriver', 'maintainer'
+        'name', 'scmContexts', 'scmOrganizations', 'managedByScrewdriver', 'maintainer'
     ], [
         'description', 'isActive', 'weightage'
     ])).label('Create Build'),

--- a/test/data/buildCluster.create.full.yaml
+++ b/test/data/buildCluster.create.full.yaml
@@ -1,6 +1,7 @@
 # BuildCluster create example
 name: iOS
 description: 'Build cluster for iOS team'
+scmContexts: ['github:github.com']
 scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false

--- a/test/data/buildCluster.create.full.yaml
+++ b/test/data/buildCluster.create.full.yaml
@@ -1,7 +1,7 @@
 # BuildCluster create example
 name: iOS
 description: 'Build cluster for iOS team'
-scmContexts: ['github:github.com']
+scmContexts: ['github:github.com', 'github:github.co.jp']
 scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false

--- a/test/data/buildCluster.create.yaml
+++ b/test/data/buildCluster.create.yaml
@@ -1,6 +1,6 @@
 # BuildCluster create example
 name: iOS
-scmContexts: ['github:github.com', 'github:git.com']
+scmContexts: ['github:github.com', 'github:github.co.jp']
 scmOrganizations: [screwdriver-cd]
 managedByScrewdriver: false
 maintainer: foo@bar.com

--- a/test/data/buildCluster.create.yaml
+++ b/test/data/buildCluster.create.yaml
@@ -1,5 +1,6 @@
 # BuildCluster create example
 name: iOS
+scmContexts: ['github:github.com', 'github:git.com']
 scmOrganizations: [screwdriver-cd]
 managedByScrewdriver: false
 maintainer: foo@bar.com

--- a/test/data/buildCluster.get.yaml
+++ b/test/data/buildCluster.get.yaml
@@ -2,7 +2,7 @@
 id: 1
 name: iOS
 description: 'Build cluster for iOS team'
-scmContext: 'github:github.com'
+scmContexts: ['github:github.com']
 scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false

--- a/test/data/buildCluster.get.yaml
+++ b/test/data/buildCluster.get.yaml
@@ -2,7 +2,7 @@
 id: 1
 name: iOS
 description: 'Build cluster for iOS team'
-scmContexts: ['github:github.com']
+scmContexts: ['github:github.com', 'github:github.co.jp']
 scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false

--- a/test/data/buildCluster.yaml
+++ b/test/data/buildCluster.yaml
@@ -1,7 +1,7 @@
 id: 1
 name: iOS
 description: 'Build cluster for iOS team'
-scmContext: 'github:github.com'
+scmContexts: ['github:github.com']
 scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false

--- a/test/data/buildCluster.yaml
+++ b/test/data/buildCluster.yaml
@@ -1,7 +1,7 @@
 id: 1
 name: iOS
 description: 'Build cluster for iOS team'
-scmContexts: ['github:github.com']
+scmContexts: ['github:github.com', 'github:github.co.jp']
 scmOrganizations: [screwdriver-cd]
 isActive: true
 managedByScrewdriver: false


### PR DESCRIPTION
## Context

Build cluster supports only one SCM context, which leads to error "This pipeline is not authorized to use this build cluster." if the same build cluster is used for different SCM context.

## Objective

This PR is intended for a build cluster to support multiple SCM contexts

## References

[1881](https://github.com/screwdriver-cd/screwdriver/issues/1881)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
