### PR TITLE
fix: update timestampFormat

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -3,9 +3,9 @@
 const Joi = require('joi');
 
 const SCHEMA_TIMESTAMP_FORMAT = Joi.string()
-    .valid('UTC', 'LOCAL_TIMEZONE', 'HUMAN_READABLE')
+    .valid('UTC', 'LOCAL_TIMEZONE')
     .optional()
-    .default('HUMAN_READABLE')
+    .default('LOCAL_TIMEZONE')
     .description('User preferred timestamp');
 const SCHEMA_DISPLAY_JOB_NAME_LENGTH = Joi.number()
     .integer()
@@ -52,11 +52,14 @@ const SCHEMA_USER_SETTINGS = Joi.object()
         /\d/,
         Joi.object().keys({
             displayJobNameLength: SCHEMA_DISPLAY_JOB_NAME_LENGTH,
-            showPRJobs: Joi.boolean(),
-            timestampFormat: SCHEMA_TIMESTAMP_FORMAT
+            showPRJobs: Joi.boolean()
         })
     )
     .unknown();
+
+SCHEMA_USER_SETTINGS.append({
+    timestampFormat: SCHEMA_TIMESTAMP_FORMAT
+});
 
 module.exports = {
     pipelineSettings: SCHEMA_PIPELINE_SETTINGS,

--- a/test/data/user.get.yaml
+++ b/test/data/user.get.yaml
@@ -5,10 +5,9 @@ scmContext: github:github.com
 settings:
     1:
         displayJobNameLength: 20
-        timestampFormat: 'HUMAN_READABLE'
     11:
         displayJobNameLength: 50
         showPRJobs: false
-        timestampFormat: 'HUMAN_READABLE'
+    timestampFormat: 'LOCAL_TIMEZONE'
     hello: world
     this: is-allowed

--- a/test/data/user.update.yaml
+++ b/test/data/user.update.yaml
@@ -3,4 +3,4 @@ settings:
     1:
         displayJobNameLength: 35
         showPRJobs: false
-        timestampFormat: 'HUMAN_READABLE'
+    timestampFormat: 'LOCAL_TIMEZONE'

--- a/test/data/user.yaml
+++ b/test/data/user.yaml
@@ -4,4 +4,4 @@ username: batman
 scmContext: github:github.com
 settings:
     displayJobNameLength: 20
-    timestampFormat: 'HUMAN_READABLE'
+    timestampFormat: 'LOCAL_TIMEZONE'


### PR DESCRIPTION
## Context
Re-order timestampFormat to top level user preference

See 
Before:

![image](https://user-images.githubusercontent.com/15989893/185235774-90bb9d72-754d-4d64-b4cc-8263ebaf1c32.png)


After:

![image](https://user-images.githubusercontent.com/15989893/185235743-7791313f-6a5c-459c-b4ad-dd2898451584.png)

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
1. move `timestampFormat` to top level
2. remove `HUMAN_READABLE` from `timestampFormat`

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://joi.dev/api/?v=17.6.0#objectappendschema

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
