### PR TITLE
fix(965):[1] $GIT_BRANCH invalid value in PR builds

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -46,6 +46,7 @@ const GET_CHECKOUT_COMMAND = Joi.object().keys({
     repo: Joi.string().required(),
     sha: Joi.string().required(),
     prRef: Joi.string().optional(),
+    prSource: Joi.string().optional(),
     prBranchName: Joi.string().optional(),
     commitBranch: Joi.string().optional(),
     manifest: Joi.string().optional(),

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -46,6 +46,7 @@ const GET_CHECKOUT_COMMAND = Joi.object().keys({
     repo: Joi.string().required(),
     sha: Joi.string().required(),
     prRef: Joi.string().optional(),
+    prBranchName: Joi.string().optional(),
     commitBranch: Joi.string().optional(),
     manifest: Joi.string().optional(),
     parentConfig: PARENT_CONFIG.optional(),

--- a/test/data/scm.getCheckoutCommand.yaml
+++ b/test/data/scm.getCheckoutCommand.yaml
@@ -2,6 +2,7 @@ branch: master
 host: github.com
 org: screwdriver-cd
 repo: data-schema
+prSource: branch
 prBranchName: prBranchName
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 scmContext: github:github.com

--- a/test/data/scm.getCheckoutCommand.yaml
+++ b/test/data/scm.getCheckoutCommand.yaml
@@ -2,6 +2,7 @@ branch: master
 host: github.com
 org: screwdriver-cd
 repo: data-schema
+prBranchName: prBranchName
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 scmContext: github:github.com
 manifest: git@github.com:org/repo.git/default.xml


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I fix [issue](https://github.com/screwdriver-cd/screwdriver/issues/965).
I add new variables,`PR_BRANCH_NAME`

## Objective
This PR adds `prBranchName` to the joi validator of  `GET_CHECKOUT_COMMAND`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
