### PR TITLE
fix(1881): add scmContext constraint and fix #1710

### DIFF
--- a/migrations/20191221-add-column-builds-parentBuilds.js
+++ b/migrations/20191221-add-column-builds-parentBuilds.js
@@ -1,0 +1,15 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}builds`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.addColumn(table, 'parentBuilds', {
+                type: Sequelize.TEXT('medium') }, { transaction });
+        });
+    }
+};

--- a/migrations/20191221-upd-buildClusters-uniqueconstraint.js
+++ b/migrations/20191221-upd-buildClusters-uniqueconstraint.js
@@ -1,0 +1,23 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}buildClusters`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.removeConstraint(table, `${table}_name_key`, transaction);
+
+            await queryInterface.addConstraint(table, ['name', 'scmContext'],
+                {
+                    name: `${table}_name_scmContext_key`,
+                    type: 'unique',
+                    transaction
+                }
+            );
+        });
+    }
+};

--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -101,7 +101,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['name'],
+    keys: ['name', 'scmContext'],
 
     /**
      * List of all fields in the model

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -49,3 +49,7 @@ steps:
         code: 0
         startTime: "2038-01-19T03:15:09.115Z"
         endTime: "2038-01-19T03:15:10.130Z"
+parentBuilds: {
+    111: { eventId: 2, jobs: { jobA: 333, jobB: 444 } },
+    222: { eventId: 3, jobs: { jobC: 555 } }
+}

--- a/test/models/buildCluster.test.js
+++ b/test/models/buildCluster.test.js
@@ -45,4 +45,26 @@ describe('model buildCluster', () => {
             assert.isNotNull(validate('empty.yaml', models.buildCluster.get).error);
         });
     });
+
+    describe('keys', () => {
+        it('has the correct keys', () => {
+            const expectedKeys = ['name', 'scmContext'];
+
+            expectedKeys.forEach((keyName) => {
+                assert.include(models.buildCluster.keys, keyName,
+                    `Key name ${keyName} not included`);
+            });
+        });
+    });
+
+    describe('indexes', () => {
+        it('defines the correct indexes', () => {
+            const expected = [{ fields: ['name'] }];
+            const indexes = models.buildCluster.indexes;
+
+            expected.forEach((indexName) => {
+                assert.include(indexes, indexName, `Index name ${indexName} not included`);
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Context

Build cluster supports only one SCM context, which leads to error "This pipeline is not authorized to use this build cluster." if the same build cluster is used for different SCM context.

parentBuilds column missing in builds migrations file

## Objective

This PR updates the unique constraint from name to a combination of name and scmContext. Random active build cluster assignment will be based on the combination of name and scmContext. Add parentBuilds column to the builds migration file.

## References

[1881](https://github.com/screwdriver-cd/screwdriver/issues/1881)
[1710](https://github.com/screwdriver-cd/screwdriver/issues/1710)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.