### PR TITLE
fix(2767): Drop and recreate stages table

### DIFF
--- a/migrations/20221003-add_column_setup_teardown_startFrom_to_stage.js
+++ b/migrations/20221003-add_column_setup_teardown_startFrom_to_stage.js
@@ -8,45 +8,39 @@ const table = `${prefix}stages`;
 module.exports = {
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async transaction => {
-            try {
-                await queryInterface.removeColumn(table, 'groupEventId');
+            await queryInterface.removeColumn(table, 'groupEventId', { transaction });
 
-                await queryInterface.addColumn(
-                    table,
-                    'setup',
-                    {
-                        type: Sequelize.INTEGER
-                    },
-                    { transaction }
-                );
-                await queryInterface.addColumn(
-                    table,
-                    'teardown',
-                    {
-                        type: Sequelize.INTEGER
-                    },
-                    { transaction }
-                );
-                await queryInterface.addColumn(
-                    table,
-                    'archived',
-                    {
-                        type: Sequelize.BOOLEAN
-                    },
-                    { transaction }
-                );
-                await queryInterface.removeConstraint(table, `${table}_pipeline_id_name_group_event_id_key`, {
-                    transaction
-                });
+            await queryInterface.addConstraint(table, {
+                fields: ['pipelineId', 'name'],
+                name: `${table}_pipeline_id_name_key`,
+                type: 'unique',
+                transaction
+            });
 
-                await queryInterface.addConstraint(table, {
-                    fields: ['pipelineId', 'name'],
-                    name: `${table}_pipeline_id_name_key`,
-                    type: 'unique',
-                    transaction
-                });
-                // eslint-disable-next-line no-empty
-            } catch (e) {}
+            await queryInterface.addColumn(
+                table,
+                'setup',
+                {
+                    type: Sequelize.INTEGER
+                },
+                { transaction }
+            );
+            await queryInterface.addColumn(
+                table,
+                'teardown',
+                {
+                    type: Sequelize.INTEGER
+                },
+                { transaction }
+            );
+            await queryInterface.addColumn(
+                table,
+                'archived',
+                {
+                    type: Sequelize.BOOLEAN
+                },
+                { transaction }
+            );
         });
     }
 };

