### PR TITLE
[2]fix(1901): add screwdriver.cd/manualStartEnabled annotation

### DIFF
--- a/config/annotations.js
+++ b/config/annotations.js
@@ -22,7 +22,8 @@ const RESERVED_JOB_ANNOTATIONS = [
     'screwdriver.cd/coverageScope',
     'screwdriver.cd/terminationGracePeriodSeconds',
     'screwdriver.cd/displayName',
-    'screwdriver.cd/mergeSharedSteps'
+    'screwdriver.cd/mergeSharedSteps',
+    'screwdriver.cd/manualStartEnabled'
 ];
 const RESERVED_PIPELINE_ANNOTATIONS = [
     'screwdriver.cd/buildCluster',


### PR DESCRIPTION
## Context
I added support for new annotations in the UI, so I want to add the annotation for validator.
https://github.com/screwdriver-cd/ui/pull/670
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
When using the `screwdriver.cd/manualStartEnabled` annotation, the validator will not output a warning.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1901
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
