### PR TITLE
feat(2767): Remove 'workflowGraph' column from stages and stageBuilds

### DIFF
--- a/migrations/20230921145023-remove-workflowgraph-from-stages.js
+++ b/migrations/20230921145023-remove-workflowgraph-from-stages.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const stagesTable = `${prefix}stages`;
+const stageBuildsTable = `${prefix}stageBuilds`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.removeColumn(stagesTable, 'workflowGraph', { transaction });
+            await queryInterface.removeColumn(stageBuildsTable, 'workflowGraph', { transaction });
+        });
+    }
+};

--- a/models/stage.js
+++ b/models/stage.js
@@ -2,7 +2,6 @@
 
 const Joi = require('joi');
 const Regex = require('../config/regex');
-const WorkflowGraph = require('../config/workflowGraph');
 const mutate = require('../lib/mutate');
 
 const MODEL = {
@@ -26,15 +25,7 @@ const MODEL = {
 
     description: Joi.string().max(256).description('Description of the Stage').example('Deploys canary jobs'),
 
-    archived: Joi.boolean().description('Flag if the stage is archived').example(true).default(false),
-
-    workflowGraph: WorkflowGraph.workflowGraph.description('Graph representation of the workflow').example({
-        nodes: [{ name: '~commit' }, { name: 'main' }, { name: 'publish' }],
-        edges: [
-            { src: '~commit', dest: 'main' },
-            { src: 'main', dest: 'publish' }
-        ]
-    })
+    archived: Joi.boolean().description('Flag if the stage is archived').example(true).default(false)
 };
 
 module.exports = {
@@ -61,11 +52,7 @@ module.exports = {
      * @type {Joi}
      */
     get: Joi.object(
-        mutate(
-            MODEL,
-            ['id', 'pipelineId', 'name', 'jobIds'],
-            ['description', 'setup', 'teardown', 'archived', 'workflowGraph']
-        )
+        mutate(MODEL, ['id', 'pipelineId', 'name', 'jobIds'], ['description', 'setup', 'teardown', 'archived'])
     ).label('Get Stage metadata'),
 
     /**
@@ -74,9 +61,9 @@ module.exports = {
      * @property update
      * @type {Joi}
      */
-    update: Joi.object(
-        mutate(MODEL, [], ['jobIds', 'description', 'setup', 'teardown', 'archived', 'workflowGraph'])
-    ).label('Update Stage'),
+    update: Joi.object(mutate(MODEL, [], ['jobIds', 'description', 'setup', 'teardown', 'archived'])).label(
+        'Update Stage'
+    ),
 
     /**
      * List of fields that determine a unique row

--- a/models/stageBuild.js
+++ b/models/stageBuild.js
@@ -2,7 +2,6 @@
 
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
-const WorkflowGraph = require('../config/workflowGraph');
 const status = require('./build').base.extract('status');
 
 const MODEL = {
@@ -11,14 +10,6 @@ const MODEL = {
     stageId: Joi.number().integer().positive().description('Stage associated with the Stage build').example(123345),
 
     eventId: Joi.number().integer().positive().description('Identifier of the event').example(123345),
-
-    workflowGraph: WorkflowGraph.workflowGraph.description('Graph representation of the workflow').example({
-        nodes: [{ name: '~commit' }, { name: 'main' }, { name: 'publish' }],
-        edges: [
-            { src: '~commit', dest: 'main' },
-            { src: 'main', dest: 'publish' }
-        ]
-    }),
 
     status
 };
@@ -46,9 +37,7 @@ module.exports = {
      * @property get
      * @type {Joi}
      */
-    get: Joi.object(mutate(MODEL, ['id', 'stageId', 'eventId'], ['workflowGraph', 'status'])).label(
-        'Get Stage Build metadata'
-    ),
+    get: Joi.object(mutate(MODEL, ['id', 'stageId', 'eventId'], ['status'])).label('Get Stage Build metadata'),
 
     /**
      * List of fields that determine a unique row

--- a/test/data/stage.yaml
+++ b/test/data/stage.yaml
@@ -6,13 +6,3 @@ jobIds: [1, 2, 3, 4]
 description: 'Deploys canary jobs'
 setup: [222]
 teardown: [333]
-workflowGraph:
-    nodes:
-        - name: '~commit'
-        - name: 'main'
-        - name: 'publish'
-    edges:
-        - src: '~commit'
-          dest: 'main'
-        - src: 'main'
-          dest: 'publish'

--- a/test/data/stageBuild.yaml
+++ b/test/data/stageBuild.yaml
@@ -2,14 +2,3 @@
 id: 123234135
 stageId: 1
 eventId: 555
-workflowGraph:
-    nodes:
-        - name: '~commit'
-        - name: 'main'
-        - name: 'publish'
-    edges:
-        - src: '~commit'
-          dest: 'main'
-        - src: 'main'
-          dest: 'publish'
-status: SUCCESS

--- a/test/models/stageBuild.test.js
+++ b/test/models/stageBuild.test.js
@@ -23,7 +23,7 @@ describe('model stage build', () => {
 
     describe('allKeys', () => {
         it('lists all of the fields in the model', () => {
-            const expectedKeys = ['id', 'stageId', 'eventId', 'workflowGraph', 'status'];
+            const expectedKeys = ['id', 'stageId', 'eventId', 'status'];
 
             expectedKeys.forEach(keyName => {
                 assert.include(models.stageBuild.allKeys, keyName, `Key name ${keyName} not included`);


### PR DESCRIPTION
## Context

PR https://github.com/screwdriver-cd/workflow-parser/pull/43 intended to segregate the `nodes` and `edges` associated with the jobs of stages to build and persist workflows separately for each stage.
And pipeline workflow contained `nodes` and `edges` for jobs outside the stages and a complete stage workflow was represented by a single node.

Later these stage workflows are always combined with pipeline workflow to stitch together an unified workflow for further processing in the backend.

## Objective

We do not need stage level workflows as they are not processed as themselves. Drop column `workflowGraph` from `stages` and `stageBuilds` table.

The `workflowGraph` of `pipeline` and `event` will contain `nodes` and `edges` for all the jobs irrespective of whether they belong to a stage or not.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2767

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
