### PR TITLE
fix: Add parentEventId index

### DIFF
--- a/migrations/20200618-add_index_parentEventId_to_events.js
+++ b/migrations/20200618-add_index_parentEventId_to_events.js
@@ -4,6 +4,7 @@
 
 const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
 const table = `${prefix}events`;
+
 module.exports = {
     up: async (queryInterface) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
@@ -12,4 +13,3 @@ module.exports = {
         });
     }
 };
-

--- a/migrations/20200618-add_index_parentEventId_to_events.js
+++ b/migrations/20200618-add_index_parentEventId_to_events.js
@@ -1,0 +1,15 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}events`;
+module.exports = {
+    up: async (queryInterface) => {
+        await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.addIndex(table, ['parentEventId'], {
+                name: `${table}_parent_event_id`, transaction });
+        });
+    }
+};
+

--- a/models/event.js
+++ b/models/event.js
@@ -146,7 +146,7 @@ module.exports = {
      * @property rangeKeys
      * @type {Array}
      */
-    rangeKeys: ['createTime', 'pipelineId', 'type', 'groupEventId'],
+    rangeKeys: ['createTime', 'pipelineId', 'type', 'groupEventId', 'parentEventId'],
 
     /**
      * Tablename to be used in the datastore
@@ -162,6 +162,11 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['createTime', 'pipelineId'] }, { fields: ['pipelineId'] },
-        { fields: ['type'] }, { fields: ['groupEventId'] }]
+    indexes: [
+        { fields: ['createTime', 'pipelineId'] },
+        { fields: ['pipelineId'] },
+        { fields: ['type'] },
+        { fields: ['groupEventId'] },
+        { fields: ['parentEventId'] }
+    ]
 };

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -88,7 +88,12 @@ describe('model event', () => {
     describe('indexes', () => {
         it('defines the correct indexes', () => {
             const expected = [
-                { fields: ['pipelineId'] }, { fields: ['type'] }, { fields: ['groupEventId'] }];
+                { fields: ['createTime', 'pipelineId'] },
+                { fields: ['pipelineId'] },
+                { fields: ['type'] },
+                { fields: ['groupEventId'] },
+                { fields: ['parentEventId'] }
+            ];
             const indexes = models.event.indexes;
 
             expected.forEach((indexName) => {


### PR DESCRIPTION
## Context
The specific query of remote join is slowly without parentEventId index. 
It was not enough to add the index groupEventId.
Therefore we need to add parentEventId index to events.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Add parentEventId index to events.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
#399 
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
