### PR TITLE
fix: templateId is DOUBLE

### DIFF
--- a/migrations/20200203-add-column_templateId_to_jobs.js
+++ b/migrations/20200203-add-column_templateId_to_jobs.js
@@ -9,7 +9,7 @@ module.exports = {
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addColumn(table, 'templateId', {
-                type: Sequelize.INTEGER }, { transaction });
+                type: Sequelize.DOUBLE }, { transaction });
 
             await queryInterface.addIndex(table, ['templateId'], {
                 name: `${table}_template_id`, transaction });

--- a/migrations/20200204-add-column_templateId_to_builds.js
+++ b/migrations/20200204-add-column_templateId_to_builds.js
@@ -9,7 +9,7 @@ module.exports = {
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
             await queryInterface.addColumn(table, 'templateId', {
-                type: Sequelize.INTEGER }, { transaction });
+                type: Sequelize.DOUBLE }, { transaction });
 
             await queryInterface.addIndex(table, ['templateId'], {
                 name: `${table}_template_id`, transaction });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
There is some code that should be DOUBLE not INTEGER.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Migration works correctly.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/data-schema/blob/dde2d906e399ce15e87b1e1808cf908e68613705/models/job.js#L70

https://github.com/screwdriver-cd/data-schema/blob/dde2d906e399ce15e87b1e1808cf908e68613705/models/build.js#L132

https://github.com/screwdriver-cd/datastore-sequelize/blob/8fd9efbbcce52d82be0867c15303f9bd2b0a4180/index.js#L116

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
