### PR TITLE
fix(2561): Should have provider passed to executor [1.5]

### DIFF
--- a/config/provider.js
+++ b/config/provider.js
@@ -8,7 +8,8 @@ const SCHEMA_VPC_OBJECT = Joi.object({
         .regex(Regex.VPC_ID)
         .max(128)
         .description('VPC ID')
-        .example('vpc-1a2b3c4d'),
+        .example('vpc-1a2b3c4d')
+        .required(),
     securityGroupIds: Joi.array()
         .items(
             Joi.string()
@@ -18,7 +19,8 @@ const SCHEMA_VPC_OBJECT = Joi.object({
                 .example('sg-51530134')
         )
         .min(1)
-        .label('List of security group IDs'),
+        .label('List of security group IDs')
+        .required(),
     subnetIds: Joi.array()
         .items(
             Joi.string()
@@ -29,6 +31,7 @@ const SCHEMA_VPC_OBJECT = Joi.object({
         )
         .min(1)
         .label('List of subnet IDs')
+        .required()
 });
 
 const SCHEMA_PROVIDER = Joi.object().keys({

--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -26,6 +26,7 @@ const buildSchemaObj = {
     jobName,
     jobState,
     jobArchived,
+    provider: Job.provider,
     annotations: Annotations.annotations,
     blockedBy: Joi.array().items(jobId),
     freezeWindows: Job.freezeWindows,
@@ -61,7 +62,8 @@ const SCHEMA_STOP = Joi.object()
         buildClusterName: models.buildCluster.base.extract('name'),
         jobId,
         token: Joi.string().label('Build JWT'),
-        pipelineId
+        pipelineId,
+        provider: Job.provider
     })
     .required();
 const SCHEMA_STATUS = Joi.object()
@@ -69,7 +71,8 @@ const SCHEMA_STATUS = Joi.object()
         buildId,
         token: Joi.string().label('Build JWT'),
         pipelineId,
-        jobId
+        jobId,
+        provider: Job.provider
     })
     .required();
 const SCHEMA_VERIFY = Joi.object()

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -2,6 +2,13 @@ jobId: 1234
 jobName: component
 jobState: ENABLED
 jobArchived: false
+provider:
+    name: aws
+    region: us-west-2
+    accountId: 111111111111
+    role: arn:aws:iam::111111111111:role/role
+    executor: eks
+    clusterName: sd-build-eks
 annotations:
     beta.screwdriver.cd/executor: k8s
 causeMessage: '[force start] Push out hotfix'

--- a/test/data/executor.stop.yaml
+++ b/test/data/executor.stop.yaml
@@ -9,3 +9,10 @@ blockedBy:
 freezeWindows:
   - "* * ? * 1"
   - "0-59 0-23 * 1 ?"
+provider:
+    name: aws
+    region: us-west-2
+    accountId: 111111111111
+    role: arn:aws:iam::111111111111:role/role
+    executor: eks
+    clusterName: sd-build-eks


### PR DESCRIPTION
## Context

Should pass provider info to the executor.

## Objective

This PR:
- adds validation for provider to be passed to the executor
- requires VPC fields to be present when set

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2561

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
