### PR TITLE
fix(2640): add pipelineId to unique key constraint

### DIFF
--- a/migrations/20220203-uniquekey-update-events.js
+++ b/migrations/20220203-uniquekey-update-events.js
@@ -1,0 +1,21 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}events`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.removeConstraint(table, `${table}_createTime_sha_key`, { transaction });
+
+            await queryInterface.addConstraint(table, ['sha', 'createTime', 'pipelineId'], {
+                name: `${table}_createTime_sha_pid_key`,
+                type: 'unique',
+                transaction
+            });
+        });
+    }
+};

--- a/models/event.js
+++ b/models/event.js
@@ -166,7 +166,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['sha', 'createTime'],
+    keys: ['sha', 'createTime', 'pipelineId'],
 
     /**
      * Primary column to sort queries by.

--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     "pg": "^7.18.2",
     "sequelize": "^5.22.5",
     "sequelize-cli": "^6.4.1",
-    "sqlite3": "^4.2.0"
+    "sqlite3": "^4.2.0",
+    "npx": "^10.2.2"
   },
   "dependencies": {
     "cron-parser": "^4.2.1",
-    "joi": "^17.5.0",
-    "npx": "^10.2.2"
+    "joi": "^17.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,18 +43,19 @@
     "eslint": "^7.32.0",
     "eslint-config-screwdriver": "^5.0.1",
     "js-yaml": "^3.14.1",
-    "mocha": "^8.4.0",
+    "mocha": "^9.2.0",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mysql2": "^1.7.0",
     "nyc": "^15.0.0",
     "pg": "^7.18.2",
     "sequelize": "^5.22.5",
-    "sequelize-cli": "^5.5.1",
-    "sqlite3": "^5.0.0"
+    "sequelize-cli": "^6.4.1",
+    "sqlite3": "^4.2.0"
   },
   "dependencies": {
     "cron-parser": "^4.2.1",
-    "joi": "^17.5.0"
+    "joi": "^17.5.0",
+    "npx": "^10.2.2"
   }
 }


### PR DESCRIPTION
## Context

When a single PR generates multiple events across different pipelines for same repository ([source dir](https://docs.screwdriver.cd/user-guide/configuration/sourceDirectory)), some of the event creation can fail, since `createTime` & `sha` is a unique constraint. Multiple events can get same `createTime` since it's [generated by API ](https://github.com/screwdriver-cd/models/blob/master/lib/eventFactory.js#L802)

## Objective

Add pipeline Id to unique Key constraint so that event creation for multiple pipelines caused by same PR  (due to Source Dir feature) can work. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/2640

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
