### PR TITLE
fix: Bump up max char length for triggers

### DIFF
--- a/migrations/20211004-update_trigger_length-triggers.js
+++ b/migrations/20211004-update_trigger_length-triggers.js
@@ -1,0 +1,17 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}triggers`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.changeColumn(table, 'src', Sequelize.STRING(128), { transaction });
+        });
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.changeColumn(table, 'dest', Sequelize.STRING(128), { transaction });
+        });
+    }
+};

--- a/models/trigger.js
+++ b/models/trigger.js
@@ -13,10 +13,10 @@ const MODEL = {
         .try(
             Joi.string()
                 .regex(Regex.EXTERNAL_TRIGGER)
-                .max(64),
+                .max(128),
             Joi.string()
                 .regex(Regex.EXTERNAL_TRIGGER_AND)
-                .max(64)
+                .max(128)
         )
         .example('~sd@1234:component'),
 
@@ -24,10 +24,10 @@ const MODEL = {
         .try(
             Joi.string()
                 .regex(Regex.EXTERNAL_TRIGGER)
-                .max(64),
+                .max(128),
             Joi.string()
                 .regex(Regex.EXTERNAL_TRIGGER_AND)
-                .max(64)
+                .max(128)
         )
         .example('~sd@5678:test')
 };


### PR DESCRIPTION
## Context

The [max job name length](https://github.com/screwdriver-cd/data-schema/blob/master/config/job.js#L81) is 100 chars, but the [max trigger name length](https://github.com/screwdriver-cd/data-schema/blob/master/models/trigger.js#L12-L31) is only 64 chars (including the additional `~sd@` prefix).

## Objective

This PR bumps up the max trigger name length to 128. 

## References
N/A

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
