### PR TITLE
feat: add group to build cluster

### DIFF
--- a/migrations/20230522124151-add-column_group_to_buildCluster.js
+++ b/migrations/20230522124151-add-column_group_to_buildCluster.js
@@ -1,0 +1,23 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}buildClusters`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                table,
+                'group',
+                {
+                    type: Sequelize.TEXT('medium'),
+                    defaultValue: 'on-prem',
+                    allowNull: false
+                },
+                { transaction }
+            );
+        });
+    }
+};

--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -31,7 +31,13 @@ const MODEL = {
 
     maintainer: Command.maintainer,
 
-    weightage: Joi.number().min(0).max(100).description('Weight percentage for build cluster').example(20)
+    weightage: Joi.number().min(0).max(100).description('Weight percentage for build cluster').example(20),
+
+    group: Joi.string()
+        .valid('on-prem', 'aws', 'gcp')
+        .default('on-prem')
+        .description('Group of the build cluster')
+        .example('aws')
 };
 
 module.exports = {
@@ -68,7 +74,8 @@ module.exports = {
                 'isActive',
                 'managedByScrewdriver',
                 'maintainer',
-                'weightage'
+                'weightage',
+                'group'
             ],
             ['description']
         )
@@ -91,7 +98,8 @@ module.exports = {
                 'managedByScrewdriver',
                 'maintainer',
                 'weightage',
-                'scmContext'
+                'scmContext',
+                'group'
             ]
         )
     ).label('Update BuildCluster'),

--- a/test/data/buildCluster.group.yaml
+++ b/test/data/buildCluster.group.yaml
@@ -1,6 +1,3 @@
-# BuildCluster get example
-id: 1
-name: iOS
 description: 'Build cluster for iOS team'
 scmContext: 'github:github.com'
 scmOrganizations: [screwdriver-cd]

--- a/test/models/buildCluster.test.js
+++ b/test/models/buildCluster.test.js
@@ -33,6 +33,10 @@ describe('model buildCluster', () => {
         it('fails the update', () => {
             assert.isNotNull(validate('empty.yaml', models.buildCluster.update).error);
         });
+
+        it('validates the update with group', () => {
+            assert.isNull(validate('buildCluster.group.yaml', models.buildCluster.update).error);
+        });
     });
 
     describe('get', () => {


### PR DESCRIPTION
## Context

Logically group build cluster with default based on the environment. 

## Objective

This PR adds a new column `group` to build cluster schema

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
