### PR TITLE
[1]feat(2695): Add jobName and pipelineId to scm.addPrComment

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -113,6 +113,8 @@ const ADD_PR_COMMENT = Joi.object()
         token,
         prNum: core.scm.hook.extract('prNum').required(),
         comment: Joi.string().required(),
+        jobName,
+        pipelineId,
         scmContext
     })
     .required();

--- a/test/data/scm.addPrComment.yaml
+++ b/test/data/scm.addPrComment.yaml
@@ -3,3 +3,5 @@ token: 'thisisatokenthingy'
 prNum: 5
 scmContext: github:github.com
 comment: 'my, what a fine PR'
+jobName: 'main'
+pipelineId: '123456'


### PR DESCRIPTION
## Context
In implementing https://github.com/screwdriver-cd/screwdriver/issues/2695, pipeline id and job name are needed in `addPrComment`.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We add job name and pipeline id to `scm.addPrComment`.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2695
Reflect at the same time as https://github.com/screwdriver-cd/models/pull/543
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
