### PR TITLE
feat(2267): allow multiple keyword scan

### DIFF
--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -18,6 +18,10 @@ const SCHEMA_SAVE = Joi.object().keys({
     params: Joi.object().unknown(true).min(1).required()
 });
 const SCHEMA_SEARCH_FIELD = Joi.string().max(100).required();
+const SCHEMA_SEARCH_KEYWORD = Joi.alternatives().try(
+    Joi.string().max(200).required(),
+    Joi.number().required()
+);
 const SCHEMA_SCAN = Joi.object().keys({
     table,
     params: Joi.object(),
@@ -30,7 +34,10 @@ const SCHEMA_SCAN = Joi.object().keys({
             Joi.array().items(SCHEMA_SEARCH_FIELD),
             SCHEMA_SEARCH_FIELD
         ),
-        keyword: Joi.string().max(200).required()
+        keyword: Joi.alternatives().try(
+            Joi.array().items(SCHEMA_SEARCH_KEYWORD),
+            SCHEMA_SEARCH_KEYWORD
+        )
     }),
     sort: Joi.string().lowercase().valid('ascending', 'descending').default('descending'),
     sortBy: Joi.string().max(100),

--- a/test/data/datastore.search.multipleKeywords.yaml
+++ b/test/data/datastore.search.multipleKeywords.yaml
@@ -1,0 +1,9 @@
+table: 'jobs'
+paginate:
+    page: 1
+    count: 2
+search:
+    field: 'id'
+    keyword: [1,2,3,4]
+sortBy: 'name'
+sort: ascending

--- a/test/plugins/datastore.test.js
+++ b/test/plugins/datastore.test.js
@@ -54,6 +54,10 @@ describe('datastore test', () => {
             assert.isNull(validate('datastore.search.multipleFields.yaml', datastore.scan).error);
         });
 
+        it('validates the update with multiple search keywords', () => {
+            assert.isNull(validate('datastore.search.multipleKeywords.yaml', datastore.scan).error);
+        });
+
         it('validates the update with all keys', () => {
             assert.isNull(validate('datastore.paginateFull.yaml', datastore.scan).error);
         });


### PR DESCRIPTION
## Context
We are changing scan() to support multi keyword search, this is a change to support that
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Allow keyword array
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2267
https://github.com/screwdriver-cd/datastore-sequelize/pull/78
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