--- a/migrations/20230810151625-drop_and_recreate_stages.js
+++ b/migrations/20230810151625-drop_and_recreate_stages.js
@@ -1,0 +1,72 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}stages`;
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const transaction = await queryInterface.sequelize.transaction();
+
+        try {
+            await queryInterface.dropTable(table, {
+                transaction
+            });
+
+            await queryInterface.createTable(
+                table,
+                {
+                    id: {
+                        allowNull: false,
+                        autoIncrement: true,
+                        primaryKey: true,
+                        type: Sequelize.INTEGER.UNSIGNED
+                    },
+                    pipelineId: {
+                        type: Sequelize.DOUBLE
+                    },
+                    name: {
+                        type: Sequelize.STRING(64)
+                    },
+                    jobIds: {
+                        type: Sequelize.TEXT
+                    },
+                    description: {
+                        type: Sequelize.STRING(256)
+                    },
+                    setup: {
+                        type: Sequelize.INTEGER
+                    },
+                    teardown: {
+                        type: Sequelize.INTEGER
+                    },
+                    archived: {
+                        type: Sequelize.BOOLEAN
+                    },
+                    workflowGraph: {
+                        type: Sequelize.TEXT
+                    }
+                },
+                { transaction }
+            );
+            await queryInterface.addConstraint(table, {
+                name: `${table}_pipeline_id_name_key`,
+                fields: ['pipelineId', 'name'],
+                type: 'unique',
+                transaction
+            });
+
+            await queryInterface.addIndex(table, {
+                name: `${table}_pipeline_id`,
+                fields: ['pipelineId'],
+                transaction
+            });
+
+            await transaction.commit();
+        } catch (e) {
+            await transaction.rollback();
+            throw e;
+        }
+    }
+};

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const yaml = require('js-yaml');
 const fs = require('fs');
 const path = require('path');
+const yaml = require('js-yaml');
 const DATA_DIR = path.join(__dirname, 'data');
 
 module.exports = {

--- a/test/models/index.test.js
+++ b/test/models/index.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { assert } = require('chai');
 const fs = require('fs');
+const { assert } = require('chai');
 const { models } = require('../..');
 
 describe('model commmons', () => {


### PR DESCRIPTION
## Context
DB migration script added in PR https://github.com/screwdriver-cd/data-schema/pull/510 resulted in unexpected changes.
Script intended to do below changes

1. remove column `groupEventId`
2. add new columns `setup`, `teardown` and `archived`
3. remove unique constraint involving `groupEventId` (`name`, `pipelineId` and `groupEventId`)
4. add unique constraint on just `name` and `pipelineId`

There were below of issues
- Step#1 was not associated with the transaction
- Step#3 failed since the constraint was already removed when column `groupEventId` was removed. 
```
ERROR: Unknown constraint error
```
- Transaction was rolled back. But, it didn't add back `groupEventId` as it was not associated with the transaction. 
- Error was caught by `catch` block and did nothing. Since the error didn't bubble up, the migration was marked as successfully applied

This created a misalignment between the DB and migration script.
Since the migration was considered as applied, it will not be reapplied even if we fix the script.
```
== 20221003-add_column_setup_teardown_startFrom_to_stage: migrating =======
Executing (24b60404-744f-4322-9de7-5936593f1102): START TRANSACTION;
Executing (24b60404-744f-4322-9de7-5936593f1102): ALTER TABLE "public"."stages" DROP COLUMN "groupEventId";
Executing (24b60404-744f-4322-9de7-5936593f1102): ALTER TABLE "public"."stages" ADD COLUMN "setup" INTEGER;
Executing (24b60404-744f-4322-9de7-5936593f1102): ALTER TABLE "public"."stages" ADD COLUMN "teardown" INTEGER;
Executing (24b60404-744f-4322-9de7-5936593f1102): ALTER TABLE "public"."stages" ADD COLUMN "archived" BOOLEAN;
Executing (24b60404-744f-4322-9de7-5936593f1102): ALTER TABLE "stages" DROP CONSTRAINT "stages_pipeline_id_name_group_event_id_key"
Error
    at Query.run (/Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/sequelize/lib/dialects/postgres/query.js:50:25)
    at /Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/sequelize/lib/sequelize.js:315:28
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /Users/dsagar/Workspace/screwdriver-cd/data-schema/migrations/20221003-add_column_setup_teardown_startFrom_to_stage.js:38:17
    at async /Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/sequelize/lib/sequelize.js:507:18
    at async Object.up (/Users/dsagar/Workspace/screwdriver-cd/data-schema/migrations/20221003-add_column_setup_teardown_startFrom_to_stage.js:10:9) {
  name: 'SequelizeUnknownConstraintError',
  parent: error: constraint "stages_pipeline_id_name_group_event_id_key" of relation "stages" does not exist
      at Parser.parseErrorMessage (/Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/pg-protocol/dist/parser.js:287:98)
      at Parser.handlePacket (/Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/pg-protocol/dist/parser.js:126:29)
      at Parser.parse (/Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/pg-protocol/dist/parser.js:39:38)
      at Socket.<anonymous> (/Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/pg-protocol/dist/index.js:11:42)
      at Socket.emit (node:events:513:28)
      at addChunk (node:internal/streams/readable:324:12)
      at readableAddChunk (node:internal/streams/readable:297:9)
      at Readable.push (node:internal/streams/readable:234:10)
      at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
    length: 161,
    severity: 'ERROR',
    code: '42704',
    detail: undefined,
    hint: undefined,
    position: undefined,
    internalPosition: undefined,
    internalQuery: undefined,
    where: undefined,
    schema: undefined,
    table: undefined,
    column: undefined,
    dataType: undefined,
    constraint: undefined,
    file: 'tablecmds.c',
    line: '11434',
    routine: 'ATExecDropConstraint',
    sql: 'ALTER TABLE "stages" DROP CONSTRAINT "stages_pipeline_id_name_group_event_id_key"',
    parameters: undefined
  },
  original: error: constraint "stages_pipeline_id_name_group_event_id_key" of relation "stages" does not exist
      at Parser.parseErrorMessage (/Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/pg-protocol/dist/parser.js:287:98)
      at Parser.handlePacket (/Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/pg-protocol/dist/parser.js:126:29)
      at Parser.parse (/Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/pg-protocol/dist/parser.js:39:38)
      at Socket.<anonymous> (/Users/dsagar/Workspace/screwdriver-cd/data-schema/node_modules/pg-protocol/dist/index.js:11:42)
      at Socket.emit (node:events:513:28)
      at addChunk (node:internal/streams/readable:324:12)
      at readableAddChunk (node:internal/streams/readable:297:9)
      at Readable.push (node:internal/streams/readable:234:10)
      at TCP.onStreamRead (node:internal/stream_base_commons:190:23) {
    length: 161,
    severity: 'ERROR',
    code: '42704',
    detail: undefined,
    hint: undefined,
    position: undefined,
    internalPosition: undefined,
    internalQuery: undefined,
    where: undefined,
    schema: undefined,
    table: undefined,
    column: undefined,
    dataType: undefined,
    constraint: undefined,
    file: 'tablecmds.c',
    line: '11434',
    routine: 'ATExecDropConstraint',
    sql: 'ALTER TABLE "stages" DROP CONSTRAINT "stages_pipeline_id_name_group_event_id_key"',
    parameters: undefined
  },
  sql: 'ALTER TABLE "stages" DROP CONSTRAINT "stages_pipeline_id_name_group_event_id_key"',
  parameters: {},
  constraint: 'stages_pipeline_id_name_group_event_id_key',
  fields: undefined,
  table: 'stages'
}
Executing (24b60404-744f-4322-9de7-5936593f1102): COMMIT;
Executing (default): SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'SequelizeMeta'
Executing (default): SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND t.relkind = 'r' and t.relname = 'SequelizeMeta' GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;
Executing (default): INSERT INTO "SequelizeMeta" ("name") VALUES ($1) RETURNING "name";
== 20221003-add_column_setup_teardown_startFrom_to_stage: migrated (0.020s)
```

## Objective
Add a new migration script to drop the `stages` table and recreate with all the columns per latest model schema.
Also fix the existing script to eliminate errors.

**Before**:
![image](https://github.com/screwdriver-cd/data-schema/assets/2124590/7caf5d23-bbd6-4f66-9e3c-23bb781211a6)


**After**:
![image](https://github.com/screwdriver-cd/data-schema/assets/2124590/17228998-2c13-4ae8-a03d-16b74fd1d226)


## References

https://github.com/screwdriver-cd/screwdriver/issues/2767

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
