### PR TITLE
Add '.', ':', to IMAGE_ALIAS regex

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -97,8 +97,8 @@ module.exports = {
     // First group: SCM plugin name (e.g. github)
     // Second group: SCM host name (e.g. github.com)
     SCM_CONTEXT: /^([^:]+):([^:]+)$/,
-    // Image aliases can only contain A-Z,a-z,0-9,-,_
-    IMAGE_ALIAS: /^[\w-]+$/,
+    // Image aliases can only contain A-Z,a-z,0-9,-,_,.,:
+    IMAGE_ALIAS: /^[\w-.:]+$/,
     // Valid Events for webhook
     WEBHOOK_EVENT: /^~([\w-]+)$/,
     // Provider region. e.g. us-west-1, ap-northeast-2

--- a/config/template.js
+++ b/config/template.js
@@ -53,7 +53,7 @@ const TEMPLATE_MAINTAINER = Joi.string()
 const TEMPLATE_IMAGES = Joi.object()
     .pattern(Regex.IMAGE_ALIAS, Job.image)
     .messages({
-        'object.unknown': '{{#label}} only supports the following characters A-Z,a-z,0-9,-,_'
+        'object.unknown': '{{#label}} only supports the following characters A-Z,a-z,0-9,-,_,.,:'
     })
     .min(1);
 

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -239,6 +239,7 @@ describe('config regex', () => {
     describe('images', () => {
         it('checks good image names', () => {
             assert.isTrue(config.regex.IMAGE_NAME.test('10-13_931-9E501_20180531234344_platform'));
+            assert.isTrue(config.regex.IMAGE_NAME.test('xcode:14.2'));
         });
 
         it('fails on bad image names', () => {


### PR DESCRIPTION
This change will allow for an alias such as `xcode:14.1`. Without this change the alias needs to be something unnatural such as `xcode-14_1`.

The image aliases are essentially only dictionary keys, so it's not clear why their naming need be restricted at all, much less be any more restrictive than the image name itself. However, on the assumption that there is a reason for the naming restriction, this commit take the conservative approach of adding only two additional characters.


## Context

This change will allow for an alias such as `xcode:14.1`. Without this change the alias needs to be something unnatural such as `xcode-14_1`.

## Objective

Less restrict naming on image aliases.

## References

None.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
