### PR TITLE
fix(1091): add aggregation field to scan schema

### DIFF
--- a/migrations/20200203-add-column_templateId_to_jobs.js
+++ b/migrations/20200203-add-column_templateId_to_jobs.js
@@ -11,8 +11,8 @@ module.exports = {
             await queryInterface.addColumn(table, 'templateId', {
                 type: Sequelize.INTEGER }, { transaction });
 
-            await queryInterface.addIndex(table, 'templateId', {
-                name: `${table}_template_id` }, { transaction });
+            await queryInterface.addIndex(table, ['templateId'], {
+                name: `${table}_template_id`, transaction });
         });
     }
 };

--- a/migrations/20200203-add-column_templateId_to_jobs.js
+++ b/migrations/20200203-add-column_templateId_to_jobs.js
@@ -10,6 +10,9 @@ module.exports = {
         await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addColumn(table, 'templateId', {
                 type: Sequelize.DOUBLE }, { transaction });
+
+            await queryInterface.addIndex(table, 'templateId', {
+                name: `${table}_template_id` }, { transaction });
         });
     }
 };

--- a/migrations/20200203-add-column_templateId_to_jobs.js
+++ b/migrations/20200203-add-column_templateId_to_jobs.js
@@ -9,7 +9,7 @@ module.exports = {
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addColumn(table, 'templateId', {
-                type: Sequelize.DOUBLE }, { transaction });
+                type: Sequelize.INTEGER }, { transaction });
 
             await queryInterface.addIndex(table, 'templateId', {
                 name: `${table}_template_id` }, { transaction });

--- a/migrations/20200204-add-column_templateId_to_builds.js
+++ b/migrations/20200204-add-column_templateId_to_builds.js
@@ -11,8 +11,8 @@ module.exports = {
             await queryInterface.addColumn(table, 'templateId', {
                 type: Sequelize.INTEGER }, { transaction });
 
-            await queryInterface.addIndex(table, 'templateId', {
-                name: `${table}_template_id` }, { transaction });
+            await queryInterface.addIndex(table, ['templateId'], {
+                name: `${table}_template_id`, transaction });
         });
     }
 };

--- a/migrations/20200204-add-column_templateId_to_builds.js
+++ b/migrations/20200204-add-column_templateId_to_builds.js
@@ -10,6 +10,9 @@ module.exports = {
         await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addColumn(table, 'templateId', {
                 type: Sequelize.DOUBLE }, { transaction });
+
+            await queryInterface.addIndex(table, 'templateId', {
+                name: `${table}_template_id` }, { transaction });
         });
     }
 };

--- a/migrations/20200204-add-column_templateId_to_builds.js
+++ b/migrations/20200204-add-column_templateId_to_builds.js
@@ -9,7 +9,7 @@ module.exports = {
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addColumn(table, 'templateId', {
-                type: Sequelize.DOUBLE }, { transaction });
+                type: Sequelize.INTEGER }, { transaction });
 
             await queryInterface.addIndex(table, 'templateId', {
                 name: `${table}_template_id` }, { transaction });

--- a/models/build.js
+++ b/models/build.js
@@ -262,5 +262,5 @@ module.exports = {
      * @type {Array}
      */
     indexes: [{ fields: ['eventId', 'createTime'] }, { fields: ['jobId'] },
-        { fields: [{ attribute: 'parentBuildId', length: 32 }] }]
+        { fields: [{ attribute: 'parentBuildId', length: 32 }] }, { fields: ['templateId'] }]
 };

--- a/models/build.js
+++ b/models/build.js
@@ -238,7 +238,7 @@ module.exports = {
      * @property rangeKeys
      * @type {Array}
      */
-    rangeKeys: ['number', 'number', 'number'],
+    rangeKeys: ['number', 'number', 'number', 'number'],
 
     /**
      * List of all fields in the model

--- a/models/job.js
+++ b/models/job.js
@@ -146,5 +146,6 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }]
+    indexes: [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] },
+        { fields: ['templateId'] }]
 };

--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -38,7 +38,8 @@ const SCHEMA_SCAN = Joi.object().keys({
     groupBy: Joi.array().items(Joi.string().max(100)).max(100),
     startTime: Joi.string().isoDate(),
     endTime: Joi.string().isoDate(),
-    timeKey: Joi.string()
+    timeKey: Joi.string(),
+    aggregationField: Joi.string()
 });
 
 module.exports = {

--- a/test/data/datastore.aggregationField.yaml
+++ b/test/data/datastore.aggregationField.yaml
@@ -1,0 +1,2 @@
+table: 'jobs'
+aggregationField: 'templateId'

--- a/test/models/build.test.js
+++ b/test/models/build.test.js
@@ -77,4 +77,17 @@ describe('model build', () => {
             assert.isNotNull(validate('empty.yaml', models.build.updateStep).error);
         });
     });
+
+    describe('indexes', () => {
+        it('defines the correct indexes', () => {
+            const expected = [{ fields: ['eventId', 'createTime'] }, { fields: ['jobId'] },
+                { fields: [{ attribute: 'parentBuildId', length: 32 }] },
+                { fields: ['templateId'] }];
+            const indexes = models.build.indexes;
+
+            expected.forEach((indexName) => {
+                assert.include(indexes, indexName, `Index name ${indexName} not included`);
+            });
+        });
+    });
 });

--- a/test/models/index.test.js
+++ b/test/models/index.test.js
@@ -74,6 +74,6 @@ describe('model commmons', () => {
     it('selected models have rangeKeys defined', () => {
         const buildModel = models.build;
 
-        assert.deepEqual(buildModel.rangeKeys, ['number', 'number', 'number']);
+        assert.deepEqual(buildModel.rangeKeys, ['number', 'number', 'number', 'number']);
     });
 });

--- a/test/models/job.test.js
+++ b/test/models/job.test.js
@@ -86,7 +86,8 @@ describe('model job', () => {
 
     describe('indexes', () => {
         it('defines the correct indexes', () => {
-            const expected = [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }];
+            const expected = [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] },
+                { fields: ['templateId'] }];
             const indexes = models.job.indexes;
 
             expected.forEach((indexName) => {

--- a/test/plugins/datastore.test.js
+++ b/test/plugins/datastore.test.js
@@ -66,6 +66,10 @@ describe('datastore test', () => {
             assert.isNull(validate('datastore.startTime.yaml', datastore.scan).error);
         });
 
+        it('validates the aggregationField option', () => {
+            assert.isNull(validate('datastore.aggregationField.yaml', datastore.scan).error);
+        });
+
         it('fails the update', () => {
             assert.isNotNull(validate('empty.yaml', datastore.scan).error);
         });


### PR DESCRIPTION
## Context

Need to allow "aggregationField" in scan config so aggregation queries can be made.

## Objective

This PR adds "aggregationField" to SCHEMA_SCAN so that scan configs that include aggregationField pass validation.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1091

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
