### PR TITLE
fix(2331): Pass locked job steps [2.5]

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -13,7 +13,7 @@ const SCHEMA_JOB_COMMAND = Joi.object()
         name: Joi.string(),
         command: Joi.string()
     })
-    .unknown(false)
+    .unknown(true) // allow other fields
     .label('Named command to execute');
 
 const SCHEMA_JOB_COMMANDS = Joi.array()

--- a/api/validator.js
+++ b/api/validator.js
@@ -11,9 +11,10 @@ const WorkflowGraph = require('../config/workflowGraph');
 const SCHEMA_JOB_COMMAND = Joi.object()
     .keys({
         name: Joi.string(),
-        command: Joi.string()
+        command: Joi.string(),
+        locked: Joi.boolean().optional()
     })
-    .unknown(true) // allow other fields
+    .unknown(false)
     .label('Named command to execute');
 
 const SCHEMA_JOB_COMMANDS = Joi.array()

--- a/test/data/job.yaml
+++ b/test/data/job.yaml
@@ -8,6 +8,7 @@ permutations:
       commands:
         - name: install
           command: npm install
+          locked: true
         - name: test
           command: npm test
         - name: build


### PR DESCRIPTION
## Context

Would be nice if the UI could show locked steps in a job when template is used.

## Objective

This PR allows more data to be sent from config parser through commands so locked step can be shown in the UI.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2331

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
