### PR TITLE
feat(2319): [1] Add order field to job config, warnMessages for template validator

### DIFF
--- a/api/templateValidator.js
+++ b/api/templateValidator.js
@@ -28,7 +28,8 @@ const SCHEMA_OUTPUT = Joi.object()
         // since a template could be parseable but invalid, the contents are unpredictable
         template: Joi.object()
             .label('The end-result of parsing the given template')
-            .required()
+            .required(),
+        warnMessages: Joi.array().optional()
     })
     .label('Template validation output');
 

--- a/api/validator.js
+++ b/api/validator.js
@@ -24,19 +24,20 @@ const SCHEMA_JOB_COMMANDS = Joi.array()
 const SCHEMA_JOB_PERMUTATION = Joi.object()
     .keys({
         annotations: Annotations.annotations,
+        blockedBy: Job.blockedBy,
         cache: Base.cachePerm,
         commands: SCHEMA_JOB_COMMANDS,
         description: Job.description,
         environment: Job.environment,
+        freezeWindows: Job.freezeWindows,
         image: Job.image,
+        order: Job.order,
         requires: Job.requires,
-        blockedBy: Job.blockedBy,
         secrets: Job.secrets,
         settings: Job.settings,
         sourcePaths: Job.sourcePaths,
-        freezeWindows: Job.freezeWindows,
-        templateId: Job.templateId,
-        subscribe: Base.subscribe
+        subscribe: Base.subscribe,
+        templateId: Job.templateId
     }).label('Job permutation');
 
 const SCHEMA_JOB_PERMUTATIONS = Joi.array().items(SCHEMA_JOB_PERMUTATION)

--- a/config/job.js
+++ b/config/job.js
@@ -92,6 +92,9 @@ const SCHEMA_STEP_OBJECT = Joi.object()
 
 const SCHEMA_DESCRIPTION = Joi.string().max(100).optional();
 const SCHEMA_IMAGE = Joi.string().regex(Regex.IMAGE_NAME);
+const SCHEMA_ORDER = Joi.array()
+    .items(SCHEMA_STEP_STRING.regex(Regex.STEP_NAME))
+    .min(0);
 const SCHEMA_SETTINGS = Joi.object().optional();
 const SCHEMA_STEP = Joi.alternatives().try(SCHEMA_STEP_STRING, SCHEMA_STEP_OBJECT);
 const SCHEMA_STEPS = Joi.array().items(SCHEMA_STEP).min(1);
@@ -142,38 +145,40 @@ const SCHEMA_CACHE = Joi.boolean().optional();
 const SCHEMA_JOB = Joi.object()
     .keys({
         annotations: Annotations.annotations,
+        blockedBy: SCHEMA_BLOCKEDBY,
+        cache: SCHEMA_CACHE,
         description: SCHEMA_DESCRIPTION,
         environment: SCHEMA_ENVIRONMENT,
+        freezeWindows: SCHEMA_FREEZEWINDOWS,
         image: SCHEMA_IMAGE,
         matrix: SCHEMA_MATRIX,
+        order: SCHEMA_ORDER,
         requires: SCHEMA_REQUIRES,
-        blockedBy: SCHEMA_BLOCKEDBY,
-        freezeWindows: SCHEMA_FREEZEWINDOWS,
         secrets: SCHEMA_SECRETS,
         settings: SCHEMA_SETTINGS,
         sourcePaths: SCHEMA_SOURCEPATHS,
         steps: SCHEMA_STEPS,
         template: SCHEMA_TEMPLATE,
-        templateId: SCHEMA_TEMPLATEID,
-        cache: SCHEMA_CACHE
+        templateId: SCHEMA_TEMPLATEID
     })
     .default({});
 const SCHEMA_JOB_NO_DUP_STEPS = Joi.object()
     .keys({
         annotations: Annotations.annotations,
+        blockedBy: SCHEMA_BLOCKEDBY,
+        cache: SCHEMA_CACHE,
         description: SCHEMA_DESCRIPTION,
         environment: SCHEMA_ENVIRONMENT,
+        freezeWindows: SCHEMA_FREEZEWINDOWS,
         image: SCHEMA_IMAGE,
         matrix: SCHEMA_MATRIX,
+        order: SCHEMA_ORDER,
         requires: SCHEMA_REQUIRES,
-        blockedBy: SCHEMA_BLOCKEDBY,
-        freezeWindows: SCHEMA_FREEZEWINDOWS,
         secrets: SCHEMA_SECRETS,
         settings: SCHEMA_SETTINGS,
         sourcePaths: SCHEMA_SOURCEPATHS,
         steps: SCHEMA_STEPS_NO_DUPS,
-        template: SCHEMA_TEMPLATE,
-        cache: SCHEMA_CACHE
+        template: SCHEMA_TEMPLATE
     })
     .default({});
 
