### PR TITLE
fix(1865): [3] Remove steps column in builds table

### DIFF
--- a/migrations/20200114-del-column-builds-steps.js
+++ b/migrations/20200114-del-column-builds-steps.js
@@ -13,3 +13,4 @@ module.exports = {
         });
     }
 };
+

--- a/migrations/20200114-del-column-builds-steps.js
+++ b/migrations/20200114-del-column-builds-steps.js
@@ -8,9 +8,10 @@ const table = `${prefix}builds`;
 module.exports = {
     // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
-        await queryInterface.sequelize.transaction(async (transaction) => {
-            await queryInterface.removeColumn(table, 'steps', { transaction });
-        });
+        try {
+            await queryInterface.removeColumn(table, 'steps');
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
     }
 };
 

--- a/migrations/20200114-del-column-builds-steps.js
+++ b/migrations/20200114-del-column-builds-steps.js
@@ -1,0 +1,15 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}builds`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.removeColumn(table, 'steps', { transaction });
+        });
+    }
+};

--- a/models/build.js
+++ b/models/build.js
@@ -92,6 +92,10 @@ const MODEL = {
         .default({})
         .description('Key=>Value information from the build itself'),
 
+    steps: Joi
+        .array().items(Step.get)
+        .description('List of steps'),
+
     status: Joi
         .string().valid([
             'ABORTED',

--- a/models/build.js
+++ b/models/build.js
@@ -92,10 +92,6 @@ const MODEL = {
         .default({})
         .description('Key=>Value information from the build itself'),
 
-    steps: Joi
-        .array().items(Step.get)
-        .description('List of steps'),
-
     status: Joi
         .string().valid([
             'ABORTED',
@@ -149,9 +145,14 @@ const environmentSchema = Joi
         Job.environment
     );
 
+const stepsSchema = Joi
+    .array().items(Step.get)
+    .description('List of steps');
+
 const GET_MODEL = Object.assign({}, MODEL, {
     parentBuildId: parentBuildIdSchema,
-    environment: environmentSchema
+    environment: environmentSchema,
+    steps: stepsSchema
 });
 
 module.exports = {

--- a/models/build.js
+++ b/models/build.js
@@ -92,10 +92,6 @@ const MODEL = {
         .default({})
         .description('Key=>Value information from the build itself'),
 
-    steps: Joi
-        .array().items(Step.get)
-        .description('List of steps'),
-
     status: Joi
         .string().valid([
             'ABORTED',

--- a/test/data/build.get.yaml
+++ b/test/data/build.get.yaml
@@ -21,5 +21,30 @@ parentBuilds:
     jobs:
         component: 888
         deploy: 999
+steps:
+    -
+        name: sd-setup
+        command: "git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci"
+        code: 0
+        startTime: "2038-01-19T03:15:08.131Z"
+        endTime: "2038-01-19T03:15:08.532Z"
+    -
+        name: install
+        command: "npm install"
+        code: 1
+        startTime: "2038-01-19T03:15:08.532Z"
+        endTime: "2038-01-19T03:15:09.114Z"
+    -
+        name: test
+        command: "npm test"
+    -
+        name: publish
+        command: "./ci/publish.sh"
+    -
+        name: sd-cleanup
+        command: "./ci/cleanup.sh"
+        code: 0
+        startTime: "2038-01-19T03:15:09.115Z"
+        endTime: "2038-01-19T03:15:10.130Z"
 environment:
   FOO: 'BAR'

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -24,31 +24,7 @@ parameters:
 meta:
     coverage: 99.54
 status: FAILURE
-steps:
-    -
-        name: sd-setup
-        command: "git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci"
-        code: 0
-        startTime: "2038-01-19T03:15:08.131Z"
-        endTime: "2038-01-19T03:15:08.532Z"
-    -
-        name: install
-        command: "npm install"
-        code: 1
-        startTime: "2038-01-19T03:15:08.532Z"
-        endTime: "2038-01-19T03:15:09.114Z"
-    -
-        name: test
-        command: "npm test"
-    -
-        name: publish
-        command: "./ci/publish.sh"
-    -
-        name: sd-cleanup
-        command: "./ci/cleanup.sh"
-        code: 0
-        startTime: "2038-01-19T03:15:09.115Z"
-        endTime: "2038-01-19T03:15:10.130Z"
+
 parentBuilds: {
     111: { eventId: 2, jobs: { jobA: 333, jobB: 444 } },
     222: { eventId: 3, jobs: { jobC: 555 } }

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -24,31 +24,6 @@ parameters:
 meta:
     coverage: 99.54
 status: FAILURE
-steps:
-    -
-        name: sd-setup
-        command: "git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci"
-        code: 0
-        startTime: "2038-01-19T03:15:08.131Z"
-        endTime: "2038-01-19T03:15:08.532Z"
-    -
-        name: install
-        command: "npm install"
-        code: 1
-        startTime: "2038-01-19T03:15:08.532Z"
-        endTime: "2038-01-19T03:15:09.114Z"
-    -
-        name: test
-        command: "npm test"
-    -
-        name: publish
-        command: "./ci/publish.sh"
-    -
-        name: sd-cleanup
-        command: "./ci/cleanup.sh"
-        code: 0
-        startTime: "2038-01-19T03:15:09.115Z"
-        endTime: "2038-01-19T03:15:10.130Z"
 parentBuilds: {
     111: { eventId: 2, jobs: { jobA: 333, jobB: 444 } },
     222: { eventId: 3, jobs: { jobC: 555 } }

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -24,6 +24,31 @@ parameters:
 meta:
     coverage: 99.54
 status: FAILURE
+steps:
+    -
+        name: sd-setup
+        command: "git clone https://gist.github.com/3d2388b2a7ba658cdcdaffa8cd874e50.git ci"
+        code: 0
+        startTime: "2038-01-19T03:15:08.131Z"
+        endTime: "2038-01-19T03:15:08.532Z"
+    -
+        name: install
+        command: "npm install"
+        code: 1
+        startTime: "2038-01-19T03:15:08.532Z"
+        endTime: "2038-01-19T03:15:09.114Z"
+    -
+        name: test
+        command: "npm test"
+    -
+        name: publish
+        command: "./ci/publish.sh"
+    -
+        name: sd-cleanup
+        command: "./ci/cleanup.sh"
+        code: 0
+        startTime: "2038-01-19T03:15:09.115Z"
+        endTime: "2038-01-19T03:15:10.130Z"
 parentBuilds: {
     111: { eventId: 2, jobs: { jobA: 333, jobB: 444 } },
     222: { eventId: 3, jobs: { jobC: 555 } }


### PR DESCRIPTION
## Context
As mentioned here screwdriver-cd/screwdriver#1865 , builds.steps and steps.command are both same data.
And these steps are defined by user's yaml and it tends to have a big size.

## Objective
Create migration file which removes steps column in builds table, because we fixed not to use steps column.

## References
- https://github.com/screwdriver-cd/models/pull/423
- https://github.com/screwdriver-cd/screwdriver/issues/1865

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
