### PR TITLE
fix(965)[1]:  ChainPR does not work

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -102,7 +102,7 @@ const SCHEMA_PR = Joi.object().keys({
     prSource: Joi.string()
         .allow('')
         .optional()
-        .label('Origin of the pull reqyest'),
+        .label('Origin of the pull request'),
     prBranchName: Joi.string()
         .allow('')
         .optional()

--- a/core/scm.js
+++ b/core/scm.js
@@ -99,6 +99,14 @@ const SCHEMA_PR = Joi.object().keys({
         .allow('')
         .optional()
         .label('Ref of the pull request'),
+    prSource: Joi.string()
+        .allow('')
+        .optional()
+        .label('Origin of the pull reqyest'),
+    prBranchName: Joi.string()
+        .allow('')
+        .optional()
+        .label('Branch name of the pull request'),
     createTime: Joi.date().iso()
         .label('Creation Time of the pull request')
         .example('2018-10-10T21:35:31Z'),

--- a/test/data/scm.pr.yaml
+++ b/test/data/scm.pr.yaml
@@ -2,6 +2,8 @@
 url: https://github.com/screwdriver-cd/screwdriver/pull/1
 title: prTitle
 ref: reference
+prSource: branch
+prBranchName: prBranch
 createTime: 2018-10-10T21:35:31Z
 username: d2lam
 userProfile: https://github.com/anonymous


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I am fixing the following features:
[1] https://github.com/screwdriver-cd/data-schema/pull/386
[2] https://github.com/screwdriver-cd/scm-base/pull/75
[3] https://github.com/screwdriver-cd/scm-github/pull/150
[4] https://github.com/screwdriver-cd/screwdriver/pull/1980

[2] Chain PR stopped working after merge.
The reason is that the environment variables required to `BuildFactory` have not been added.
Therefore, we will modify chainPR to work.

## Objective
Add necessary data when calling `BuildFactory`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
