### PR TITLE
fix(2580): Make 'state' as required in pipeline schema

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -92,7 +92,8 @@ const MODEL = {
         .max(10)
         .description('Current state of the pipeline')
         .example('ACTIVE')
-        .default('ACTIVE'),
+        .default('ACTIVE')
+        .required(),
 
     subscribedScmUrlsWithActions: Joi.array()
         .items(


### PR DESCRIPTION
## Context

`state` field on the `pipeline` is meant to be non-nullable. It is not marked are required in the schema.

## Objective

This PR marks the field are required in the schema.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2580

Related PRs:
https://github.com/screwdriver-cd/data-schema/pull/490

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
