### PR TITLE
fix(2669): Do not allow empty array for stage jobIds [1]

### DIFF
--- a/models/stage.js
+++ b/models/stage.js
@@ -28,8 +28,6 @@ const MODEL = {
                 .positive()
                 .description('Identifier for this job')
                 .example(123345)
-                .optional()
-                .allow(null)
         )
         .description('Job IDs in this Stage'),
 

--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
     "npx": "^10.2.2",
     "nyc": "^15.0.0",
     "pg": "^7.18.2",
-    "sequelize": "^6.21.3",
-    "sequelize-cli": "^6.4.1",
+    "sequelize": "^6.24.0",
+    "sequelize-cli": "^6.5.1",
     "sqlite3": "^4.2.0"
   },
   "dependencies": {
     "cron-parser": "^4.5.0",
-    "joi": "^17.6.0"
+    "joi": "^17.6.2"
   }
 }


### PR DESCRIPTION
## Context

Should not allow empty jobs list for stage definitions.

## Objective

This PR removes optional tag and allow null for jobIds.
 
## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2669

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
