### PR TITLE
fix: get and create schema for buildCluster

### DIFF
--- a/models/buildCluster.js
+++ b/models/buildCluster.js
@@ -73,10 +73,12 @@ module.exports = {
                 'isActive',
                 'managedByScrewdriver',
                 'maintainer',
-                'weightage',
-                'group'
+                'weightage'
             ],
-            ['description']
+            [
+                'description',
+                'group'
+            ]
         )
     ).label('Get BuildCluster'),
 
@@ -113,7 +115,7 @@ module.exports = {
         mutate(
             MODEL,
             ['name', 'scmOrganizations', 'managedByScrewdriver', 'maintainer'],
-            ['description', 'isActive', 'weightage', 'scmContext']
+            ['description', 'isActive', 'weightage', 'scmContext', 'group']
         )
     ).label('Create Build'),
 


### PR DESCRIPTION
## Context

BuildCluster get schema should not return group if null

## Objective

This PR fixes the create and get schema for buildCluster

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
