### PR TITLE
fix: allow dot in template/command full name

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -15,7 +15,7 @@ module.exports = {
     // Example: chefdk/knife@1.2.3 or chefdk/knife@stable
     // Only <COMMAND_NAMESPACE>/<COMMAND_NAME> or <COMMAND_NAMESPACE>/<COMMAND_NAME> is also acceptable
     FULL_COMMAND_NAME:
-        /^([\w-]+)\/([\w-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-]+)))?$/,
+        /^([\w-]+)\/([\w-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-.]+)))?$/,
     // Template namespaces can only be named with A-Z,a-z,0-9,-,_
     TEMPLATE_NAMESPACE: /^[\w-]+$/,
     // Templates can only be named with A-Z,a-z,0-9,-,_,/; can only contain one /
@@ -32,7 +32,7 @@ module.exports = {
     // Full name of template and version. Can be <TEMPLATE_NAME>@<VERSION> or <TEMPLATE_NAME>@<TEMPLATE_TAG_NAME>
     // Example: chef/publish@1.2.3 or chef/publish@stable
     // Only <TEMPLATE_NAME> or <TEMPLATE_NAME>@ is also acceptable
-    FULL_TEMPLATE_NAME: /^([\w/-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-]+)))?$/,
+    FULL_TEMPLATE_NAME: /^([\w/-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-.]+)))?$/,
     // Full name of template and version with grouping for the namespace
     // eslint-disable-next-line max-len
     FULL_TEMPLATE_NAME_WITH_NAMESPACE: /^([\w-]+)\/([\w/-]+)(?:@((?:(?:\d+)(?:\.\d+)?(?:\.\d+)?)|(?:[a-zA-Z][\w-]+)))?$/,

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -151,6 +151,10 @@ describe('config regex', () => {
             assert.isTrue(config.regex.FULL_COMMAND_NAME.test('chefdk/knife'));
         });
 
+        it('checks good command full names with tag including dot', () => {
+            assert.isTrue(config.regex.FULL_COMMAND_NAME.test('chefdk/knife@v1.1.1'));
+        });
+
         it('fails on bad command full names', () => {
             assert.isFalse(config.regex.FULL_COMMAND_NAME.test('bad name'));
         });
@@ -195,6 +199,10 @@ describe('config regex', () => {
 
         it('checks good template full names without version', () => {
             assert.isTrue(config.regex.FULL_TEMPLATE_NAME.test('chefdk/knife'));
+        });
+
+        it('checks good template full names with tag including dot', () => {
+            assert.isTrue(config.regex.FULL_TEMPLATE_NAME.test('chefdk/knife@v1.1.1'));
         });
 
         it('fails on bad template full names', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Using dot is allowed in template/command tag.
However, it is not allowed in template/command full name regex.
It should be allowed also in template/command full name.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Allow dot in template/command full name regex.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/data-schema/pull/343
https://github.com/screwdriver-cd/data-schema/pull/342

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
