### PR TITLE
fix(2026): Update startFrom field [1]

### DIFF
--- a/migrations/20200316-extend-startFrom-to-events.js
+++ b/migrations/20200316-extend-startFrom-to-events.js
@@ -8,7 +8,7 @@ const table = `${prefix}events`;
 module.exports = {
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
-            await queryInterface.changeColumn(table, 'startFrom', Sequelize.STRING(64),
+            await queryInterface.changeColumn(table, 'startFrom', Sequelize.STRING(110),
                 { transaction }
             );
         });

--- a/migrations/20200316-extend-startFrom-to-events.js
+++ b/migrations/20200316-extend-startFrom-to-events.js
@@ -1,0 +1,16 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}events`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.changeColumn(table, 'startFrom', Sequelize.STRING(64),
+                { transaction }
+            );
+        });
+    }
+};

--- a/models/event.js
+++ b/models/event.js
@@ -55,9 +55,9 @@ const MODEL = {
         .description('SHA of the configuration pipeline this project depends on')
         .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'),
     startFrom: Joi
-        .string()
+        .alternatives().try(trigger, jobName)
         .description('Event start point - a job name or trigger name (~commit/~pr)')
-        .example('main'),
+        .example('~commit'),
     type: Joi
         .string().valid([
             'pr',
@@ -83,7 +83,6 @@ const MODEL = {
 };
 
 const CREATE_MODEL = Object.assign({}, MODEL, {
-    startFrom: Joi.alternatives().try(trigger, jobName),
     buildId,
     parentBuildId,
     parentBuilds,


### PR DESCRIPTION
## Context

It's important to update the field so it has the proper description in the swagger API documentation. However, `startFrom` is not required when `buildId` is provided (https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/events/create.js#L34-L52).

## Objective

This PR moves the definition of `startFrom` from the CREATE_MODEL to the BASE.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2026

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
