### PR TITLE
fix(1881): revert build cluster multiple scmcontext changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Screwdriver Data Schema
+# Screwdriver Data  Schema
 [![Version][npm-image]][npm-url] ![Downloads][downloads-image] [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url] [![Dependency Status][daviddm-image]][daviddm-url] ![License][license-image]
 
 > Internal data schema of [Screwdriver](https://github.com/screwdriver-cd/screwdriver)


### PR DESCRIPTION
## Context

Screwdriver api failing to start with key null error. Locally it works as expected, but on the server, it fails.

## Objective

Reverting build cluster multiple scmContexts changes to see if that addresses the issue

## References

[1881](https://github.com/screwdriver-cd/screwdriver/issues/1881)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
