### PR TITLE
fix(1710): Update workflowGraph to allow external join trigger

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -121,7 +121,10 @@ const SCHEMA_TEMPLATE = Joi.string().regex(Regex.FULL_TEMPLATE_NAME);
 // ~commit, ~commit:staging, ~commit:/^user-.*$/, ~pr, etc.
 const SCHEMA_TRIGGER = sdJoi.string().regex(Regex.TRIGGER).branchFilter();
 const SCHEMA_INTERNAL_TRIGGER = Joi.string().regex(Regex.INTERNAL_TRIGGER); // ~main, ~jobOne
-const SCHEMA_EXTERNAL_TRIGGER = Joi.string().regex(Regex.EXTERNAL_TRIGGER); // ~sd@123:main
+const SCHEMA_EXTERNAL_TRIGGER = Joi.alternatives().try(
+    Joi.string().regex(Regex.EXTERNAL_TRIGGER).max(64),
+    Joi.string().regex(Regex.EXTERNAL_TRIGGER_AND).max(64))
+    .example('~sd@1234:component'); // ~sd@123:main or sd@123:main
 const SCHEMA_CRON_EXPRESSION = Cron.string().cron();
 const SCHEMA_REQUIRES_VALUE = Joi.alternatives().try(
     SCHEMA_INTERNAL_TRIGGER, SCHEMA_JOBNAME, SCHEMA_TRIGGER);
@@ -206,5 +209,6 @@ module.exports = {
     template: SCHEMA_TEMPLATE,
     requiresValue: SCHEMA_REQUIRES_VALUE,
     jobName: SCHEMA_JOBNAME,
+    externalTrigger: SCHEMA_EXTERNAL_TRIGGER,
     trigger: SCHEMA_TRIGGER
 };

--- a/config/workflowGraph.js
+++ b/config/workflowGraph.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Joi = require('joi');
-const { jobName, requiresValue } = require('../config/job');
+const { externalTrigger, jobName, requiresValue } = require('../config/job');
 
 const SCHEMA_WORKFLOW_GRAPH = Joi.object().keys({
     nodes: Joi.array().items(Joi.object().keys({
@@ -9,7 +9,8 @@ const SCHEMA_WORKFLOW_GRAPH = Joi.object().keys({
     }).unknown()),
     edges: Joi.array().items(Joi.object().keys({
         src: requiresValue,
-        dest: jobName
+        dest: Joi.alternatives().try(
+            externalTrigger, jobName)
     }).unknown())
 });
 

--- a/test/data/config.workflowGraph.yaml
+++ b/test/data/config.workflowGraph.yaml
@@ -2,8 +2,16 @@ nodes:
     - name: ~commit
     - name: main
     - name: publish
+    - name: sd@123:publish
+    - name: sd@333:E
+    - name: G
 edges:
     - src: ~commit
       dest: main
     - src: main
       dest: publish
+    - src: sd@123:publish
+      dest: sd@333:E
+    - src: sd@333:E
+      dest: G
+      join: true


### PR DESCRIPTION
## Context

Workflow graph should allow dest that look like external triggers (ie: `sd@123:main`).

## Objective

This PR allows external triggers for src/dest in workflow graph.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
