### PR TITLE
fix: fix migration file for mysql

### DIFF
--- a/migrations/20210122-add_column_latestVersion_to_commands.js
+++ b/migrations/20210122-add_column_latestVersion_to_commands.js
@@ -11,7 +11,7 @@ module.exports = {
             await queryInterface.addColumn(table, 'latest', {
                 type: Sequelize.BOOLEAN }, { transaction });
             // eslint-disable-next-line max-len
-            await queryInterface.sequelize.query(`UPDATE ${table} SET latest = true WHERE id in (SELECT max(id) FROM ${table} GROUP BY namespace, name)`);
+            await queryInterface.sequelize.query(`UPDATE ${table} SET latest = true WHERE id in (SELECT max(id) FROM (SELECT * FROM ${table}) AS cmd GROUP BY namespace, name)`);
         });
     }
 };

--- a/migrations/20210122-add_column_latestVersion_to_templates.js
+++ b/migrations/20210122-add_column_latestVersion_to_templates.js
@@ -11,7 +11,7 @@ module.exports = {
             await queryInterface.addColumn(table, 'latest', {
                 type: Sequelize.BOOLEAN }, { transaction });
             // eslint-disable-next-line max-len
-            await queryInterface.sequelize.query(`UPDATE ${table} SET latest = true WHERE id in (SELECT max(id) FROM ${table} GROUP BY namespace, name)`);
+            await queryInterface.sequelize.query(`UPDATE ${table} SET latest = true WHERE id in (SELECT max(id) FROM (SELECT * FROM ${table}) AS tmpl GROUP BY namespace, name)`);
         });
     }
 };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
In MySQL, we can't modify the same table which we use in the SELECT part.
Therefore, MySQL cannot use these migration files.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Nesting the subquery deeper into a from clause.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://stackoverflow.com/questions/45494/mysql-error-1093-cant-specify-target-table-for-update-in-from-clause

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
