### PR TITLE
fix: Update to cron-parser v4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
     "mysql2": "^1.7.0",
     "nyc": "^15.0.0",
     "pg": "^7.18.2",
-    "sequelize": "^5.22.4",
+    "sequelize": "^5.22.5",
     "sequelize-cli": "^5.5.1",
-    "sqlite3": "^4.2.0"
+    "sqlite3": "^5.0.0"
   },
   "dependencies": {
-    "cron-parser": "^2.18.0",
-    "joi": "^17.4.2"
+    "cron-parser": "^4.2.1",
+    "joi": "^17.5.0"
   }
 }


### PR DESCRIPTION
## Context

We're on a fairly old version of cron-parser; latest version has support for "run on the last weekday of the month".

## Objective

This PR updates to use latest version of cron-parser package: https://www.npmjs.com/package/cron-parser

## References

N/A

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
