### PR TITLE
fix(2135): Update unique constraint for templateTags

### DIFF
--- a/migrations/20230822154332-update-templateTags-unique-constriant.js
+++ b/migrations/20230822154332-update-templateTags-unique-constriant.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}templateTags`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.removeConstraint(table, `${table}_namespace_name_tag_key`, { transaction });
+
+            await queryInterface.addConstraint(table, {
+                name: `${table}_namespace_name_tag_templateType_key`,
+                fields: ['name', 'tag', 'namespace', 'templateType'],
+                type: 'unique',
+                transaction
+            });
+        });
+    }
+};


### PR DESCRIPTION
## Context

PR https://github.com/screwdriver-cd/screwdriver/issues/2135 added a new column `templateType` to `templateTags` table.
With this, we intend to store tags for pipeline level templates in `templateTags` (where we currently store job level template tags) and distinguish job level and pipeline level template base on `templateType`.

But the unique constraint was not updated to include `templateType`.
![image](https://github.com/screwdriver-cd/data-schema/assets/2124590/db955318-c02c-4a76-b85b-d5032e34f6ca)


## Objective

Include `templateType` in the unique constraint.
![image](https://github.com/screwdriver-cd/data-schema/assets/2124590/b91c9e5a-6d99-45c5-9723-bf2b597ea9d3)


## References

https://github.com/screwdriver-cd/screwdriver/issues/2135

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
