### PR TITLE
fix: Add index groupEventId to events

### DIFF
--- a/migrations/20200611-add_index_groupEventId_to_events.js
+++ b/migrations/20200611-add_index_groupEventId_to_events.js
@@ -1,0 +1,16 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}events`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            
+            await queryInterface.addIndex(table, ['groupEventId'], {
+                name: `${table}_group_event_id`, transaction });
+        });
+    }
+};

--- a/migrations/20200611-add_index_groupEventId_to_events.js
+++ b/migrations/20200611-add_index_groupEventId_to_events.js
@@ -6,9 +6,8 @@ const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
 const table = `${prefix}events`;
 
 module.exports = {
-    up: async (queryInterface, Sequelize) => {
+    up: async (queryInterface) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
-            
             await queryInterface.addIndex(table, ['groupEventId'], {
                 name: `${table}_group_event_id`, transaction });
         });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The specific query of remote join is slowly without `groupEventId` index. Therefore we need to add `groupEventId` index to events. 

## Objective
Add `groupEventId` index to events. 

## References
https://github.com/screwdriver-cd/data-schema/pull/395
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
