### PR TITLE
fix(2437): Allow passing in scmContext to buildCluster [1]

### DIFF
--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -89,7 +89,7 @@ module.exports = {
      */
     update: Joi.object(mutate(MODEL, [], [
         'description', 'isActive', 'scmOrganizations', 'managedByScrewdriver',
-        'maintainer', 'weightage'
+        'maintainer', 'weightage', 'scmContext'
     ])).label('Update BuildCluster'),
 
     /**
@@ -101,7 +101,7 @@ module.exports = {
     create: Joi.object(mutate(MODEL, [
         'name', 'scmOrganizations', 'managedByScrewdriver', 'maintainer'
     ], [
-        'description', 'isActive', 'weightage'
+        'description', 'isActive', 'weightage', 'scmContext'
     ])).label('Create Build'),
 
     /**

--- a/test/data/buildCluster.create.yaml
+++ b/test/data/buildCluster.create.yaml
@@ -3,3 +3,4 @@ name: iOS
 scmOrganizations: [screwdriver-cd]
 managedByScrewdriver: false
 maintainer: foo@bar.com
+scmContext: gitlab:gitlab.com

--- a/test/data/buildCluster.update.yaml
+++ b/test/data/buildCluster.update.yaml
@@ -5,3 +5,4 @@ isActive: true
 managedByScrewdriver: false
 maintainer: foo@bar.com
 weightage: 50
+scmContext: gitlab:gitlab.com


### PR DESCRIPTION
## Context

Should be allowed to pass in scmContext to build cluster. This is necessary for read-only SCM, since scmContext cannot be derived from user profile (since you cannot login to read-only SCM).

## Objective

This PR allows scmContext to be passed into build cluster create/update. 

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437, https://github.com/screwdriver-cd/screwdriver/pull/2495

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
