### PR TITLE
feat(data-schema): Add validation for settings

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -107,7 +107,29 @@ const SCHEMA_STEP_OBJECT = Joi.object()
 
 const SCHEMA_DESCRIPTION = Joi.string().max(100).optional();
 const SCHEMA_IMAGE = Joi.string().regex(Regex.IMAGE_NAME);
-const SCHEMA_SETTINGS = Joi.object().optional();
+const SCHEMA_EMAIL_ADDR_STRING = Joi.string().email();
+const SCHEMA_STATUS_STRING = Joi.string().regex(Regex.STATUS);
+const SCHEMA_SLACK_CHANNEL_STRING = Joi.string();
+const SCHEMA_SETTINGS_EMAIL = Joi.alternatives().try(
+    Joi.array().items(SCHEMA_EMAIL_ADDR_STRING),
+    Joi.object().keys({
+        addresses: Joi.array().items(SCHEMA_EMAIL_ADDR_STRING).optional(),
+        statuses: Joi.array().items(SCHEMA_STATUS_STRING).optional()
+    })
+);
+const SCHEMA_SETTINGS_SLACK = Joi.alternatives().try(
+    Joi.array().items(SCHEMA_SLACK_CHANNEL_STRING),
+    Joi.object().keys({
+        channels: Joi.array().items(SCHEMA_SLACK_CHANNEL_STRING).optional(),
+        statuses: Joi.array().items(SCHEMA_STATUS_STRING).optional(),
+        minimized: Joi.bool().optional()
+    })
+);
+const SCHEMA_SETTINGS = Joi.object()
+    .keys({
+        email: SCHEMA_SETTINGS_EMAIL.optional(),
+        slack: SCHEMA_SETTINGS_SLACK.optional()
+    });
 const SCHEMA_STEP = Joi.alternatives().try(SCHEMA_STEP_STRING, SCHEMA_STEP_OBJECT);
 const SCHEMA_STEPS = Joi.array().items(SCHEMA_STEP).min(1);
 const SCHEMA_STEPS_NO_DUPS = Joi.array().items(SCHEMA_STEP).min(1).unique((a, b) => {

--- a/config/job.js
+++ b/config/job.js
@@ -111,6 +111,7 @@ const SCHEMA_EMAIL_ADDR_STRING = Joi.string().email();
 const SCHEMA_STATUS_STRING = Joi.string().regex(Regex.STATUS);
 const SCHEMA_SLACK_CHANNEL_STRING = Joi.string();
 const SCHEMA_SETTINGS_EMAIL = Joi.alternatives().try(
+    SCHEMA_EMAIL_ADDR_STRING.optional(),
     Joi.array().items(SCHEMA_EMAIL_ADDR_STRING),
     Joi.object().keys({
         addresses: Joi.array().items(SCHEMA_EMAIL_ADDR_STRING).optional(),
@@ -118,6 +119,7 @@ const SCHEMA_SETTINGS_EMAIL = Joi.alternatives().try(
     })
 );
 const SCHEMA_SETTINGS_SLACK = Joi.alternatives().try(
+    SCHEMA_SLACK_CHANNEL_STRING.optional(),
     Joi.array().items(SCHEMA_SLACK_CHANNEL_STRING),
     Joi.object().keys({
         channels: Joi.array().items(SCHEMA_SLACK_CHANNEL_STRING).optional(),

--- a/config/job.js
+++ b/config/job.js
@@ -107,30 +107,10 @@ const SCHEMA_STEP_OBJECT = Joi.object()
 
 const SCHEMA_DESCRIPTION = Joi.string().max(100).optional();
 const SCHEMA_IMAGE = Joi.string().regex(Regex.IMAGE_NAME);
-const SCHEMA_EMAIL_ADDR_STRING = Joi.string().email();
-const SCHEMA_STATUS_STRING = Joi.string().regex(Regex.STATUS);
-const SCHEMA_SLACK_CHANNEL_STRING = Joi.string();
-const SCHEMA_SETTINGS_EMAIL = Joi.alternatives().try(
-    SCHEMA_EMAIL_ADDR_STRING.optional(),
-    Joi.array().items(SCHEMA_EMAIL_ADDR_STRING),
-    Joi.object().keys({
-        addresses: Joi.array().items(SCHEMA_EMAIL_ADDR_STRING).optional(),
-        statuses: Joi.array().items(SCHEMA_STATUS_STRING).optional()
-    })
-);
-const SCHEMA_SETTINGS_SLACK = Joi.alternatives().try(
-    SCHEMA_SLACK_CHANNEL_STRING.optional(),
-    Joi.array().items(SCHEMA_SLACK_CHANNEL_STRING),
-    Joi.object().keys({
-        channels: Joi.array().items(SCHEMA_SLACK_CHANNEL_STRING).optional(),
-        statuses: Joi.array().items(SCHEMA_STATUS_STRING).optional(),
-        minimized: Joi.bool().optional()
-    })
-);
 const SCHEMA_SETTINGS = Joi.object()
     .keys({
-        email: SCHEMA_SETTINGS_EMAIL.optional(),
-        slack: SCHEMA_SETTINGS_SLACK.optional()
+        email: Joi.optional(),
+        slack: Joi.optional()
     });
 const SCHEMA_STEP = Joi.alternatives().try(SCHEMA_STEP_STRING, SCHEMA_STEP_OBJECT);
 const SCHEMA_STEPS = Joi.array().items(SCHEMA_STEP).min(1);

--- a/config/regex.js
+++ b/config/regex.js
@@ -85,7 +85,5 @@ module.exports = {
     // Optionally, can have rootDir. For example: github.com:abc-123:master:src/app/component
     SCM_URI: /^([^:]+):([^:]+):([^:]+)(?::([^:]+))?$/,
     // Image aliases can only contain A-Z,a-z,0-9,-,_
-    IMAGE_ALIAS: /^[\w-]+$/,
-    // Status can only contain A-Z
-    STATUS: /^[A-Z]+$/
+    IMAGE_ALIAS: /^[\w-]+$/
 };

--- a/config/regex.js
+++ b/config/regex.js
@@ -85,5 +85,7 @@ module.exports = {
     // Optionally, can have rootDir. For example: github.com:abc-123:master:src/app/component
     SCM_URI: /^([^:]+):([^:]+):([^:]+)(?::([^:]+))?$/,
     // Image aliases can only contain A-Z,a-z,0-9,-,_
-    IMAGE_ALIAS: /^[\w-]+$/
+    IMAGE_ALIAS: /^[\w-]+$/,
+    // Status can only contain A-Z
+    STATUS: /^[A-Z]+$/
 };

--- a/test/data/config.job.settings.yaml
+++ b/test/data/config.job.settings.yaml
@@ -1,1 +1,1 @@
-foo: bar
+email: foo@bar.com


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1574
 
## Objective

This PR adds validation for settings in the shared section. Currently the settings has 2 keys `email` and `slack`. These can have multiple values like arrays of strings of objects. So this is being validated now. Apart from this, a regex for status has been added for status validation.

## References

screwdriver-cd/screwdriver#1574

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
