### PR TITLE
fix: Add schema for jwt token config

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -9,7 +9,17 @@ const regex = require('./regex');
 const template = require('./template');
 const workflowGraph = require('./workflowGraph');
 const parameters = require('./parameters');
+const tokenConfig = require('./tokenConfig');
 
 module.exports = {
-    annotations, base, command, commandFormat, job, regex, template, workflowGraph, parameters
+    annotations,
+    base,
+    command,
+    commandFormat,
+    job,
+    regex,
+    template,
+    workflowGraph,
+    parameters,
+    tokenConfig
 };

--- a/config/tokenConfig.js
+++ b/config/tokenConfig.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const Joi = require('joi');
+const models = require('../models');
+
+const TOKEN_CONFIG = Joi.object({
+    username: [Joi.string().required(), Joi.ref('buildId')],
+    buildId: Joi.reach(models.build.base, 'id').required(),
+    jobId: Joi.reach(models.job.base, 'id').required(),
+    eventId: Joi.reach(models.event.base, 'id'),
+    isPR: Joi.boolean().required().default(false),
+    pipelineId: Joi.reach(models.pipeline.base, 'id').required(),
+    scmContext: Joi.reach(models.pipeline.base, 'scmContext').required(),
+    configPipelineId: Joi.reach(models.pipeline.base, 'id').optional(),
+    prParentJobId: Joi.reach(models.job.base, 'id').optional()
+});
+
+/**
+ * The definition of the jwt token config
+ * @type {Object}
+ */
+module.exports = TOKEN_CONFIG;

--- a/config/tokenConfig.js
+++ b/config/tokenConfig.js
@@ -8,7 +8,7 @@ const TOKEN_CONFIG = Joi.object({
     buildId: Joi.reach(models.build.base, 'id').required(),
     jobId: Joi.reach(models.job.base, 'id').required(),
     eventId: Joi.reach(models.event.base, 'id'),
-    isPR: Joi.boolean().required().default(true),
+    isPR: Joi.boolean().required(),
     pipelineId: Joi.reach(models.pipeline.base, 'id').required(),
     scmContext: Joi.reach(models.pipeline.base, 'scmContext').required(),
     configPipelineId: Joi.reach(models.pipeline.base, 'id').optional(),

--- a/config/tokenConfig.js
+++ b/config/tokenConfig.js
@@ -8,7 +8,7 @@ const TOKEN_CONFIG = Joi.object({
     buildId: Joi.reach(models.build.base, 'id').required(),
     jobId: Joi.reach(models.job.base, 'id').required(),
     eventId: Joi.reach(models.event.base, 'id'),
-    isPR: Joi.boolean().required().default(false),
+    isPR: Joi.boolean().required().default(true),
     pipelineId: Joi.reach(models.pipeline.base, 'id').required(),
     scmContext: Joi.reach(models.pipeline.base, 'scmContext').required(),
     configPipelineId: Joi.reach(models.pipeline.base, 'id').optional(),

--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -38,7 +38,9 @@ const SCHEMA_START = Joi.object().keys({
         .label('API URI'),
     token: Joi.string().required()
         .label('Build JWT'),
-    enqueueTime: Joi.date().iso()
+    enqueueTime: Joi.date().iso(),
+    isPR: Joi.boolean().optional().default(false),
+    prParentJobId: jobId.optional()
 }).required();
 const SCHEMA_STOP = Joi.object().keys({
     annotations: Annotations.annotations,

--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -39,7 +39,7 @@ const SCHEMA_START = Joi.object().keys({
     token: Joi.string().required()
         .label('Build JWT'),
     enqueueTime: Joi.date().iso(),
-    isPR: Joi.boolean().optional().default(false),
+    isPR: Joi.boolean().optional().default(true),
     prParentJobId: jobId.optional()
 }).required();
 const SCHEMA_STOP = Joi.object().keys({

--- a/test/config/tokenConfig.test.js
+++ b/test/config/tokenConfig.test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const assert = require('chai').assert;
+const config = require('../../').config;
+const validate = require('../helper').validate;
+const tokenConfig = config.tokenConfig;
+
+describe('config tokenConfig', () => {
+    describe('tokenConfig', () => {
+        it('validates tokenConfig', () => {
+            assert.isNull(validate('config.tokenConfig.yaml', tokenConfig).error);
+        });
+    });
+});

--- a/test/data/config.tokenConfig.yaml
+++ b/test/data/config.tokenConfig.yaml
@@ -1,0 +1,9 @@
+username: 123
+buildId: 123
+jobId: 567
+eventId: 666
+isPR: true
+pipelineId: 1
+scmContext: "github.com"
+prParentJobId: 456
+

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -25,3 +25,5 @@ pipeline:
     scmContext: http://mock
     admin: admin
     token: asdf
+isPR: true
+prParentJobId: 457


### PR DESCRIPTION
## Context

Jwt token config used for auth needs a defined schema which will validate any changes to the token structure

## Objective

This PR adds token config schema and additional properties to executor schema

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
