### PR TITLE
feat(1091): add template data into jobs

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -34,7 +34,8 @@ const SCHEMA_JOB_PERMUTATION = Joi.object()
         secrets: Job.secrets,
         settings: Job.settings,
         sourcePaths: Job.sourcePaths,
-        freezeWindows: Job.freezeWindows
+        freezeWindows: Job.freezeWindows,
+        templateDetails: Job.templateDetails
     }).label('Job permutation');
 
 const SCHEMA_JOB_PERMUTATIONS = Joi.array().items(SCHEMA_JOB_PERMUTATION)

--- a/config/job.js
+++ b/config/job.js
@@ -124,7 +124,7 @@ const SCHEMA_TEMPLATE_DETAILS = Joi.object({
     version: Joi.string()
 })
     .description('Information about the template that is used by the job')
-    .example({ name: "gridci-6_10_3", namespace: "HadoopTools", version: "1.0.0" })
+    .example({ name: 'gridci-6_10_3', namespace: 'HadoopTools', version: '1.0.0' })
 // ~commit, ~commit:staging, ~commit:/^user-.*$/, ~pr, etc.
 const SCHEMA_TRIGGER = sdJoi.string().regex(Regex.TRIGGER).branchFilter();
 const SCHEMA_INTERNAL_TRIGGER = Joi.string().regex(Regex.INTERNAL_TRIGGER); // ~main, ~jobOne

--- a/config/job.js
+++ b/config/job.js
@@ -118,6 +118,7 @@ const SCHEMA_STEPS_NO_DUPS = Joi.array().items(SCHEMA_STEP).min(1).unique((a, b)
     return Object.keys(a).some(key => b[key]);
 });
 const SCHEMA_TEMPLATE = Joi.string().regex(Regex.FULL_TEMPLATE_NAME);
+const SCHEMA_TEMPLATE_DETAILS = Joi.object();
 // ~commit, ~commit:staging, ~commit:/^user-.*$/, ~pr, etc.
 const SCHEMA_TRIGGER = sdJoi.string().regex(Regex.TRIGGER).branchFilter();
 const SCHEMA_INTERNAL_TRIGGER = Joi.string().regex(Regex.INTERNAL_TRIGGER); // ~main, ~jobOne
@@ -207,6 +208,7 @@ module.exports = {
     step: SCHEMA_STEP,
     steps: SCHEMA_STEPS,
     template: SCHEMA_TEMPLATE,
+    templateDetails: SCHEMA_TEMPLATE_DETAILS,
     requiresValue: SCHEMA_REQUIRES_VALUE,
     jobName: SCHEMA_JOBNAME,
     externalTrigger: SCHEMA_EXTERNAL_TRIGGER,

--- a/config/job.js
+++ b/config/job.js
@@ -124,7 +124,7 @@ const SCHEMA_TEMPLATE_DETAILS = Joi.object({
     version: Joi.string()
 })
     .description('Information about the template that is used by the job')
-    .example({ name: 'gridci-6_10_3', namespace: 'HadoopTools', version: '1.0.0' })
+    .example({ name: 'gridci-6_10_3', namespace: 'HadoopTools', version: '1.0.0' });
 // ~commit, ~commit:staging, ~commit:/^user-.*$/, ~pr, etc.
 const SCHEMA_TRIGGER = sdJoi.string().regex(Regex.TRIGGER).branchFilter();
 const SCHEMA_INTERNAL_TRIGGER = Joi.string().regex(Regex.INTERNAL_TRIGGER); // ~main, ~jobOne

--- a/config/job.js
+++ b/config/job.js
@@ -4,6 +4,7 @@ const Annotations = require('./annotations');
 const Joi = require('joi');
 const Regex = require('./regex');
 const Cron = require('./cronExpression');
+const Template = require('./template');
 
 const SPECIFIC_BRANCH_POS = 4;
 
@@ -119,9 +120,9 @@ const SCHEMA_STEPS_NO_DUPS = Joi.array().items(SCHEMA_STEP).min(1).unique((a, b)
 });
 const SCHEMA_TEMPLATE = Joi.string().regex(Regex.FULL_TEMPLATE_NAME);
 const SCHEMA_TEMPLATE_DETAILS = Joi.object({
-    name: Joi.string(),
-    namespace: Joi.string(),
-    version: Joi.string()
+    name: Template.name,
+    namespace: Template.namespace,
+    version: Template.version
 })
     .description('Information about the template that is used by the job')
     .example({ name: 'gridci-6_10_3', namespace: 'HadoopTools', version: '1.0.0' });

