### PR TITLE
fix: Add annotation to disable job by default [1]

### DIFF
--- a/config/annotations.js
+++ b/config/annotations.js
@@ -25,7 +25,8 @@ const RESERVED_JOB_ANNOTATIONS = [
     'screwdriver.cd/mergeSharedSteps',
     'screwdriver.cd/manualStartEnabled',
     'screwdriver.cd/blockedBySameJob',
-    'screwdriver.cd/blockedBySameJobWaitTime'
+    'screwdriver.cd/blockedBySameJobWaitTime',
+    'screwdriver.cd/jobDisabledByDefault'
 ];
 const RESERVED_PIPELINE_ANNOTATIONS = [
     'screwdriver.cd/buildCluster',

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "npx": "^10.2.2",
     "nyc": "^15.0.0",
     "pg": "^7.18.2",
-    "sequelize": "^6.6.5",
+    "sequelize": "^6.20.1",
     "sequelize-cli": "^6.4.1",
     "sqlite3": "^4.2.0"
   },
   "dependencies": {
-    "cron-parser": "^4.2.1",
+    "cron-parser": "^4.4.0",
     "joi": "^17.6.0"
   }
 }


### PR DESCRIPTION
## Context

Sometimes users might have repos/pipelines with build periodic configs. If developers fork and create their own pipelines, they might not want these cron jobs to get auto triggered. It would be nice to have an additional annotation for disabling jobs upon creation so users are required to consciously enable them if they want the periodic builds.

## Objective

This PR adds a new annotation to job annotations: `screwdriver.cd/jobDisabledByDefault`.

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
