### PR TITLE
feat(1577): add option filteredEventsForNoBuilds

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -29,8 +29,9 @@ const SCHEMA_PIPELINE_SETTINGS = Joi.object()
         metricsDowntimeJobs: SCHEMA_METRICS_DOWNTIME_JOBS,
         metricsDowntimeStatuses: SCHEMA_METRICS_DOWNTIME_STATUSES,
         public: Joi.boolean(),
-        groupedEvents: Joi.boolean().default(false),
-        showEventTriggers: Joi.boolean().default(false)
+        groupedEvents: Joi.boolean().optional(),
+        showEventTriggers: Joi.boolean().optional(),
+        filterEventsForNoBuilds: Joi.boolean().optional()
     })
     .default({});
 


### PR DESCRIPTION
## Context
Add ability to save the preference of filter events for no builds.
And fixed an [issue](https://github.com/screwdriver-cd/screwdriver/issues/2668) where when any of the pipeline preferences was turned on, it would be turned off except for the target setting.

UI PR is [here](https://github.com/screwdriver-cd/ui/pull/770).

## Objective
- Add ability to save the preference of filter events for no builds.
- Fixed to use `optional()` instead of `default(false)`

## References

- https://github.com/screwdriver-cd/screwdriver/issues/1577
  - adding a toggle switch on a pipeline or an option page to filter empty events.
- https://github.com/screwdriver-cd/screwdriver/issues/2668
  -  when any of the pipeline preferences was turned on, it would be turned off except for the target setting.


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
