### PR TITLE
feat: expose a fields property on models

### DIFF
--- a/models/banner.js
+++ b/models/banner.js
@@ -48,6 +48,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Banner'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for Banner that will come back during a GET request
      *
      * @property get

--- a/models/build.js
+++ b/models/build.js
@@ -171,6 +171,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Build'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for Build that will come back during a GET request
      *
      * @property get

--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -61,6 +61,14 @@ module.exports = {
     base: Joi.object(MODEL).label('BuildCluster'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for BuildCluster that will come back during a GET request
      *
      * @property get

--- a/models/collection.js
+++ b/models/collection.js
@@ -70,6 +70,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Collection'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for collection that will come back during a GET request
      *
      * @property get

--- a/models/command.js
+++ b/models/command.js
@@ -41,6 +41,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Command'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for command that will come back during a GET request
      *
      * @property get

--- a/models/commandTag.js
+++ b/models/commandTag.js
@@ -30,6 +30,14 @@ module.exports = {
     base: Joi.object(MODEL).label('CommandTag'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * List of fields that determine a unique row
      *
      * @property keys

--- a/models/event.js
+++ b/models/event.js
@@ -105,6 +105,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Event'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for Event that will come back during a GET request
      *
      * @property get

--- a/models/job.js
+++ b/models/job.js
@@ -90,6 +90,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Job'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for Job that will come back during a GET request
      *
      * @property get

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -90,6 +90,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Pipeline'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for Pipeline that will come back during a GET request
      *
      * @property get

--- a/models/secret.js
+++ b/models/secret.js
@@ -39,6 +39,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Secret'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for secret that will come back during a GET request
      *
      * @property get

--- a/models/step.js
+++ b/models/step.js
@@ -57,6 +57,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Step'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for Step that will come back during a GET request
      *
      * @property get

--- a/models/template.js
+++ b/models/template.js
@@ -49,6 +49,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Template'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for template that will come back during a GET request
      *
      * @property get

--- a/models/templateTag.js
+++ b/models/templateTag.js
@@ -34,6 +34,14 @@ module.exports = {
     base: Joi.object(MODEL).label('TemplateTag'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * List of fields that determine a unique row
      *
      * @property keys

--- a/models/token.js
+++ b/models/token.js
@@ -64,6 +64,14 @@ module.exports = {
     base: Joi.object(MODEL).without('userId', 'pipelineId').label('Token'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for token that will come back during a GET request
      *
      * @property get

--- a/models/trigger.js
+++ b/models/trigger.js
@@ -30,6 +30,14 @@ module.exports = {
     base: Joi.object(MODEL).label('Trigger'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * List of fields that determine a unique row
      *
      * @property keys

--- a/models/user.js
+++ b/models/user.js
@@ -36,6 +36,14 @@ module.exports = {
     base: Joi.object(MODEL).label('User'),
 
     /**
+     * All the available properties of Job
+     *
+     * @property fields
+     * @type {Object}
+     */
+    fields: MODEL,
+
+    /**
      * Properties for User that will be passed during a CREATE request
      *
      * @property create


### PR DESCRIPTION
## Context

[Sequelize](https://github.com/screwdriver-cd/datastore-sequelize/blob/b4609dc1ccb38888b26afc2f048f5f9cec6b6bb5/index.js#L27) library uses joi.object().describe() to get all the keys that are there in the model, profiling the sd node process has showed that this heavily used function takes up a lot of the processing time due to the nature of it describe a huge joi object on the entire model which leads to performance issues. To fix this we need to expose the model object itself to sequelize.

## Objective

This PR adds a property fields on models and exposes the model object.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2216

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
