### PR TITLE
fix: Display JobNameLength in user settings

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -51,13 +51,13 @@ const SCHEMA_USER_SETTINGS = Joi.object()
     .pattern(
         /\d/,
         Joi.object().keys({
-            displayJobNameLength: SCHEMA_DISPLAY_JOB_NAME_LENGTH,
             showPRJobs: Joi.boolean()
         })
     )
     .unknown();
 
 SCHEMA_USER_SETTINGS.append({
+    displayJobNameLength: SCHEMA_DISPLAY_JOB_NAME_LENGTH,
     timestampFormat: SCHEMA_TIMESTAMP_FORMAT
 });
 

--- a/test/data/user.get.yaml
+++ b/test/data/user.get.yaml
@@ -3,11 +3,9 @@ id: 123
 username: batman
 scmContext: github:github.com
 settings:
-    1:
-        displayJobNameLength: 20
     11:
-        displayJobNameLength: 50
         showPRJobs: false
+    displayJobNameLength: 50
     timestampFormat: 'LOCAL_TIMEZONE'
     hello: world
     this: is-allowed

--- a/test/data/user.update.yaml
+++ b/test/data/user.update.yaml
@@ -1,6 +1,6 @@
 # User Example
 settings:
     1:
-        displayJobNameLength: 35
         showPRJobs: false
+    displayJobNameLength: 35
     timestampFormat: 'LOCAL_TIMEZONE'


### PR DESCRIPTION
## Context

Re-order JobNameLength to user settings.

## Objective

Move JobNameLength from User Preference to user settings .

## References

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
