### PR TITLE
fix(2649): Remove unused column 'parameters' from 'templates' table

### DIFF
--- a/config/template.js
+++ b/config/template.js
@@ -3,7 +3,6 @@
 const Joi = require('joi');
 const Job = require('./job');
 const Regex = require('./regex');
-const Parameters = require('./parameters');
 
 const TEMPLATE_NAMESPACE = Joi.string()
     .regex(Regex.TEMPLATE_NAMESPACE)
@@ -62,8 +61,6 @@ const TEMPLATE_IMAGES = Joi.object()
     })
     .min(1);
 
-const SCHEMA_JOB_PARAMETERS = Parameters.parameters.optional();
-
 const SCHEMA_TEMPLATE = Joi.object().keys({
     namespace: TEMPLATE_NAMESPACE,
     name: TEMPLATE_NAME.required(),
@@ -74,8 +71,7 @@ const SCHEMA_TEMPLATE = Joi.object().keys({
         .required()
         .or('image', 'template')
         .or('steps', 'template'),
-    images: TEMPLATE_IMAGES,
-    parameters: SCHEMA_JOB_PARAMETERS
+    images: TEMPLATE_IMAGES
 });
 
 /**
@@ -93,6 +89,5 @@ module.exports = {
     maintainer: TEMPLATE_MAINTAINER,
     config: Job.templateJob,
     configNoDupSteps: Job.jobNoDupSteps,
-    images: TEMPLATE_IMAGES,
-    parameters: SCHEMA_JOB_PARAMETERS
+    images: TEMPLATE_IMAGES
 };

--- a/migrations/20220728171252-remove_column_parameters_from_templates.js
+++ b/migrations/20220728171252-remove_column_parameters_from_templates.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}templates`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        try {
+            await queryInterface.removeColumn(table, 'parameters');
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
+    }
+};

--- a/models/template.js
+++ b/models/template.js
@@ -32,8 +32,7 @@ const MODEL = {
         .description('When this template was created')
         .example('2038-01-19T03:14:08.131Z'),
     trusted: Joi.boolean().description('Mark whether template is trusted'),
-    latest: Joi.boolean().description('Whether this is latest version'),
-    parameters: Template.parameters
+    latest: Joi.boolean().description('Whether this is latest version')
 };
 
 const CREATE_MODEL = { ...MODEL, config: Template.configNoDupSteps };
@@ -65,7 +64,7 @@ module.exports = {
         mutate(
             MODEL,
             ['id', 'labels', 'name', 'version', 'description', 'maintainer', 'pipelineId'],
-            ['config', 'namespace', 'images', 'createTime', 'trusted', 'latest', 'parameters']
+            ['config', 'namespace', 'images', 'createTime', 'trusted', 'latest']
         )
     ).label('Get Template'),
 
@@ -79,7 +78,7 @@ module.exports = {
         mutate(
             CREATE_MODEL,
             ['config', 'name', 'version', 'description', 'maintainer'],
-            ['labels', 'namespace', 'images', 'parameters']
+            ['labels', 'namespace', 'images']
         )
     ).label('Create Template'),
 

--- a/test/config/template.test.js
+++ b/test/config/template.test.js
@@ -36,7 +36,7 @@ describe('config template', () => {
 
         describe('parameters', () => {
             it('validates parameters', () => {
-                assert.isNull(validate('config.template.parameters.yaml', config.job.parameters).error);
+                assert.isNull(validate('config.template.parameters.yaml', config.template.template).error);
             });
         });
     });

--- a/test/data/config.template.parameters.yaml
+++ b/test/data/config.template.parameters.yaml
@@ -1,13 +1,21 @@
-# Job Level Parameters Example
-auth_strategy: simple
-user:
-    value: sd-bot
-    description: User running build
-# multiple default value Example
-node_version: ["10.0.0", "12.0.0"]
-tag:
-    value:
-        - "latest"
-        - "stable"
-    description: Docker Image tag
-
+name: test/template
+version: "1.3"
+description: Template for testing
+maintainer: foo@bar.com
+config:
+    image: node:6
+    steps:
+        - install: npm install
+        - test: npm test
+    parameters:
+        auth_strategy: simple
+        user:
+            value: sd-bot
+            description: User running build
+        # multiple default value Example
+        node_version: [ "10.0.0", "12.0.0" ]
+        tag:
+            value:
+                - "latest"
+                - "stable"
+            description: Docker Image tag


### PR DESCRIPTION
## Context

`parameters` column in `templates` table is not being used. `parameters` is embedded into the config which is stored under the column `config`.

## Objective

This PR drops the column `parameters` from the `templates` table.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2649

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
