### PR TITLE
fix: modify migration files to current sequelize params

### DIFF
--- a/migrations/20190919-initdb-banners.js
+++ b/migrations/20190919-initdb-banners.js
@@ -36,7 +36,8 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['message', 'createTime', 'type'], {
+            await queryInterface.addConstraint(table, {
+                fields: ['message', 'createTime', 'type'],
                 name: `${table}_message_createTime_type_key`,
                 type: 'unique',
                 transaction

--- a/migrations/20190919-initdb-banners.js
+++ b/migrations/20190919-initdb-banners.js
@@ -37,8 +37,8 @@ module.exports = {
             );
 
             await queryInterface.addConstraint(table, {
-                fields: ['message', 'createTime', 'type'],
                 name: `${table}_message_createTime_type_key`,
+                fields: ['message', 'createTime', 'type'],
                 type: 'unique',
                 transaction
             });

--- a/migrations/20190919-initdb-buildClusters.js
+++ b/migrations/20190919-initdb-buildClusters.js
@@ -45,14 +45,16 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['name'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_name_key`,
+                fields: ['name'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['name'], {
+            await queryInterface.addIndex(table, {
                 name: `${prefix}build_clusters_name`,
+                fields: ['name'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-builds.js
+++ b/migrations/20190919-initdb-builds.js
@@ -78,24 +78,28 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['jobId', 'number'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_jobId_number_key`,
+                fields: ['jobId', 'number'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['eventId', 'createTime'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_event_id_create_time`,
+                fields: ['eventId', 'createTime'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['jobId'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_job_id`,
+                fields: ['jobId'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, [{ attribute: 'parentBuildId', length: 32 }], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_parent_build_id`,
+                fields: [{ attribute: 'parentBuildId', length: 32 }],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-collections.js
+++ b/migrations/20190919-initdb-collections.js
@@ -36,8 +36,9 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addIndex(table, ['userId'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_user_id`,
+                fields: ['userId'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-commandTags.js
+++ b/migrations/20190919-initdb-commandTags.js
@@ -36,18 +36,21 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addIndex(table, ['name'], {
+            await queryInterface.addIndex(table, {
                 name: `${prefix}command_tags_name`,
+                fields: ['name'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['namespace'], {
+            await queryInterface.addIndex(table, {
                 name: `${prefix}command_tags_namespace`,
+                fields: ['namespace'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['tag'], {
+            await queryInterface.addIndex(table, {
                 name: `${prefix}command_tags_tag`,
+                fields: ['tag'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-commands.js
+++ b/migrations/20190919-initdb-commands.js
@@ -60,13 +60,15 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addIndex(table, ['name'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_name`,
+                fields: ['name'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['namespace'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_namespace`,
+                fields: ['namespace'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-events.js
+++ b/migrations/20190919-initdb-events.js
@@ -63,24 +63,28 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['createTime', 'sha'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_createTime_sha_key`,
+                fields: ['createTime', 'sha'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['createTime', 'pipelineId'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_create_time_pipeline_id`,
+                fields: ['createTime', 'pipelineId'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['pipelineId'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_pipeline_id`,
+                fields: ['pipelineId'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['type'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_type`,
+                fields: ['type'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-jobs.js
+++ b/migrations/20190919-initdb-jobs.js
@@ -51,19 +51,22 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['name', 'pipelineId'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_name_pipelineId_key`,
+                fields: ['name', 'pipelineId'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['pipelineId', 'state'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_pipeline_id_state`,
+                fields: ['pipelineId', 'state'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['state'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_state`,
+                fields: ['state'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-pipelines.js
+++ b/migrations/20190919-initdb-pipelines.js
@@ -57,14 +57,16 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['scmUri'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_scmUri_key`,
+                fields: ['scmUri'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['scmUri'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_scm_uri`,
+                fields: ['scmUri'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-secrets.js
+++ b/migrations/20190919-initdb-secrets.js
@@ -33,14 +33,16 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['pipelineId', 'name'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_pipelineId_name_key`,
+                fields: ['pipelineId', 'name'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['pipelineId'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_pipeline_id`,
+                fields: ['pipelineId'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-steps.js
+++ b/migrations/20190919-initdb-steps.js
@@ -42,19 +42,22 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['buildId', 'name'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_buildId_name_key`,
+                fields: ['buildId', 'name'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['buildId'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_build_id`,
+                fields: ['buildId'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['name'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_name`,
+                fields: ['name'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-templateTags.js
+++ b/migrations/20190919-initdb-templateTags.js
@@ -36,24 +36,28 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['name', 'tag', 'namespace'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_namespace_name_tag_key`,
+                fields: ['name', 'tag', 'namespace'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['name'], {
+            await queryInterface.addIndex(table, {
                 name: `${prefix}template_tags_name`,
+                fields: ['name'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['namespace'], {
+            await queryInterface.addIndex(table, {
                 name: `${prefix}template_tags_namespace`,
+                fields: ['namespace'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['tag'], {
+            await queryInterface.addIndex(table, {
                 name: `${prefix}template_tags_tag`,
+                fields: ['tag'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-templates.js
+++ b/migrations/20190919-initdb-templates.js
@@ -54,19 +54,22 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['name', 'version', 'namespace'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_namespace_name_version_key`,
+                fields: ['name', 'version', 'namespace'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['name'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_name`,
+                fields: ['name'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['namespace'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_namespace`,
+                fields: ['namespace'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-tokens.js
+++ b/migrations/20190919-initdb-tokens.js
@@ -39,24 +39,28 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['hash'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_hash_key`,
+                fields: ['hash'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['hash'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_hash`,
+                fields: ['hash'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['pipelineId'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_pipeline_id`,
+                fields: ['pipelineId'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['userId'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_user_id`,
+                fields: ['userId'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-triggers.js
+++ b/migrations/20190919-initdb-triggers.js
@@ -27,19 +27,22 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['src', 'dest'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_src_dest_key`,
+                fields: ['src', 'dest'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['src'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_src`,
+                fields: ['src'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['dest'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_dest`,
+                fields: ['dest'],
                 transaction
             });
         });

--- a/migrations/20190919-initdb-users.js
+++ b/migrations/20190919-initdb-users.js
@@ -30,19 +30,22 @@ module.exports = {
                 { transaction }
             );
 
-            await queryInterface.addConstraint(table, ['username', 'scmContext'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_username_scmContext_key`,
+                fields: ['username', 'scmContext'],
                 type: 'unique',
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['scmContext'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_scm_context`,
+                fields: ['scmContext'],
                 transaction
             });
 
-            await queryInterface.addIndex(table, ['username'], {
+            await queryInterface.addIndex(table, {
                 name: `${table}_username`,
+                fields: ['username'],
                 transaction
             });
         });

--- a/migrations/20191221-upd-buildClusters-uniqueconstraint.js
+++ b/migrations/20191221-upd-buildClusters-uniqueconstraint.js
@@ -11,8 +11,9 @@ module.exports = {
         await queryInterface.sequelize.transaction(async transaction => {
             await queryInterface.removeConstraint(table, `${table}_name_key`, transaction);
 
-            await queryInterface.addConstraint(table, ['name', 'scmContext'], {
+            await queryInterface.addConstraint(table, {
                 name: `${table}_name_scmContext_key`,
+                fields: ['name', 'scmContext'],
                 type: 'unique',
                 transaction
             });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

migration for new screwdriver cluster is not working due to sequelize's params change.

the error is like below:

> ERROR: Fields must be specified through options.fields

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

modify old migration files to current sequelize params.
it passed migration for an empty database (using MySQL 5.7.33).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

- [QueryInterface | Sequelize](https://sequelize.org/master/class/src/dialects/abstract/query-interface.js~QueryInterface.html#instance-method-addConstraint)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