--- a/config/job.js
+++ b/config/job.js
@@ -118,7 +118,13 @@ const SCHEMA_STEPS_NO_DUPS = Joi.array().items(SCHEMA_STEP).min(1).unique((a, b)
     return Object.keys(a).some(key => b[key]);
 });
 const SCHEMA_TEMPLATE = Joi.string().regex(Regex.FULL_TEMPLATE_NAME);
-const SCHEMA_TEMPLATE_DETAILS = Joi.object();
+const SCHEMA_TEMPLATE_DETAILS = Joi.object({
+    name: Joi.string(),
+    namespace: Joi.string(),
+    version: Joi.string()
+})
+    .description('Information about the template that is used by the job')
+    .example({ name: "gridci-6_10_3", namespace: "HadoopTools", version: "1.0.0" })
 // ~commit, ~commit:staging, ~commit:/^user-.*$/, ~pr, etc.
 const SCHEMA_TRIGGER = sdJoi.string().regex(Regex.TRIGGER).branchFilter();
 const SCHEMA_INTERNAL_TRIGGER = Joi.string().regex(Regex.INTERNAL_TRIGGER); // ~main, ~jobOne

--- a/models/job.js
+++ b/models/job.js
@@ -64,18 +64,7 @@ const MODEL = {
         .boolean()
         .description('Flag if the job is archived')
         .example(true)
-        .default(false),
-
-    templateDetails: Joi
-        .object({
-            name: Joi.string(),
-            namespace: Joi.string(),
-            version: Joi.string(),
-            maintainer: Joi.string(),
-            trusted: Joi.string()
-        })
-        .description('Information about the template that is used by the job')
-        .example({ name: "gridci-6_10_3", namespace: "HadoopTools", version: "1.0.0", maintainer: "hadoop@oath.com", trusted: "true" })
+        .default(false)
 };
 
 const EXTENDED_MODEL = {

--- a/models/job.js
+++ b/models/job.js
@@ -64,7 +64,18 @@ const MODEL = {
         .boolean()
         .description('Flag if the job is archived')
         .example(true)
-        .default(false)
+        .default(false),
+
+    templateDetails: Joi
+        .object({
+            name: Joi.string(),
+            namespace: Joi.string(),
+            version: Joi.string(),
+            maintainer: Joi.string(),
+            trusted: Joi.string()
+        })
+        .description('Information about the template that is used by the job')
+        .example({ name: "gridci-6_10_3", namespace: "HadoopTools", version: "1.0.0", maintainer: "hadoop@oath.com", trusted: "true" })
 };
 
 const EXTENDED_MODEL = {
@@ -94,7 +105,7 @@ module.exports = {
     get: Joi.object(mutate(EXTENDED_MODEL, [
         'id', 'pipelineId', 'name', 'state'
     ], [
-        'description', 'permutations', 'archived', 'prParentJobId',
+        'description', 'permutations', 'archived', 'prParentJobId', 'templateDetails',
         // job enable/disable state change
         'stateChanger', 'stateChangeTime', 'stateChangeMessage',
         // possible extended fields for pull/merge request info from scm

--- a/models/job.js
+++ b/models/job.js
@@ -94,7 +94,7 @@ module.exports = {
     get: Joi.object(mutate(EXTENDED_MODEL, [
         'id', 'pipelineId', 'name', 'state'
     ], [
-        'description', 'permutations', 'archived', 'prParentJobId', 'templateDetails',
+        'description', 'permutations', 'archived', 'prParentJobId',
         // job enable/disable state change
         'stateChanger', 'stateChangeTime', 'stateChangeMessage',
         // possible extended fields for pull/merge request info from scm


### PR DESCRIPTION
## Context

Need to start tracking which template jobs use so that the data can be aggregated to provide metrics on template popularity.

## Objective

Add template data to jobs, as a result of this pr jobs will begin to store template name, namespace, version inside of permutations.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1091

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
