### PR TITLE
fix(2312): add getCount to pagination and scan

### DIFF
--- a/api/pagination.js
+++ b/api/pagination.js
@@ -24,7 +24,11 @@ const MODEL = {
 
     sortBy: Joi
         .string().max(100)
-        .description('Field to sort by')
+        .description('Field to sort by'),
+
+    getCount: Joi
+        .boolean()
+        .description('Return total count')
 };
 
 /**

--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -46,7 +46,8 @@ const SCHEMA_SCAN = Joi.object().keys({
     startTime: Joi.string().isoDate(),
     endTime: Joi.string().isoDate(),
     timeKey: Joi.string(),
-    aggregationField: Joi.string()
+    aggregationField: Joi.string(),
+    getCount: Joi.boolean()
 });
 const SCHEMA_QUERY = Joi.object().keys({
     table,

--- a/test/data/datastore.search.multipleFields.yaml
+++ b/test/data/datastore.search.multipleFields.yaml
@@ -7,3 +7,4 @@ search:
     keyword: '%screwdriver%'
 sortBy: 'name'
 sort: ascending
+getCount: true

--- a/test/data/paginationFull.yaml
+++ b/test/data/paginationFull.yaml
@@ -3,3 +3,4 @@ count: 30
 sort: 'ascending'
 sortBy: 'scmRepo.name'
 search: 'screwdriver-cd/screwdriver'
+getCount: true


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Would be nice if we can get total count alongside paginated content
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add a field `getCount` to indicated that we want to get total count
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2312
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
