### PR TITLE
fix(2767): Allow update stage archived [1.5]

### DIFF
--- a/models/stage.js
+++ b/models/stage.js
@@ -61,7 +61,9 @@ module.exports = {
      * @property update
      * @type {Joi}
      */
-    update: Joi.object(mutate(MODEL, [], ['jobIds', 'description', 'setup', 'teardown'])).label('Update Stage'),
+    update: Joi.object(mutate(MODEL, [], ['jobIds', 'description', 'setup', 'teardown', 'archived'])).label(
+        'Update Stage'
+    ),
 
     /**
      * List of fields that determine a unique row


### PR DESCRIPTION
## Context

Sometimes we might need to update stage `archived` field.

## Objective

This PR allows updating stage `archived`.

## References

Related to https://github.com/screwdriver-cd/data-schema/pull/510

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
