### PR TITLE
fix(2669): Remove old unique constraint for stages table

### DIFF
--- a/migrations/20220908-remove_unique_constraint_from_stages.js
+++ b/migrations/20220908-remove_unique_constraint_from_stages.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}stages`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        try {
+            await queryInterface.removeConstraint(table, `${table}_pipeline_id_name_key`);
+            // eslint-disable-next-line no-empty
+        } catch (e) {}
+    }
+};


### PR DESCRIPTION
## Context

After changing up the stages schema, a new unique constraint was added: https://github.com/screwdriver-cd/data-schema/blob/master/migrations/20220705-upd-stage-color-eventId-createTime.js#L27, https://github.com/screwdriver-cd/data-schema/blob/master/models/stage.js#L71

So we no longer need the old unique constraint: https://github.com/screwdriver-cd/data-schema/blob/master/migrations/20220607-initdb-stages.js#L43

## Objective

This PR removes the old unique constraint through a migration file.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
