### PR TITLE
fix to have timestamps on the events sidebar

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -2,6 +2,11 @@
 
 const Joi = require('joi');
 
+const SCHEMA_TIMESTAMP_FORMAT = Joi.string()
+    .valid('UTC', 'LOCAL_TIMEZONE', 'HUMAN_READABLE')
+    .optional()
+    .default('HUMAN_READABLE')
+    .description('User preferred timestamp');
 const SCHEMA_DISPLAY_JOB_NAME_LENGTH = Joi.number()
     .integer()
     .min(20)
@@ -46,7 +51,8 @@ const SCHEMA_USER_SETTINGS = Joi.object()
         /\d/,
         Joi.object().keys({
             displayJobNameLength: SCHEMA_DISPLAY_JOB_NAME_LENGTH,
-            showPRJobs: Joi.boolean()
+            showPRJobs: Joi.boolean(),
+            timestampFormat: SCHEMA_TIMESTAMP_FORMAT
         })
     )
     .unknown();

--- a/test/data/user.get.yaml
+++ b/test/data/user.get.yaml
@@ -5,8 +5,10 @@ scmContext: github:github.com
 settings:
     1:
         displayJobNameLength: 20
+        timestampFormat: 'HUMAN_READABLE'
     11:
         displayJobNameLength: 50
         showPRJobs: false
+        timestampFormat: 'HUMAN_READABLE'
     hello: world
     this: is-allowed

--- a/test/data/user.update.yaml
+++ b/test/data/user.update.yaml
@@ -3,3 +3,4 @@ settings:
     1:
         displayJobNameLength: 35
         showPRJobs: false
+        timestampFormat: 'HUMAN_READABLE'

--- a/test/data/user.yaml
+++ b/test/data/user.yaml
@@ -4,3 +4,4 @@ username: batman
 scmContext: github:github.com
 settings:
     displayJobNameLength: 20
+    timestampFormat: 'HUMAN_READABLE'


### PR DESCRIPTION
## Context
When user looks at events, getting several events happened "2 months ago." When looking  at the list view, confused with timestamp such as "August 18, 2020 4:52 PM."

## Objective
Preference is to have absolute timestamps on the events sidebar. Have a session for Event Timeline Format under the Options -> User Preference -UTC Timestamp, Local Timestamp, Human Readable Timestamp

## References
https://github.com/screwdriver-cd/screwdriver/issues/2218


## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
