### PR TITLE
fix: validation error on chanPR with remote join

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -45,7 +45,7 @@ module.exports = {
     // PR JOB Name can only be PR-1 or PR-1:main, group1: PR-prNum, group2: jobName
     PR_JOB_NAME: /^(PR-\d+)(?::([\w-]+))?$/,
     // Match all possible job name
-    ALL_JOB_NAME: /^(PR-[0-9]+:)?[\w-]+$/,
+    ALL_JOB_NAME: /^(PR-[0-9]+:)?[\w-@:]+$/,
     // Internal trigger like ~component or ~main
     INTERNAL_TRIGGER: /^~([\w-]+)$/,
 

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -273,6 +273,14 @@ describe('config regex', () => {
             assert.deepEqual('PR-1:main-job'.match(config.regex.PR_JOB_NAME)[2], 'main-job');
         });
 
+        it('checks all possible job names', () => {
+            assert.isTrue(config.regex.ALL_JOB_NAME.test('foo-BAR_15'));
+            assert.isTrue(config.regex.ALL_JOB_NAME.test('PR-1'));
+            assert.isTrue(config.regex.ALL_JOB_NAME.test('PR-1:main'));
+            assert.isTrue(config.regex.ALL_JOB_NAME.test('PR-1:main-job'));
+            assert.isTrue(config.regex.ALL_JOB_NAME.test('PR-1:sd@21:external_fork'));
+        });
+
         it('checks bad PR job names', () => {
             assert.isFalse(config.regex.PR_JOB_NAME.test('PR-1-main'));
             assert.isFalse(config.regex.PR_JOB_NAME.test('PR-1:main:job'));


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
When chainPR triggers remote join, event screen does not show full workflowgraph in pr event list.

<img width="304" alt="Screen_Shot_2020-05-21_at_17_15_06" src="https://user-images.githubusercontent.com/32473622/82538550-e0f07780-9b86-11ea-8858-158b8c5b9bf4.png">

The error message is like below.
```
200521/022434.929, (1590027874916:3d8985daec91:31:kag51fdw:10970) [request,server,error] data: Error: "List of builds" at position 0 fails because [child "parentBuilds" fails because [child "20" fails because [child "jobs" fails because ["PR-1:sd@21:external_fork" is no
t allowed, "PR-1:sd@22:external_fork" is not allowed]]]]
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Fix validation error on chainPR with remote join. This PR makes chainPR possible to show full workflowgraph like below.
![Screen Shot 2020-05-21 at 17 21 04](https://user-images.githubusercontent.com/32473622/82538944-81df3280-9b87-11ea-953f-39cd6d1eb21e.jpg)
(Jobs which not executed is external things, so it is no problem on chanPR)

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
