### PR TITLE
fix(2017): fix checkoutUrl regex

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -80,7 +80,7 @@ module.exports = {
     ENV_NAME: /^[A-Z_][A-Z0-9_]*$/,
     // Repo checkout url. For example: https://github.com/screwdriver-cd/data-schema.git#branchName or git@github.com:screwdriver-cd/data-schema.git
     // eslint-disable-next-line max-len
-    CHECKOUT_URL: /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)?(#[^\s]+)?$/,
+    CHECKOUT_URL: /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)?(#[^\s]+)?$/,
     // scmUri. For example: github.com:abc-123:master or bitbucket.org:{123}:master
     // Optionally, can have rootDir. For example: github.com:abc-123:master:src/app/component
     SCM_URI: /^([^:]+):([^:]+):([^:]+)(?::([^:]+))?$/,

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -390,6 +390,16 @@ describe('config regex', () => {
                         'data.schema',
                         '#banana'
                     ]
+                },
+                {
+                    url: 'org-1234@bitbucket.org:screwdriver-cd/data.schema#banana',
+                    match: [
+                        'org-1234@bitbucket.org:screwdriver-cd/data.schema#banana',
+                        'bitbucket.org',
+                        'screwdriver-cd',
+                        'data.schema',
+                        '#banana'
+                    ]
                 }
             ];
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
checkoutUrl regex rejects valid url with pattern like `org-1234@github.com:/a/b.git`

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
change regex to accept `org-1234@github.com:/a/b.git`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2017

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
