### PR TITLE
fix(1710): Allow null for parentBuilds ids

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -36,11 +36,11 @@ const MODEL = {
     parentBuilds: Joi
         .object()
         .pattern(/\d/, Joi.object({
-            eventId: ID,
-            jobs: Joi.object().pattern(Regex.JOB_NAME, ID)
+            eventId: ID.allow(null),
+            jobs: Joi.object().pattern(Regex.JOB_NAME, ID.allow(null))
         }))
         .example({
-            111: { eventId: 2, jobs: { jobA: 333, jobB: 444 } },
+            111: { eventId: 2, jobs: { jobA: 333, jobB: null } },
             222: { eventId: 3, jobs: { jobC: 555 } }
         }),
 

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -12,10 +12,10 @@ stats:
   imagePullStartTime: '2017-01-06T02:49:50.384359267Z'
 parentBuilds:
   111:
-    eventId: 1
+    eventId: null
     jobs:
         component: 666
-        deploy: 777
+        deploy: null
   222:
     eventId: 2
     jobs:


### PR DESCRIPTION
## Context

When adding default parentBuilds values, we put `null` in the place of IDs (https://github.com/screwdriver-cd/screwdriver/blob/06eb9ddf80495edc74f44e3261c65e6546d8b81c/plugins/builds/index.js#L409-L413). This is currently causing external parallel fork join builds to fail with this error:
```
[request,server,error] data: Error: "List of builds" at position 0 fails because [child "parentBuilds" fails because [child "1093" fails because [child "eventId" fails because ["eventId" must be a number]]]]
```

## Objective

This PR allows null for parentBuilds IDs.

## References

Fix: https://github.com/hapijs/joi/issues/504
Related to: https://github.com/screwdriver-cd/screwdriver/issues/1710

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
