### PR TITLE
fix(2892): normalize the type of SCM user id to String

### DIFF
--- a/core/scm.js
+++ b/core/scm.js
@@ -5,7 +5,7 @@ const Regex = require('../config/regex');
 
 const SCHEMA_USER = Joi.object()
     .keys({
-        id: Joi.alternatives(Joi.string(), Joi.number().integer().positive()).allow('').optional(),
+        id: Joi.string().allow('').optional(),
 
         url: Joi.string()
             .uri()

--- a/test/data/scm.user.yaml
+++ b/test/data/scm.user.yaml
@@ -1,5 +1,5 @@
 # SCM User Example
-id: 1234
+id: "1234"
 name: St. John Johnson
 username: stjohnjohnson
 url: https://github.com/stjohnjohnson


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up of PR https://github.com/screwdriver-cd/data-schema/pull/518

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR normalize the type of SCM user id to String.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/2892#issuecomment-1602452632

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
