### PR TITLE
fix: Add description to autoKeysGeneration

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -19,7 +19,9 @@ const CREATE_MODEL = {
         .required(),
 
     rootDir: Scm.rootDir,
-    autoKeysGeneration: Joi.boolean().optional()
+    autoKeysGeneration: Joi.boolean()
+        .optional()
+        .description('Flag to generate and add the public deploy key for a specific scm')
 };
 
 const MODEL = {


### PR DESCRIPTION
## Context

It's confusing what certain fields are for in the API.
<img width="1442" alt="Screen Shot 2021-09-01 at 3 29 14 PM" src="https://user-images.githubusercontent.com/3230529/131754458-f797baa0-a90a-466a-886e-bacc0c7e8059.png">


## Objective

This PR adds a description to the field autoKeysGeneration.

## References

N/A
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
