### PR TITLE
fix: add key length for mysql

### DIFF
--- a/config/command.js
+++ b/config/command.js
@@ -65,6 +65,7 @@ const COMMAND_FORMAT = Joi
         'docker',
         'binary'
     )
+    .max(16)
     .description('Format of the Command')
     .example('habitat');
 

--- a/models/banner.js
+++ b/models/banner.js
@@ -34,6 +34,7 @@ const MODEL = {
         .example('batman123'),
 
     type: Joi.string().valid('info', 'warn')
+        .max(32)
         .description('Type/Severity of the banner message')
         .example('info')
 };

--- a/models/event.js
+++ b/models/event.js
@@ -63,6 +63,7 @@ const MODEL = {
             'pr',
             'pipeline'
         )
+        .max(10)
         .description('Type of the event')
         .example('pr'),
     workflowGraph: WorkflowGraph.workflowGraph

--- a/models/job.js
+++ b/models/job.js
@@ -39,6 +39,7 @@ const MODEL = {
             'ENABLED',
             'DISABLED'
         )
+        .max(10)
         .description('Current state of the Job')
         .example('ENABLED')
         .default('ENABLED'),

--- a/test/models/index.test.js
+++ b/test/models/index.test.js
@@ -56,17 +56,13 @@ describe('model commmons', () => {
 
                         // console.log(column, columnName);
                         if (column.key === columnName && schema.type === 'string') {
-                            if (schema.valids || !schema.rules) {
-                                // OK
-                            } else {
-                                const result = schema.rules.find(
-                                    rule => rule.name === 'max' || rule.name === 'length');
+                            const result = !schema.rules ? undefined : schema.rules.find(
+                                rule => rule.name === 'max' || rule.name === 'length');
 
-                                assert.isDefined(
-                                    result,
-                                    `${model}.${columnName} schema must have ` +
-                                    '(valids|length|max) definition.');
-                            }
+                            assert.isDefined(
+                                result,
+                                `${model}.${columnName} schema must have ` +
+                                '(valids|length|max) definition.');
                         }
                     });
                 });


### PR DESCRIPTION
## Context
As it has been accidentally deleted previously, I want bringing it back with this PR.
https://github.com/screwdriver-cd/data-schema/commit/679ed5d26a7c16d44e69ecac149a37bde1007cb2#diff-f9752cf0b76dbe6ff913d5934b1fe45bL41
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/data-schema/pull/311
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
