### PR TITLE
fix: Fix migration file for mysql

### DIFF
--- a/migrations/20201102-change_column_subscribedScmUrlsWithActions_to_pipelines.js
+++ b/migrations/20201102-change_column_subscribedScmUrlsWithActions_to_pipelines.js
@@ -8,8 +8,18 @@ const table = `${prefix}pipelines`;
 module.exports = {
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
+            await queryInterface.removeIndex(table, `${table}_subscribed_scm_urls_with_actions`);
+
             await queryInterface.changeColumn(table, 'subscribedScmUrlsWithActions', {
                 type: Sequelize.TEXT('medium') }, { transaction });
+
+            await queryInterface.addIndex(
+                table,
+                [{ attribute: 'subscribedScmUrlsWithActions', length: 128 }],
+                {
+                    name: `${table}_subscribed_scm_urls_with_actions`,
+                    transaction
+                });
         });
     }
 };

--- a/migrations/20201102-change_column_subscribedScmUrlsWithActions_to_pipelines.js
+++ b/migrations/20201102-change_column_subscribedScmUrlsWithActions_to_pipelines.js
@@ -8,7 +8,11 @@ const table = `${prefix}pipelines`;
 module.exports = {
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async (transaction) => {
-            await queryInterface.removeIndex(table, `${table}_subscribed_scm_urls_with_actions`);
+            await queryInterface.removeIndex(
+                table,
+                `${table}_subscribed_scm_urls_with_actions`,
+                { transaction }
+            );
 
             await queryInterface.changeColumn(table, 'subscribedScmUrlsWithActions', {
                 type: Sequelize.TEXT('medium') }, { transaction });

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -172,5 +172,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['scmUri'] }]
+    indexes: [{ fields: ['scmUri'] }, { fields: ['subscribedScmUrlsWithActions'], length: 128 }]
 };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
[migrations/20201102-change_column_subscribedScmUrlsWithActions_to_pipelines.js](https://github.com/kumada626/data-schema/blob/9ebe3a42d3779de62e8c371ebe06cde74de883ec/migrations/20201102-change_column_subscribedScmUrlsWithActions_to_pipelines.js) is not applied on mysql.
Because text column has to be indexed with length in mysql.

Therefore, in the case of mysql the index must be dropped before changing the column type.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Drop index before changing the column type.
Re add index after changing the column type.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
