### PR TITLE
fix(2331): Add templateId to template config

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -189,42 +189,14 @@ const SCHEMA_JOB = Joi.object()
         templateId: SCHEMA_TEMPLATEID
     })
     .default({});
-const SCHEMA_JOB_NO_DUP_STEPS = Joi.object()
+const SCHEMA_JOB_NO_DUP_STEPS = SCHEMA_JOB
     .keys({
-        annotations: Annotations.annotations,
-        blockedBy: SCHEMA_BLOCKEDBY,
-        cache: SCHEMA_CACHE,
-        description: SCHEMA_DESCRIPTION,
-        environment: SCHEMA_ENVIRONMENT,
-        freezeWindows: SCHEMA_FREEZEWINDOWS,
-        image: SCHEMA_IMAGE,
-        matrix: SCHEMA_MATRIX,
-        order: SCHEMA_ORDER,
-        requires: SCHEMA_REQUIRES,
-        secrets: SCHEMA_SECRETS,
-        settings: SCHEMA_SETTINGS,
-        sourcePaths: SCHEMA_SOURCEPATHS,
-        steps: SCHEMA_STEPS_NO_DUPS,
-        template: SCHEMA_TEMPLATE
+        steps: SCHEMA_STEPS_NO_DUPS
     })
     .default({});
-const SCHEMA_TEMPLATE_JOB = Joi.object()
+const SCHEMA_TEMPLATE_JOB = SCHEMA_JOB
     .keys({
-        annotations: Annotations.annotations,
-        blockedBy: SCHEMA_BLOCKEDBY,
-        cache: SCHEMA_CACHE,
-        description: SCHEMA_DESCRIPTION,
-        environment: SCHEMA_ENVIRONMENT,
-        freezeWindows: SCHEMA_FREEZEWINDOWS,
-        image: SCHEMA_IMAGE,
-        matrix: SCHEMA_MATRIX,
-        order: SCHEMA_ORDER,
-        requires: SCHEMA_REQUIRES,
-        secrets: SCHEMA_SECRETS,
-        settings: SCHEMA_SETTINGS,
-        sourcePaths: SCHEMA_SOURCEPATHS,
-        steps: SCHEMA_TEMPLATE_STEPS,
-        template: SCHEMA_TEMPLATE
+        steps: SCHEMA_TEMPLATE_STEPS
     })
     .default({});
 


### PR DESCRIPTION
## Context

Template tag is failing with:
```
00:00:10 $ template-tag --name tiff/template --tag latest
00:00:10 Error: Error getting latest template version. 500 (Internal Server Error): "[0].config.templateId" is not allowed
00:00:10     at request.then (/usr/local/lib/node_modules/screwdriver-template-main/index.js:158:19)
00:00:10     at <anonymous>
00:00:10     at process._tickCallback (internal/process/next_tick.js:189:7)
```
https://cd.screwdriver.cd/pipelines/256/builds/682810/steps/autotag

## Objective

This PR adds `templateId` field to template `config` section.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2331

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
