### PR TITLE
feat(2053): [1]  Add warning annotations to the validator response

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -55,7 +55,8 @@ const SCHEMA_OUTPUT = Joi.object()
         jobs: SCHEMA_JOBS,
         childPipelines: Base.childPipelines,
         workflowGraph: WorkflowGraph.workflowGraph,
-        parameters: Parameters.parameters
+        parameters: Parameters.parameters,
+        warnAnnotations: Joi.array().optional()
     })
     .label('Execution information');
 

--- a/test/api/validator.test.js
+++ b/test/api/validator.test.js
@@ -30,6 +30,10 @@ describe('api validator', () => {
             assert.isNull(validate('validator.erroroutput.yaml', api.validator.output).error);
         });
 
+        it('validates basic output with warnings', () => {
+            assert.isNull(validate('validator.warningsoutput.yaml', api.validator.output).error);
+        });
+
         it('validates output with childPipelines', () => {
             assert.isNull(
                 validate('validator-with-childPipelines.output.yaml', api.validator.output).error);

--- a/test/data/validator.warningsoutput.yaml
+++ b/test/data/validator.warningsoutput.yaml
@@ -1,0 +1,71 @@
+jobs:
+  main:
+  - image: node:4
+    commands:
+      - name: install
+        command: npm install
+      - name: test
+        command: npm test
+      - name: build
+        command: npm run build
+    annotations:
+      beta.screwdriver.cd/auto_pr_builds: fork-only
+    description: "This is a description"
+    environment:
+      NODE_VERSION: 4
+    settings:
+      email: foo@bar.com
+    sourcePaths:
+      - src/A
+      - src/AConfig
+  - image: node:5
+    commands:
+    - name: install
+      command: npm install
+    - name: test
+      command: npm test
+    - name: build
+      command: npm run build
+    annotations:
+      beta.screwdriver.cd/auto_pr_builds: fork-only
+    description: "This is a description"
+    environment:
+      NODE_VERSION: 5
+    settings:
+      email: foo@bar.com
+    sourcePaths:
+      - src/A
+      - src/AConfig
+  - image: node:6
+    commands:
+    - name: install
+      command: npm install
+    - name: test
+      command: npm test
+    - name: build
+      command: npm run build
+    annotations:
+      beta.screwdriver.cd/auto_pr_builds: fork-only
+    description: "This is a description"
+    environment:
+      NODE_VERSION: 6
+    settings:
+      email: foo@bar.com
+    sourcePaths:
+      - src/A
+      - src/AConfig
+    secrets:
+      - ANOTHER_SECRET
+
+  publish:
+  - image: node:4
+    commands:
+    - name: install
+      command: npm publish
+    environment: {}
+    secrets:
+      - NPM_TOKEN
+
+warnAnnotations:
+- 'screwdriver.cd/chainPR'
+- 'screwdriver.cd/cpu'


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Add feature of https://github.com/screwdriver-cd/screwdriver/issues/2053
In this PR,  allow the API to throw the array with warning annotations.

This PR is a preparation for users to be aware of Annotations that are not valid when they are set.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add a new `warnAnnotations` to the validator's output schema.


## References
This is part of https://github.com/screwdriver-cd/screwdriver/issues/2053

[2] https://github.com/screwdriver-cd/config-parser/pull/107
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
