### PR TITLE
feat: make build cluster group name more relaxed

### DIFF
--- a/migrations/20230522124151-add-column_group_to_buildCluster.js
+++ b/migrations/20230522124151-add-column_group_to_buildCluster.js
@@ -12,9 +12,7 @@ module.exports = {
                 table,
                 'group',
                 {
-                    type: Sequelize.TEXT('medium'),
-                    defaultValue: 'on-prem',
-                    allowNull: false
+                    type: Sequelize.TEXT('medium')
                 },
                 { transaction }
             );

--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -34,10 +34,9 @@ const MODEL = {
     weightage: Joi.number().min(0).max(100).description('Weight percentage for build cluster').example(20),
 
     group: Joi.string()
-        .valid('on-prem', 'aws', 'gcp')
-        .default('on-prem')
+        .default('default')
         .description('Group of the build cluster')
-        .example('aws')
+        .example(('aws', 'gcp', 'on-prem', 'default'))
 };
 
 module.exports = {


### PR DESCRIPTION
## Context

Build cluster group is restricitve

## Objective

This PR updates the group field to be a string and not limit the group names

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
