### PR TITLE
fix: Do not allow stateChanger and stateChangeTime in job update [3]

### DIFF
--- a/models/job.js
+++ b/models/job.js
@@ -115,14 +115,13 @@ module.exports = {
     ])).label('Get Job'),
 
     /**
-     * Properties for Job that will come back during a UPDATE request
+     * Properties for Job that will be passed during an UPDATE request
      *
      * @property update
      * @type {Joi}
      */
     update: Joi.object(mutate(MODEL, [], [
-        'state', 'stateChanger', 'stateChangeTime',
-        'stateChangeMessage'
+        'state', 'stateChangeMessage'
     ])).label('Update Job'),
 
     /**

--- a/package.json
+++ b/package.json
@@ -42,19 +42,19 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "js-yaml": "^3.14.0",
-    "mocha": "^8.2.1",
+    "js-yaml": "^3.14.1",
+    "mocha": "^8.3.2",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
-    "nyc": "^15.0.0",
     "mysql2": "^1.7.0",
+    "nyc": "^15.0.0",
     "pg": "^7.18.2",
-    "sequelize": "^5.22.3",
+    "sequelize": "^5.22.4",
     "sequelize-cli": "^5.5.1",
     "sqlite3": "^4.2.0"
   },
   "dependencies": {
-    "cron-parser": "^2.15.0",
-    "joi": "^17.1.1"
+    "cron-parser": "^2.18.0",
+    "joi": "^17.4.0"
   }
 }

--- a/test/data/job.state.update.yaml
+++ b/test/data/job.state.update.yaml
@@ -1,4 +1,2 @@
 state: 'ENABLED'
-stateChanger: 'd2lam'
-stateChangeTime: '2011-01-26T19:01:12Z'
 stateChangeMessage: 'Testing out new feature change in beta only'


### PR DESCRIPTION
## Context

Currently, users can pass in `stateChanger` and `stateChangeTime` to job update endpoint. This information does not need to be passed in, since we can gather it from user credentials, etc.

## Objective

This PR removes `stateChanger` and `stateChangeTime` from allowed job update params.
Note: This will break anyone directly calling `PUT /jobs/:id` with `stateChanger` and `stateChangeTime` passed in.

## References

Blocked by https://github.com/screwdriver-cd/screwdriver/pull/2412

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
