### PR TITLE
feat: Add allow empty to buildRegion

### DIFF
--- a/config/provider.js
+++ b/config/provider.js
@@ -52,6 +52,7 @@ const SCHEMA_PROVIDER = Joi.object().keys({
         .description('Region where builds will run if different from service region')
         .default('')
         .example('us-east-2')
+        .allow('')
         .optional(),
     accountId: Joi.alternatives()
         .try(


### PR DESCRIPTION
## Context

`buildRegion` should be allowed to be empty

## Objective

This PR allow empty for property `buildRegion`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
