### PR TITLE
fix(2199): Downtime jobs should be array of jobIds [1]

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Joi = require('joi');
-const Job = require('./job');
 
 const SCHEMA_DISPLAY_JOB_NAME_LENGTH = Joi.number().integer()
     .min(20)
@@ -10,12 +9,21 @@ const SCHEMA_DISPLAY_JOB_NAME_LENGTH = Joi.number().integer()
     .description('Job name length to display on workflowGraph')
     .example(20);
 const SCHEMA_METRICS_DOWNTIME_JOBS = Joi.array().items(
-    Job.jobName
-).description('Jobs to watch for downtime');
+    Joi
+        .number().integer().positive()
+        .description('Identifier for this job')
+        .example(123345)
+        .optional()
+        .allow(null)
+).description('Job IDs to watch for downtime');
+const SCHEMA_METRICS_DOWNTIME_STATUSES = Joi.array().items(
+    Joi.string()
+).description('Build statuses to watch for downtime');
 
 const SCHEMA_PIPELINE_SETTINGS = Joi.object()
     .keys({
-        metricsDowntimeJobs: SCHEMA_METRICS_DOWNTIME_JOBS
+        metricsDowntimeJobs: SCHEMA_METRICS_DOWNTIME_JOBS,
+        metricsDowntimeStatuses: SCHEMA_METRICS_DOWNTIME_STATUSES
     })
     .default({});
 const SCHEMA_USER_SETTINGS = Joi.object()
@@ -26,5 +34,6 @@ const SCHEMA_USER_SETTINGS = Joi.object()
 
 module.exports = {
     pipelineSettings: SCHEMA_PIPELINE_SETTINGS,
-    userSettings: SCHEMA_USER_SETTINGS
+    userSettings: SCHEMA_USER_SETTINGS,
+    metricsDowntimeJobs: SCHEMA_METRICS_DOWNTIME_JOBS
 };

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -27,8 +27,8 @@ childPipelines:
     startAll: true
 settings:
     metricsDowntimeJobs:
-            - staging
-            - production
+            - 123
+            - 456
 subscribedScmUrlsWithActions:
     - scmUri: github.com:56781234:master
       actions: [commit, tag, release]

--- a/test/data/pipeline.update.yaml
+++ b/test/data/pipeline.update.yaml
@@ -4,5 +4,8 @@ rootDir: src/app/test
 autoKeysGeneration: false
 settings:
     metricsDowntimeJobs:
-            - main
-            - production
+        - 222
+        - 333
+    metricsDowntimeStatuses:
+        - FAILURE
+        - ABORTED


### PR DESCRIPTION
## Context

Would be better for UI to pass in array of job IDs rather than have the API look them up.

## Objective

This PR changes `downtimeJobs` to array of `jobIds` vs `jobNames`; also adds `downtimeStatuses`.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2199

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
