### PR TITLE
fix: migration error for mysql

### DIFF
--- a/migrations/20210310-add_uniquekey_to_builds.js
+++ b/migrations/20210310-add_uniquekey_to_builds.js
@@ -11,7 +11,7 @@ module.exports = {
         await queryInterface.sequelize.transaction(async (transaction) => {
             const dialect = queryInterface.sequelize.getDialect();
             // eslint-disable-next-line max-len
-            let query = `DELETE a FROM "${table}" AS a, "${table}" AS b WHERE a.id > b.id AND a."eventId" = b."eventId" AND a."jobId" = b."jobId"`;
+            let query = `DELETE a FROM ${table} AS a, ${table} AS b WHERE a.id > b.id AND a.eventId = b.eventId AND a.jobId = b.jobId`;
 
             if (dialect === 'postgres') {
                 // eslint-disable-next-line max-len


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Under the mysql environment, the following error occurred during migration, so fix it.

```
ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to us
e near '"builds" AS a, "builds" AS b WHERE a.id > b.id AND a."eventId" = b."eventId" AND' at line 1
```

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Migration become possible under mysql environment.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
