### PR TITLE
fix(2496): Remove PR jobs with invalid name

### DIFF
--- a/migrations/20220628180148-remove_pr_jobs_invalid_name.js
+++ b/migrations/20220628180148-remove_pr_jobs_invalid_name.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}jobs`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async transaction => {
+            const dialect = queryInterface.sequelize.getDialect();
+            // sqlite
+            let query = `DELETE FROM "${table}" WHERE "name" LIKE 'PR-%' AND INSTR(name, ':') = 0`;
+
+            if (dialect === 'postgres') {
+                query = `DELETE FROM "${table}" WHERE "name" LIKE 'PR-%' AND POSITION(':' IN "name") = 0`;
+            } else if (dialect === 'mysql') {
+                query = `DELETE FROM \`${table}\` WHERE name LIKE 'PR-%' AND POSITION(':' IN name) = 0`;
+            }
+
+            await queryInterface.sequelize.query(query, { transaction });
+        });
+    }
+};


### PR DESCRIPTION
## Context

Raw queries updated in https://github.com/screwdriver-cd/models/pull/547 and https://github.com/screwdriver-cd/models/pull/548 is causing below error for certain pipelines (Ex: https://cd.screwdriver.cd/pipelines/9)
`negative substring length not allowed`

Those pipelines have pull request jobs that were created before 2018 which violates the naming format `PR-<PULL_REQUEST_NUMBER>:<PARENT_JOB_NAME>` (Ex: `PR-32:main`). Here are few invalid job names associated with https://cd.screwdriver.cd/pipelines/9
```
PR-147
PR-148
PR-149
PR-150
PR-151
```

Here are some queries (PostgreSQL) to detect pull request jobs with invalid name
**Total count**
```
SELECT COUNT(*)
        FROM "jobs"
        WHERE name LIKE 'PR-%'
        AND POSITION(':' IN name) = 0;
```

**Job Details**
```
SELECT *
        FROM "jobs"
        WHERE name LIKE 'PR-%'
        AND POSITION(':' IN name) = 0
        ORDER BY "id" ASC;
```

**Grouped by pipeline**
```
SELECT j."pipelineId", count(*) as "invalidJobCount", p."scmRepo"
        FROM "jobs" j, "pipelines" p
        WHERE j."pipelineId" = p.id
        AND j.name LIKE 'PR-%'
        AND POSITION(':' IN j.name) = 0
        GROUP BY j."pipelineId", p."scmRepo"
        ORDER BY "invalidJobCount" DESC;
```

## Objective

This PR removes all such corrupted rows from the `jobs` tables.

It is safe to delete these
1. majority of them are archived
2. these are associated with PRs created before 2018
3. If deleted, PR jobs get recreated when there is any activity on the PR (via web hooks) or from the UI/API (PR sync or restarting/starting new event)

## References

https://github.com/screwdriver-cd/screwdriver/issues/2720

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
