### PR TITLE
feat(1967): add query to datastore

### DIFF
--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -41,6 +41,16 @@ const SCHEMA_SCAN = Joi.object().keys({
     timeKey: Joi.string(),
     aggregationField: Joi.string()
 });
+const SCHEMA_QUERY = Joi.object().keys({
+    table,
+    queries: Joi.array().items(
+        Joi.object().keys({
+            dbType: Joi.string(),
+            query: Joi.string()
+    })),
+    replacements: Joi.object(),
+    rawResponse: Joi.boolean()
+});
 
 module.exports = {
     /**
@@ -81,5 +91,13 @@ module.exports = {
      * @property scan
      * @type {Joi}
      */
-    scan: SCHEMA_SCAN
+    scan: SCHEMA_SCAN,
+
+    /**
+     * Properties for Datastore that will be passed for the QUERY method
+     *
+     * @property query
+     * @type {Joi}
+     */
+    query: SCHEMA_QUERY
 };

--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -45,9 +45,9 @@ const SCHEMA_QUERY = Joi.object().keys({
     table,
     queries: Joi.array().items(
         Joi.object().keys({
-            dbType: Joi.string(),
-            query: Joi.string()
-    })),
+            dbType: Joi.string().required(),
+            query: Joi.string().required()
+        })).required(),
     replacements: Joi.object(),
     rawResponse: Joi.boolean()
 });

--- a/test/data/datastore.query.rawResponse.yaml
+++ b/test/data/datastore.query.rawResponse.yaml
@@ -1,0 +1,6 @@
+table: 'jobs'
+queries: [{
+    dbType: 'postgres',
+    query: 'SELECT * FROM builds'
+}]
+rawResponse: true

--- a/test/data/datastore.query.replacements.yaml
+++ b/test/data/datastore.query.replacements.yaml
@@ -1,0 +1,8 @@
+table: 'jobs'
+queries: [{
+    dbType: 'postgres',
+    query: 'SELECT * FROM builds WHERE "id" in (:ids)'
+}]
+replacements: {
+    ids: [1,2,3]
+}

--- a/test/data/datastore.query.yaml
+++ b/test/data/datastore.query.yaml
@@ -1,0 +1,5 @@
+table: 'jobs'
+queries: [{
+    dbType: 'postgres',
+    query: 'SELECT * FROM builds'
+}]

--- a/test/plugins/datastore.test.js
+++ b/test/plugins/datastore.test.js
@@ -74,4 +74,22 @@ describe('datastore test', () => {
             assert.isNotNull(validate('empty.yaml', datastore.scan).error);
         });
     });
+
+    describe('query', () => {
+        it('validates the query', () => {
+            assert.isNull(validate('datastore.query.yaml', datastore.query).error);
+        });
+
+        it('validates the query with replacements', () => {
+            assert.isNull(validate('datastore.query.replacements.yaml', datastore.query).error);
+        });
+
+        it('validates the query with rawResponse', () => {
+            assert.isNull(validate('datastore.query.rawResponse.yaml', datastore.query).error);
+        });
+
+        it('fails the query', () => {
+            assert.isNotNull(validate('empty.yaml', datastore.query).error);
+        });
+    });
 });


### PR DESCRIPTION
## Context

Need to add the ability to do raw queries to datastore so queries that are otherwise impossible to do through sequelize can be done, as such need to add a schema for this method to data schema.

## Objective

Add a schema for the datastore query method to data schema so method calls can be validated.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1967

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
