### PR TITLE
fix(1785): Add groupEventId index for events

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -146,7 +146,7 @@ module.exports = {
      * @property rangeKeys
      * @type {Array}
      */
-    rangeKeys: ['createTime', 'pipelineId', 'type'],
+    rangeKeys: ['createTime', 'pipelineId', 'type', 'groupEventId'],
 
     /**
      * Tablename to be used in the datastore
@@ -163,5 +163,5 @@ module.exports = {
      * @type {Array}
      */
     indexes: [{ fields: ['createTime', 'pipelineId'] }, { fields: ['pipelineId'] },
-        { fields: ['type'] }]
+        { fields: ['type'] }, { fields: ['groupEventId'] }]
 };

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -87,7 +87,8 @@ describe('model event', () => {
 
     describe('indexes', () => {
         it('defines the correct indexes', () => {
-            const expected = [{ fields: ['pipelineId'] }, { fields: ['type'] }];
+            const expected = [
+                { fields: ['pipelineId'] }, { fields: ['type'] }, { fields: ['groupEventId'] }];
             const indexes = models.event.indexes;
 
             expected.forEach((indexName) => {

--- a/test/models/index.test.js
+++ b/test/models/index.test.js
@@ -32,7 +32,7 @@ describe('model commmons', () => {
     });
 
     // See https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L311
-    it('selected models have same length of indexes and rangeKeys.', () => {
+    it('selected models have same length of indexes and rangeKeys', () => {
         modelsToCheck.forEach((model) => {
             if (Object.prototype.hasOwnProperty.call(models[model], 'rangeKeys')) {
                 assert.strictEqual(


### PR DESCRIPTION
## Context

Adding `groupEventId` as a field to index to events model will help with faster lookup.

## Objective

This PR adds `groupEventId` to events index.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1785

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
