### PR TITLE
fix(1710): Allow pass in parentBuilds to event create [1]

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -121,9 +121,7 @@ const SCHEMA_TEMPLATE = Joi.string().regex(Regex.FULL_TEMPLATE_NAME);
 // ~commit, ~commit:staging, ~commit:/^user-.*$/, ~pr, etc.
 const SCHEMA_TRIGGER = sdJoi.string().regex(Regex.TRIGGER).branchFilter();
 const SCHEMA_INTERNAL_TRIGGER = Joi.string().regex(Regex.INTERNAL_TRIGGER); // ~main, ~jobOne
-const SCHEMA_EXTERNAL_TRIGGER = Joi.alternatives().try(
-    Joi.string().regex(Regex.EXTERNAL_TRIGGER).max(64),
-    Joi.string().regex(Regex.EXTERNAL_TRIGGER_AND).max(64))
+const SCHEMA_EXTERNAL_TRIGGER = Joi.string().regex(Regex.EXTERNAL_TRIGGER_ALL)
     .example('~sd@1234:component'); // ~sd@123:main or sd@123:main
 const SCHEMA_CRON_EXPRESSION = Cron.string().cron();
 const SCHEMA_REQUIRES_VALUE = Joi.alternatives().try(
@@ -134,7 +132,7 @@ const SCHEMA_REQUIRES = Joi.alternatives().try(
 );
 const SCHEMA_BLOCKEDBY_VALUE = Joi.alternatives().try(
     SCHEMA_INTERNAL_TRIGGER,
-    SCHEMA_EXTERNAL_TRIGGER
+    Joi.string().regex(Regex.EXTERNAL_TRIGGER)
 );
 const SCHEMA_BLOCKEDBY = Joi.alternatives().try(
     Joi.array().items(SCHEMA_BLOCKEDBY_VALUE),

--- a/config/regex.js
+++ b/config/regex.js
@@ -49,10 +49,13 @@ module.exports = {
 
     // Don't combine EXTERNAL_TRIGGER and EXTERNAL_TRIGGER_AND for backward compatibility
     // BlockBy does not support EXTERNAL_TRIGGER_AND
-    // External trigger like ~sd@123:component
+    // External trigger like ~sd@123:component (OR case)
     EXTERNAL_TRIGGER: /^~sd@(\d+):([\w-]+)$/,
-    // External trigger like sd@123:component
+    // External trigger like sd@123:component (AND case)
     EXTERNAL_TRIGGER_AND: /^sd@(\d+):([\w-]+)$/,
+    // External trigger (OR and AND case)
+    // Can be ~sd@123:component or sd@123:component
+    EXTERNAL_TRIGGER_ALL: /^~?sd@(\d+):([\w-]+)$/,
 
     // Can be ~pr, ~commit, ~release, ~tag or ~commit:branchName, or ~sd@123:component
     // Note: if you modify this regex, you must modify `sdJoi` definition in the `config/job.js`

--- a/models/event.js
+++ b/models/event.js
@@ -7,6 +7,7 @@ const WorkflowGraph = require('../config/workflowGraph');
 const { trigger } = require('../config/job');
 const jobName = Joi.reach(require('./job').base, 'name');
 const parentBuildId = Joi.reach(require('./build').get, 'parentBuildId');
+const parentBuilds = Joi.reach(require('./build').get, 'parentBuilds');
 const buildId = Joi.reach(require('./build').get, 'id');
 const prNum = Joi.reach(Scm.hook, 'prNum');
 
@@ -81,6 +82,7 @@ const CREATE_MODEL = Object.assign({}, MODEL, {
     startFrom: Joi.alternatives().try(trigger, jobName),
     buildId,
     parentBuildId,
+    parentBuilds,
     prNum
 });
 
@@ -121,7 +123,7 @@ module.exports = {
      */
     create: Joi.object(mutate(CREATE_MODEL, [], [
         'pipelineId', 'startFrom', 'buildId', 'causeMessage', 'parentBuildId', 'parentEventId',
-        'configPipelineSha', 'meta', 'prNum', 'creator', 'baseBranch'
+        'configPipelineSha', 'meta', 'prNum', 'creator', 'baseBranch', 'parentBuilds'
     ])).label('Create Event'),
 
     /**

--- a/test/data/event.create.restart.yaml
+++ b/test/data/event.create.restart.yaml
@@ -1,2 +1,9 @@
 # Event Create for Restarting a Build Example
 buildId: 123
+parentBuildId: [2]
+parentBuilds:
+    123:
+        eventId: 555
+        jobs:
+            main: 1
+            fork: 2


### PR DESCRIPTION
## Context

When restarting a build, it would be nice to see parentBuilds information.

## Objective

This PR allows passing in parentBuilds info to event create so it can be passed into build create.
This PR also adds regex for OR and AND case for external trigger.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1710

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
