### PR TITLE
fix(1079): Add autoKeysGeneration key to update schema and tests

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -120,7 +120,7 @@ module.exports = {
      * @type {Joi}
      */
     update: Joi.object(mutate(CREATE_MODEL, [], [
-        'checkoutUrl', 'rootDir'
+        'checkoutUrl', 'rootDir', 'autoKeysGeneration'
     ])).label('Update Pipeline'),
 
     /**

--- a/test/data/pipeline.update.yaml
+++ b/test/data/pipeline.update.yaml
@@ -1,3 +1,4 @@
 # Pipeline Create Example
 checkoutUrl: git@github.com:screwdriver-cd/data-schema.git#branch
 rootDir: src/app/test
+autoKeysGeneration: false


### PR DESCRIPTION
## Context

screwdriver-cd/screwdriver#1079

## Objective

Add autoDeployKeysGeneration flag to update schema.

## References

screwdriver-cd/screwdriver#1079

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
