### PR TITLE
feat(1785): Add groupEventId [1]

### DIFF
--- a/migrations/20200304-add-column_groupEventId_to_events.js
+++ b/migrations/20200304-add-column_groupEventId_to_events.js
@@ -3,16 +3,13 @@
 'use strict';
 
 const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
-const table = `${prefix}builds`;
+const table = `${prefix}events`;
 
 module.exports = {
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
-            await queryInterface.addColumn(table, 'templateId', {
-                type: Sequelize.INTEGER }, { transaction });
-
-            await queryInterface.addIndex(table, ['templateId'], {
-                name: `${table}_template_id`, transaction });
+            await queryInterface.addColumn(table, 'groupEventId', {
+                type: Sequelize.DOUBLE }, { transaction });
         });
     }
 };

--- a/migrations/20200304-add-column_groupEventId_to_events.js
+++ b/migrations/20200304-add-column_groupEventId_to_events.js
@@ -1,0 +1,18 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}builds`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.addColumn(table, 'templateId', {
+                type: Sequelize.INTEGER }, { transaction });
+
+            await queryInterface.addIndex(table, ['templateId'], {
+                name: `${table}_template_id`, transaction });
+        });
+    }
+};

--- a/models/event.js
+++ b/models/event.js
@@ -18,7 +18,11 @@ const MODEL = {
         .example(123345),
     parentEventId: Joi
         .number().integer().positive()
-        .description('Identifier of the parent event')
+        .description('Identifier of the direct parent event')
+        .example(123344),
+    groupEventId: Joi
+        .number().integer().positive()
+        .description('Identifier of the group parent event')
         .example(123344),
     causeMessage: Joi
         .string().max(512).truncate().allow('')
@@ -111,8 +115,8 @@ module.exports = {
     get: Joi.object(mutate(MODEL, [
         'id', 'commit', 'createTime', 'creator', 'pipelineId', 'sha', 'type'
     ], [
-        'causeMessage', 'meta', 'parentEventId', 'startFrom', 'workflowGraph', 'pr', 'prNum',
-        'configPipelineSha', 'baseBranch'
+        'causeMessage', 'meta', 'parentEventId', 'groupEventId', 'startFrom',
+        'workflowGraph', 'pr', 'prNum', 'configPipelineSha', 'baseBranch'
     ])).label('Get Event'),
 
     /**
@@ -123,7 +127,8 @@ module.exports = {
      */
     create: Joi.object(mutate(CREATE_MODEL, [], [
         'pipelineId', 'startFrom', 'buildId', 'causeMessage', 'parentBuildId', 'parentEventId',
-        'configPipelineSha', 'meta', 'prNum', 'creator', 'baseBranch', 'parentBuilds'
+        'groupEventId', 'configPipelineSha', 'meta', 'prNum', 'creator', 'baseBranch',
+        'parentBuilds'
     ])).label('Create Event'),
 
     /**

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -2,6 +2,7 @@
 startFrom: main
 parentBuildId: 123
 parentEventId: 123456
+groupEventId: 123456
 pipelineId: 1235123
 creator:
     name: sd:scheduler


### PR DESCRIPTION
## Context

Need a way to group similar events that we triggered by the same event or started manually.

## Objective

This PR adds a new field `groupEventId` to event model to track similar events. `parentEventId` cannot be used since it tracks the direct parent event id, not the master parent event id.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1785

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
