### PR TITLE
feat(2580): Add a new field 'state' to pipeline model to distinguish between active and obsolete child pipelines

### DIFF
--- a/migrations/20220607152947-add_column_state_to_pipeline.js
+++ b/migrations/20220607152947-add_column_state_to_pipeline.js
@@ -1,0 +1,23 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}pipelines`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                table,
+                'state',
+                {
+                    type: Sequelize.STRING(10),
+                    defaultValue: 'ACTIVE',
+                    allowNull: false
+                },
+                { transaction }
+            );
+        });
+    }
+};

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -10,6 +10,8 @@ const WorkflowGraph = require('../config/workflowGraph');
 const Parameters = require('../config/parameters');
 const mutate = require('../lib/mutate');
 
+const STATES = ['ACTIVE', 'INACTIVE'];
+
 const CREATE_MODEL = {
     checkoutUrl: Joi.string()
         .regex(Regex.CHECKOUT_URL)
@@ -85,6 +87,13 @@ const MODEL = {
 
     settings: Settings.pipelineSettings,
 
+    state: Joi.string()
+        .valid(...STATES)
+        .max(10)
+        .description('Current state of the pipeline')
+        .example('ACTIVE')
+        .default('ACTIVE'),
+
     subscribedScmUrlsWithActions: Joi.array()
         .items(
             Joi.object().keys({
@@ -123,7 +132,7 @@ module.exports = {
     get: Joi.object(
         mutate(
             MODEL,
-            ['id', 'scmUri', 'scmContext', 'createTime', 'admins'],
+            ['id', 'scmUri', 'scmContext', 'createTime', 'admins', 'state'],
             [
                 'workflowGraph',
                 'scmRepo',
@@ -174,6 +183,14 @@ module.exports = {
      * @type {Array}
      */
     allKeys: Object.keys(MODEL),
+
+    /**
+     * All the available states of Pipeline
+     *
+     * @property allStates
+     * @type {Array}
+     */
+    allStates: STATES,
 
     /**
      * Tablename to be used in the datastore

--- a/test/data/collection.get.yaml
+++ b/test/data/collection.get.yaml
@@ -15,6 +15,7 @@ pipelines:
         name: screwdriver-cd/screwdriver
         branch: master
         url: https://github.com/screwdriver-cd/screwdriver/tree/master
+      state: ACTIVE
       annotations:
         screwdriver.cd/executor.resource:
           - XCODE8
@@ -46,6 +47,7 @@ pipelines:
         name: screwdriver-cd/config-parser
         branch: master
         url: https://github.com/screwdriver-cd/config-parser/tree/master
+      state: ACTIVE
       annotations:
         screwdriver.cd/executor.resource:
           - XCODE8

--- a/test/data/pipeline.get.yaml
+++ b/test/data/pipeline.get.yaml
@@ -36,3 +36,4 @@ subscribedScmUrlsWithActions:
       actions: [commit, tag, release]
     - scmUri: github.com:34568912:master
       actions: [commit, tag, release]
+state: ACTIVE

--- a/test/data/pipeline.yaml
+++ b/test/data/pipeline.yaml
@@ -7,3 +7,4 @@ scmRepo:
     name: screwdriver-cd/screwdriver
     branch: master
     url: https://github.com/screwdriver-cd/screwdriver/tree/master
+state: ACTIVE

--- a/test/models/pipeline.test.js
+++ b/test/models/pipeline.test.js
@@ -19,6 +19,12 @@ describe('model pipeline', () => {
         it('fails the create', () => {
             assert.isNotNull(validate('empty.yaml', models.pipeline.create).error);
         });
+
+        it('validates that state is not allowed', () => {
+            assert.isNotNull(
+                validate('pipeline.create.yaml', models.pipeline.create, { state: models.pipeline.allStates[0] }).error
+            );
+        });
     });
 
     describe('get', () => {
@@ -29,6 +35,20 @@ describe('model pipeline', () => {
         it('fails the get', () => {
             assert.isNotNull(validate('empty.yaml', models.pipeline.get).error);
         });
+
+        // valid states
+        models.pipeline.allStates.forEach(validState => {
+            it('validates the valid states', () => {
+                assert.isNull(validate('pipeline.get.yaml', models.pipeline.get, { state: validState }).error);
+            });
+        });
+
+        // invalid states
+        [null, '', 'some_invalid_state'].forEach(validState => {
+            it('validates the invalid states', () => {
+                assert.isNotNull(validate('pipeline.get.yaml', models.pipeline.get, { state: validState }).error);
+            });
+        });
     });
 
     describe('update', () => {
@@ -38,6 +58,12 @@ describe('model pipeline', () => {
 
         it('fails the update', () => {
             assert.isNotNull(validate('empty.yaml', models.pipeline.update).error);
+        });
+
+        it('validates that state is not allowed', () => {
+            assert.isNotNull(
+                validate('pipeline.update.yaml', models.pipeline.update, { state: models.pipeline.allStates[0] }).error
+            );
         });
     });
 });


### PR DESCRIPTION

## Context

Changes were made in https://github.com/screwdriver-cd/models/pull/534 to stop auto deletion of child pipelines when the SCM URLs removed/modified in the external config.

We need a way to distinguish between active and obsolete child pipeline to allow the user to review and take necessary actions on obsolete child pipelines
- reactivate the pipeline by restoring the SCM URL in the external config
- explicitly delete the pipeline from the UI/API


## Objective

This PR adds a new field called `state` to the `pipeline` model to distinguish between active and obsolete child pipelines.


## References
https://github.com/screwdriver-cd/screwdriver/issues/2580


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
