### PR TITLE
feat: add git deployKey annotation and additional provider properties

### DIFF
--- a/config/annotations.js
+++ b/config/annotations.js
@@ -29,7 +29,8 @@ const RESERVED_PIPELINE_ANNOTATIONS = [
     'screwdriver.cd/buildCluster',
     'screwdriver.cd/restrictPR',
     'screwdriver.cd/chainPR',
-    'screwdriver.cd/pipelineDescription'
+    'screwdriver.cd/pipelineDescription',
+    'screwdriver.cd/useDeployKey'
 ];
 
 /**

--- a/config/provider.js
+++ b/config/provider.js
@@ -73,6 +73,7 @@ const SCHEMA_PROVIDER = Joi.object().keys({
         .example('sd-build-eks'),
     executorLogs: Joi.boolean()
         .optional()
+        .default(false)
         .description('Enable debug logs for executor codebuild'),
     launcherImage: Joi.string()
         .description('Screwdriver launcher image in user Registry')
@@ -82,7 +83,27 @@ const SCHEMA_PROVIDER = Joi.object().keys({
         .example('v6.4'),
     privilegedMode: Joi.boolean()
         .optional()
-        .description('Enable privileged mode for container')
+        .default(false)
+        .description('Enable privileged mode for container'),
+    computeType: Joi.string()
+        .valid(
+            'BUILD_GENERAL1_SMALL',
+            'BUILD_GENERAL1_LARGE',
+            'BUILD_GENERAL1_MEDIUM',
+            'BUILD_GENERAL1_LARGE',
+            'BUILD_GENERAL1_2XLARGE',
+            'BUILD_GENERAL1_LARGE',
+            'BUILD_GENERAL1_MEDIUM',
+            'BUILD_GENERAL1_LARGE'
+        )
+        .optional()
+        .default('BUILD_GENERAL1_SMALL')
+        .description('CodeBuild compute type'),
+    environment: Joi.string()
+        .optional()
+        .valid('ARM_CONTAINER', 'LINUX_CONTAINER', 'LINUX_GPU_CONTAINER')
+        .default('LINUX_CONTAINER')
+        .description('CodeBuild environment type')
 });
 
 module.exports = {

--- a/test/data/config.job.providersls.yaml
+++ b/test/data/config.job.providersls.yaml
@@ -14,3 +14,5 @@ role: arn:aws:iam::111111111111:role/role
 executor: sls
 launcherImage: 123456789012.dkr.ecr.us-east-2.amazonaws.com/screwdriver-hub:launcherv6.4
 launcherVersion : v6.4
+computeType: BUILD_GENERAL1_LARGE
+environment: 'ARM_CONTAINER'


### PR DESCRIPTION
## Context

Users should be able to opt-in to use short-lived git deploy keys for `git checkout` when running builds with Screwdriver AWS integration

## Objective

This PR adds git `useDeployKey` annotation along with additional provider properties

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