@@ -183,15 +188,20 @@ const SCHEMA_JOB_NO_DUP_STEPS = Joi.object()
  */
 module.exports = {
     annotations: Annotations.annotations,
+    blockedBy: SCHEMA_BLOCKEDBY,
+    cache: SCHEMA_CACHE,
     description: SCHEMA_DESCRIPTION,
     environment: SCHEMA_ENVIRONMENT,
+    externalTrigger: SCHEMA_EXTERNAL_TRIGGER,
+    freezeWindows: SCHEMA_FREEZEWINDOWS,
     image: SCHEMA_IMAGE,
     job: SCHEMA_JOB,
+    jobName: SCHEMA_JOBNAME,
     jobNoDupSteps: SCHEMA_JOB_NO_DUP_STEPS,
     matrix: SCHEMA_MATRIX,
+    order: SCHEMA_ORDER,
     requires: SCHEMA_REQUIRES,
-    blockedBy: SCHEMA_BLOCKEDBY,
-    freezeWindows: SCHEMA_FREEZEWINDOWS,
+    requiresValue: SCHEMA_REQUIRES_VALUE,
     secret: SCHEMA_SECRET,
     secrets: SCHEMA_SECRETS,
     settings: SCHEMA_SETTINGS,
@@ -201,9 +211,5 @@ module.exports = {
     steps: SCHEMA_STEPS,
     template: SCHEMA_TEMPLATE,
     templateId: SCHEMA_TEMPLATEID,
-    requiresValue: SCHEMA_REQUIRES_VALUE,
-    jobName: SCHEMA_JOBNAME,
-    externalTrigger: SCHEMA_EXTERNAL_TRIGGER,
-    trigger: SCHEMA_TRIGGER,
-    cache: SCHEMA_CACHE
+    trigger: SCHEMA_TRIGGER
 };

--- a/test/data/config.template.yaml
+++ b/test/data/config.template.yaml
@@ -3,9 +3,15 @@ version: "1.3"
 description: Template for testing
 maintainer: foo@bar.com
 config:
+  template: simple/template@1
+  order:
+    - install
+    - test
+    - other
+    - echo
   image: node:6
   steps:
-    - install: npm install 
+    - install: npm install
     - test: npm test
     - echo: echo $FOO
   environment:

--- a/test/data/template-validator.output.yaml
+++ b/test/data/template-validator.output.yaml
@@ -1,5 +1,7 @@
 ---
 errors: []
+warnMessages:
+    - init step in cannot be found in current template or external template; skipping
 template:
     name: template_namespace/nodejs_main
     version: 1.1.2

--- a/test/data/template.create.yaml
+++ b/test/data/template.create.yaml
@@ -8,6 +8,12 @@ labels:
     - test
     - beta
 config:
+  template: simple/template@1
+  order:
+    - install
+    - test
+    - other
+    - echo
   image: node:6
   steps:
     - install: npm install


### PR DESCRIPTION
## Context

Would be nice if template owners could pick and choose which steps from a template should be run in their own.

## Objective

This PR adds support for the `order` keyword in a job; also adds support for warnMessages for template validator.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2319

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
