### PR TITLE
feat(#2561): Add jobname & apiuri to executor stop config

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -64,7 +64,12 @@ const SCHEMA_STOP = Joi.object()
         jobId,
         token: Joi.string().label('Build JWT'),
         pipelineId,
-        provider: Job.provider
+        provider: Job.provider,
+        apiUri: Joi.string()
+            .uri()
+            .required()
+            .label('API URI'),
+        jobName
     })
     .unknown(true) // allow other fields
     .required();

--- a/test/data/executor.stop.yaml
+++ b/test/data/executor.stop.yaml
@@ -3,6 +3,8 @@ annotations:
 buildId: 453264
 buildClusterName: sd
 jobId: 1234
+jobName: main
+apiUri: 'http://screwdriver.cd'
 blockedBy:
   - 111
   - 222


### PR DESCRIPTION
## Context

`jobname` and `apiUri` are needed in executor stop config for AWS Integration

## Objective

This PR adds jobname and apiUri in executor stop config

## References

https://github.com/screwdriver-cd/screwdriver/issues/2559
https://github.com/screwdriver-cd/screwdriver/issues/2561

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
