### PR TITLE
fix: Allow null or number for id in parentBuilds

### DIFF
--- a/models/build.js
+++ b/models/build.js
@@ -8,6 +8,7 @@ const Job = require('../config/job');
 const Step = require('./step');
 const ID = Joi.number().integer().positive();
 const PARENT_BUILD_ID = ID;
+const PARENT_BUILDS_ID = Joi.alternatives().try(ID, Joi.valid(null));
 const buildClusterName = Joi.reach(require('./buildCluster').base, 'name');
 
 const MODEL = {
@@ -36,8 +37,8 @@ const MODEL = {
     parentBuilds: Joi
         .object()
         .pattern(/\d/, Joi.object({
-            eventId: ID.allow(null),
-            jobs: Joi.object().pattern(Regex.JOB_NAME, ID.allow(null))
+            eventId: PARENT_BUILDS_ID,
+            jobs: Joi.object().pattern(Regex.JOB_NAME, PARENT_BUILDS_ID)
         }))
         .example({
             111: { eventId: 2, jobs: { jobA: 333, jobB: null } },


### PR DESCRIPTION
## Context

Does not seem possible to add `.allow(null)` to a `Joi.number()`.

## Objective

This PR changes the ID to allow for number or null.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
