### PR TITLE
[1] fix: noisy logs, no commit found for sha

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -234,7 +234,12 @@ const SCHEMA_HOOK = Joi.object().keys({
     releaseAuthor: Joi.string()
         .allow('')
         .optional()
-        .label('Author of the event')
+        .label('Author of the event'),
+
+    deleted: Joi.boolean()
+        .allow(null)
+        .optional()
+        .label('Deleted status of the event')
 
 }).label('SCM Hook');
 

--- a/test/data/scm.hook.push.yaml
+++ b/test/data/scm.hook.push.yaml
@@ -7,5 +7,6 @@ scmContext: github:github.com
 sha: ccc49349d3cffbd12ea9e3d41521480b4aa5de5f
 type: repo
 username: stjohnjohnson
+deleted: true
 ref: reference
 commitAuthors: ['john1', 'john2']


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Such errors occurs in a situation, and it is noisy in any investigation or analysis.
```
Getting errors with [{"action":"getCommit","token":"248ec46cbf868bfe999bf6590c0ba42ee8cd90a2","params":{"owner":"yoshwata-test","repo":"branch-filter-test","ref":"0000000000000000000000000000000000000000"}}]: HttpError: No commit found for SHA: 0000000000000000000000000000000000000000
```

The situation is
- When a branch is deleted
- the branch is match with the branch filter regex.

`00000` means that deleted branch is not exist anymore.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

API does not emit `No commit found for SHA: 0000~` error.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/data-schema/pull/410
https://github.com/screwdriver-cd/scm-github/pull/179

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
