### PR TITLE
fix(1839): Add enqueueTime to start schema

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -36,7 +36,8 @@ const SCHEMA_START = Joi.object().keys({
     apiUri: Joi.string().uri().required()
         .label('API URI'),
     token: Joi.string().required()
-        .label('Build JWT')
+        .label('Build JWT'),
+    enqueueTime: Joi.date().iso()
 }).required();
 const SCHEMA_STOP = Joi.object().keys({
     annotations: Annotations.annotations,


### PR DESCRIPTION
## Context

Add enqueueTime to get the time when build was pushed to queue

## Objective

This field will be used for comparing runtime of build with timeout

## References

https://github.com/screwdriver-cd/screwdriver/issues/1839

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
