### PR TITLE
fix(2669): Remove createTime from stage model [1.5]

### DIFF
--- a/migrations/20220705-upd-stage-color-eventId-createTime.js
+++ b/migrations/20220705-upd-stage-color-eventId-createTime.js
@@ -23,15 +23,6 @@ module.exports = {
                     { transaction }
                 );
 
-                await queryInterface.addColumn(
-                    table,
-                    'createTime',
-                    {
-                        type: Sequelize.STRING(32)
-                    },
-                    { transaction }
-                );
-
                 await queryInterface.addConstraint(table, {
                     name: `${table}_pipeline_id_name_group_event_id_key`,
                     fields: ['pipelineId', 'name', 'groupEventId'],
@@ -41,7 +32,7 @@ module.exports = {
 
                 await queryInterface.addIndex(table, {
                     name: `${table}_group_event_id_create_time`,
-                    fields: ['groupEventId', 'createTime'],
+                    fields: ['groupEventId'],
                     transaction
                 });
                 // eslint-disable-next-line no-empty

--- a/models/stage.js
+++ b/models/stage.js
@@ -42,11 +42,7 @@ const MODEL = {
         .integer()
         .positive()
         .description('Identifier of the group event')
-        .example(123345),
-
-    createTime: Joi.string()
-        .isoDate()
-        .description('When this stage was created')
+        .example(123345)
 };
 
 module.exports = {
@@ -95,5 +91,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['pipelineId'] }, { fields: ['groupEventId', 'createTime'] }]
+    indexes: [{ fields: ['pipelineId'] }, { fields: ['groupEventId'] }]
 };

--- a/test/data/stage.yaml
+++ b/test/data/stage.yaml
@@ -4,3 +4,4 @@ pipelineId: 123345
 name: deploy
 jobIds: [1, 2, 3, 4]
 description: 'Deploys canary jobs'
+groupEventId: 555

--- a/test/models/stage.test.js
+++ b/test/models/stage.test.js
@@ -23,7 +23,7 @@ describe('model stage', () => {
 
     describe('allKeys', () => {
         it('lists all of the fields in the model', () => {
-            const expectedKeys = ['id', 'pipelineId', 'name', 'jobIds', 'description', 'groupEventId', 'createTime'];
+            const expectedKeys = ['id', 'pipelineId', 'name', 'jobIds', 'description', 'groupEventId'];
 
             expectedKeys.forEach(keyName => {
                 assert.include(models.stage.allKeys, keyName, `Key name ${keyName} not included`);
@@ -39,7 +39,7 @@ describe('model stage', () => {
 
     describe('indexes', () => {
         it('defines the correct indexes', () => {
-            const expected = [{ fields: ['pipelineId'] }, { fields: ['groupEventId', 'createTime'] }];
+            const expected = [{ fields: ['pipelineId'] }, { fields: ['groupEventId'] }];
             const { indexes } = models.stage;
 
             expected.forEach(indexName => {


### PR DESCRIPTION
## Context

Create time is not needed for stage model since we can rely on event data for "latest" created stage.

## Objective

This PR removes createTime from stage model.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
