### PR TITLE
fix(2331): Allow only template for template config

### DIFF
--- a/config/template.js
+++ b/config/template.js
@@ -69,7 +69,7 @@ const SCHEMA_TEMPLATE = Joi.object()
         version: TEMPLATE_VERSION.required(),
         description: TEMPLATE_DESCRIPTION.required(),
         maintainer: TEMPLATE_MAINTAINER.required(),
-        config: Job.templateJob.required().with('image', 'steps').or('image').or('steps'),
+        config: Job.templateJob.required().or('image', 'template').or('steps', 'template'),
         images: TEMPLATE_IMAGES
     });
 


### PR DESCRIPTION
## Context

Template config should be allowed to just have a `template` without `image` and `steps`.
Currently, the validator is failing with this template yaml:
```
name: test
namespace: demo
version: "1.0"
maintainer: foo@bar.com
description: Demo locked step
config:
  image: node:8
  template: tifftemplate@1.0.2
```
With these errors:
```
"image" missing required peer "steps"
"config" must contain at least one of [steps]
```

## Objective

This PR just checks that either template is present or both image and steps.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2331

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
