### PR TITLE
feat: add buildRegion param to schema

### DIFF
--- a/config/provider.js
+++ b/config/provider.js
@@ -45,6 +45,12 @@ const SCHEMA_PROVIDER = Joi.object().keys({
         .max(64)
         .description('Region')
         .example('us-west-2'),
+    buildRegion: Joi.string()
+        .regex(Regex.REGION)
+        .max(64)
+        .description('Region where builds will run if different from region')
+        .example('us-east-2')
+        .optional(),
     accountId: Joi.alternatives()
         .try(
             Joi.string()


### PR DESCRIPTION
## Context

Add optional property `buildRegion` to provider schema to build in cross region

## Objective

This PR adds optional property `buildRegion` to provider 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
