### PR TITLE
fix: allow aliasname empty

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -2,6 +2,11 @@
 
 const Joi = require('joi');
 
+const SCHEMA_TIMESTAMP_FORMAT = Joi.string()
+    .valid('UTC', 'LOCAL_TIMEZONE', 'HUMAN_READABLE')
+    .optional()
+    .default('HUMAN_READABLE')
+    .description('User preferred timestamp');
 const SCHEMA_DISPLAY_JOB_NAME_LENGTH = Joi.number()
     .integer()
     .min(20)
@@ -31,7 +36,13 @@ const SCHEMA_PIPELINE_SETTINGS = Joi.object()
         public: Joi.boolean(),
         groupedEvents: Joi.boolean().optional(),
         showEventTriggers: Joi.boolean().optional(),
-        filterEventsForNoBuilds: Joi.boolean().optional()
+        filterEventsForNoBuilds: Joi.boolean().optional(),
+        aliasName: Joi.string()
+            .allow('')
+            .max(32)
+            .description('A customizable alias for pipeline name')
+            .example('scwdvr-cd')
+            .optional()
     })
     .default({});
 
@@ -41,7 +52,8 @@ const SCHEMA_USER_SETTINGS = Joi.object()
         /\d/,
         Joi.object().keys({
             displayJobNameLength: SCHEMA_DISPLAY_JOB_NAME_LENGTH,
-            showPRJobs: Joi.boolean()
+            showPRJobs: Joi.boolean(),
+            timestampFormat: SCHEMA_TIMESTAMP_FORMAT
         })
     )
     .unknown();


### PR DESCRIPTION
## Context

User cannot rename the pipeline back to empty string, on changing AliasName to an empty string it gives `400`.

## Objective
Users can rename the pipeline alias back to an empty string.

## References
https://github.com/screwdriver-cd/screwdriver/issues/2744

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
