### PR TITLE
fix: update property name to environmentType

### DIFF
--- a/config/provider.js
+++ b/config/provider.js
@@ -120,7 +120,11 @@ const SCHEMA_PROVIDER = Joi.object().keys({
         .optional()
         .valid('ARM_CONTAINER', 'LINUX_CONTAINER', 'LINUX_GPU_CONTAINER')
         .default('LINUX_CONTAINER')
-        .description('CodeBuild environment type')
+        .description('CodeBuild environment type'),
+    debugSession: Joi.boolean()
+        .optional()
+        .default(false)
+        .description('Enable debug session inside build container')
 });
 
 module.exports = {

--- a/config/provider.js
+++ b/config/provider.js
@@ -116,7 +116,7 @@ const SCHEMA_PROVIDER = Joi.object().keys({
         .optional()
         .default('BUILD_GENERAL1_SMALL')
         .description('CodeBuild compute type'),
-    environment: Joi.string()
+    environmentType: Joi.string()
         .optional()
         .valid('ARM_CONTAINER', 'LINUX_CONTAINER', 'LINUX_GPU_CONTAINER')
         .default('LINUX_CONTAINER')

--- a/test/data/config.job.providersls.yaml
+++ b/test/data/config.job.providersls.yaml
@@ -15,4 +15,4 @@ executor: sls
 launcherImage: 123456789012.dkr.ecr.us-east-2.amazonaws.com/screwdriver-hub:launcherv6.4
 launcherVersion : v6.4
 computeType: BUILD_GENERAL1_LARGE
-environment: 'ARM_CONTAINER'
+environmentType: 'ARM_CONTAINER'


### PR DESCRIPTION
## Context

The property `environment` name was incorrect, consumer service refers to `environmentType`

## Objective

This PR updates the name of property to `environmentType`

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
