### PR TITLE
feat(2624): Support to define parameters in SDV4 templates

### DIFF
--- a/config/template.js
+++ b/config/template.js
@@ -3,6 +3,7 @@
 const Joi = require('joi');
 const Job = require('./job');
 const Regex = require('./regex');
+const Parameters = require('./parameters');
 
 const TEMPLATE_NAMESPACE = Joi.string()
     .regex(Regex.TEMPLATE_NAMESPACE)
@@ -61,6 +62,8 @@ const TEMPLATE_IMAGES = Joi.object()
     })
     .min(1);
 
+const SCHEMA_JOB_PARAMETERS = Parameters.parameters.optional();
+
 const SCHEMA_TEMPLATE = Joi.object().keys({
     namespace: TEMPLATE_NAMESPACE,
     name: TEMPLATE_NAME.required(),
@@ -71,7 +74,8 @@ const SCHEMA_TEMPLATE = Joi.object().keys({
         .required()
         .or('image', 'template')
         .or('steps', 'template'),
-    images: TEMPLATE_IMAGES
+    images: TEMPLATE_IMAGES,
+    parameters: SCHEMA_JOB_PARAMETERS
 });
 
 /**
@@ -89,5 +93,6 @@ module.exports = {
     maintainer: TEMPLATE_MAINTAINER,
     config: Job.templateJob,
     configNoDupSteps: Job.jobNoDupSteps,
-    images: TEMPLATE_IMAGES
+    images: TEMPLATE_IMAGES,
+    parameters: SCHEMA_JOB_PARAMETERS
 };

--- a/migrations/20211215-add_column_parameters_to_templates.js
+++ b/migrations/20211215-add_column_parameters_to_templates.js
@@ -1,0 +1,21 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}templates`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                table,
+                'parameters',
+                {
+                    type: Sequelize.TEXT('medium')
+                },
+                { transaction }
+            );
+        });
+    }
+};

--- a/models/template.js
+++ b/models/template.js
@@ -32,7 +32,8 @@ const MODEL = {
         .description('When this template was created')
         .example('2038-01-19T03:14:08.131Z'),
     trusted: Joi.boolean().description('Mark whether template is trusted'),
-    latest: Joi.boolean().description('Whether this is latest version')
+    latest: Joi.boolean().description('Whether this is latest version'),
+    parameters: Template.parameters
 };
 
 const CREATE_MODEL = { ...MODEL, config: Template.configNoDupSteps };
@@ -64,7 +65,7 @@ module.exports = {
         mutate(
             MODEL,
             ['id', 'labels', 'name', 'version', 'description', 'maintainer', 'pipelineId'],
-            ['config', 'namespace', 'images', 'createTime', 'trusted', 'latest']
+            ['config', 'namespace', 'images', 'createTime', 'trusted', 'latest', 'parameters']
         )
     ).label('Get Template'),
 
@@ -78,7 +79,7 @@ module.exports = {
         mutate(
             CREATE_MODEL,
             ['config', 'name', 'version', 'description', 'maintainer'],
-            ['labels', 'namespace', 'images']
+            ['labels', 'namespace', 'images', 'parameters']
         )
     ).label('Create Template'),
 

--- a/test/config/template.test.js
+++ b/test/config/template.test.js
@@ -33,5 +33,11 @@ describe('config template', () => {
         it('returns error when template namespace exists and name has a slash', () => {
             assert.isNotNull(validate('config.template.badNameWithSlash.yaml', config.template.template).error);
         });
+
+        describe('parameters', () => {
+            it('validates parameters', () => {
+                assert.isNull(validate('config.template.parameters.yaml', config.job.parameters).error);
+            });
+        });
     });
 });

--- a/test/data/config.template.parameters.yaml
+++ b/test/data/config.template.parameters.yaml
@@ -1,0 +1,13 @@
+# Job Level Parameters Example
+auth_strategy: simple
+user:
+    value: sd-bot
+    description: User running build
+# multiple default value Example
+node_version: ["10.0.0", "12.0.0"]
+tag:
+    value:
+        - "latest"
+        - "stable"
+    description: Docker Image tag
+


### PR DESCRIPTION
## Context

Parameters can be defined only in Screwdriver pipeline configuration and but not in templates.

## Objective

Provide a way to define parameters in sdv4 template so not everyone needs to add it when they use the sdv4 template.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2624

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
