### PR TITLE
fix: expand scmUri length

### DIFF
--- a/migrations/20230720-update_branch_name_length.js
+++ b/migrations/20230720-update_branch_name_length.js
@@ -1,0 +1,14 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}pipelines`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.changeColumn(table, 'scmUri', Sequelize.STRING(500), { transaction });
+        });
+    }
+};

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -33,7 +33,7 @@ const MODEL = {
 
     scmUri: Joi.string()
         .regex(Regex.SCM_URI)
-        .max(128)
+        .max(500)
         .description('Unique identifier for the application')
         .example('github.com:123456:master')
         .example('github.com:123456:master:src/app/component'),


### PR DESCRIPTION
## Context

Currently, scmUri is set to 128 characters, so if a branch name or a src directory is very long, the 128 characters will be exceeded and the pipeline will not run and an error will occur.

## Objective

A pipeline runs successfully even if a branch name or src directory is long.

## References
The configuration of scmUri is `<scm name>:<Repository ID>:<Branch name>:<src dir path>`.
A branch name limit is 250 characters.
A src dir path limit is 100 characters. ([link](https://github.com/screwdriver-cd/data-schema/blob/f2e6b3b29145866ad1aff038986cae80577dac30/core/scm.js#L36))
Also, to avoid problems when the scm is slightly longer, set it to 500 characters.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
