### PR TITLE
fix: Allow other fields for executor params

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -52,6 +52,7 @@ const buildSchemaObj = {
 };
 const SCHEMA_START = Joi.object()
     .keys(buildSchemaObj)
+    .unknown(true) // allow other fields
     .required();
 const SCHEMA_STOP = Joi.object()
     .keys({
@@ -65,6 +66,7 @@ const SCHEMA_STOP = Joi.object()
         pipelineId,
         provider: Job.provider
     })
+    .unknown(true) // allow other fields
     .required();
 const SCHEMA_STATUS = Joi.object()
     .keys({
@@ -74,9 +76,11 @@ const SCHEMA_STATUS = Joi.object()
         jobId,
         provider: Job.provider
     })
+    .unknown(true) // allow other fields
     .required();
 const SCHEMA_VERIFY = Joi.object()
     .keys(buildSchemaObj)
+    .unknown(true) // allow other fields
     .required();
 
 module.exports = {


### PR DESCRIPTION
## Context

Should not fail if extra params are passed into executor.

## Objective

This PR adds allowUnknown to executor params.

## References
N/A

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
