### PR TITLE
fix(2676): Allow provider path to external repo

### DIFF
--- a/config/job.js
+++ b/config/job.js
@@ -169,7 +169,9 @@ const SCHEMA_SOURCEPATH = Joi.string()
 const SCHEMA_SOURCEPATHS = Joi.alternatives().try(Joi.array().items(SCHEMA_SOURCEPATH), SCHEMA_SOURCEPATH);
 const SCHEMA_CACHE = Joi.boolean().optional();
 const SCHEMA_PARAMETERS = Parameters.parameters.optional();
-const SCHEMA_PROVIDER = Provider.provider.optional();
+const SCHEMA_PROVIDER = Joi.alternatives()
+    .try(Provider.provider, Joi.string().regex(Regex.CHECKOUT_URL))
+    .optional();
 const SCHEMA_JOB = Joi.object()
     .keys({
         annotations: Annotations.annotations,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": false
   },
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.6",
     "eslint": "^7.32.0",
     "eslint-config-screwdriver": "^5.0.1",
     "js-yaml": "^3.14.1",
@@ -47,15 +47,15 @@
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
     "mysql2": "^1.7.0",
+    "npx": "^10.2.2",
     "nyc": "^15.0.0",
     "pg": "^7.18.2",
     "sequelize": "^6.6.5",
     "sequelize-cli": "^6.4.1",
-    "sqlite3": "^4.2.0",
-    "npx": "^10.2.2"
+    "sqlite3": "^4.2.0"
   },
   "dependencies": {
     "cron-parser": "^4.2.1",
-    "joi": "^17.5.0"
+    "joi": "^17.6.0"
   }
 }

--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -3,6 +3,7 @@
 const Joi = require('joi');
 const Annotations = require('../config/annotations');
 const Job = require('../config/job');
+const Provider = require('../config/provider');
 const models = require('../models');
 const buildId = models.build.base.extract('id').required();
 const eventId = models.event.base.extract('id');
@@ -26,7 +27,7 @@ const buildSchemaObj = {
     jobName,
     jobState,
     jobArchived,
-    provider: Job.provider,
+    provider: Provider.provider.optional(),
     annotations: Annotations.annotations,
     blockedBy: Joi.array().items(jobId),
     freezeWindows: Job.freezeWindows,
@@ -64,7 +65,7 @@ const SCHEMA_STOP = Joi.object()
         jobId,
         token: Joi.string().label('Build JWT'),
         pipelineId,
-        provider: Job.provider,
+        provider: Provider.provider.optional(),
         apiUri: Joi.string()
             .uri()
             .required()
@@ -79,7 +80,7 @@ const SCHEMA_STATUS = Joi.object()
         token: Joi.string().label('Build JWT'),
         pipelineId,
         jobId,
-        provider: Job.provider
+        provider: Provider.provider.optional()
     })
     .unknown(true) // allow other fields
     .required();

--- a/test/data/config.job.providerexternal.yaml
+++ b/test/data/config.job.providerexternal.yaml
@@ -1,0 +1,2 @@
+# Job Level External Provider Example
+git@github.com:tkyi/mytest.git#master:provider.yaml


### PR DESCRIPTION
## Context

Users might want to point their provider to an external repo rather than copy paste a bunch of repetitive code.

## Objective

This PR allows for a checkout url type string as the provider in a screwdriver.yaml.

before:

```
provider:
    name: aws
    region: us-west-2
    accountId: 111111111111
    role: arn:aws:iam::111111111111:role/role
    executor: eks
    clusterName: sd-build-eks
```

after:
`provider: git@github.com:tkyi/testing.git#test:provider.yaml`

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2676

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
