### PR TITLE
[4]feat(1815): change to warnMessages from warnAnnotations

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -57,7 +57,7 @@ const SCHEMA_OUTPUT = Joi.object()
         childPipelines: Base.childPipelines,
         workflowGraph: WorkflowGraph.workflowGraph,
         parameters: Parameters.parameters,
-        warnAnnotations: Joi.array().optional(),
+        warnMessages: Joi.array().optional(),
         subscribe: Base.subscribe
     })
     .label('Execution information');

--- a/test/data/validator.warningsoutput.yaml
+++ b/test/data/validator.warningsoutput.yaml
@@ -66,6 +66,6 @@ jobs:
     secrets:
       - NPM_TOKEN
 
-warnAnnotations:
+warnMessages:
 - 'screwdriver.cd/chainPR'
 - 'screwdriver.cd/cpu'


### PR DESCRIPTION
## Context
API is outputting error message `data: ValidationError: "warnMessages" is not allowed`, I fixed it.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
It should work correctly when combined with the following modules.
https://github.com/screwdriver-cd/models/releases/tag/v28.5.5
https://github.com/screwdriver-cd/config-parser/releases/tag/v6.3.0
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1815
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

[4] : https://github.com/screwdriver-cd/data-schema/pull/427 (this PR)
[5] : https://github.com/screwdriver-cd/screwdriver/pull/2308

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
