### PR TITLE
feat: add cloud readiness for template

### DIFF
--- a/config/compatibilities.js
+++ b/config/compatibilities.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Joi = require('joi');
+
+const compatibilities = Joi.object({
+    clouds: Joi.array()
+        .items(Joi.string())
+        .description('A list of cloud that template supports')
+        .example(['aws', 'gcp', 'azure'])
+        .optional(),
+    architectures: Joi.array()
+        .items(Joi.string())
+        .description('A list of architectures that template supports')
+        .example(['x86', 'x86_64', 'arm64'])
+        .optional()
+});
+
+module.exports = {
+    compatibilities
+};

--- a/models/command.js
+++ b/models/command.js
@@ -4,7 +4,7 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Command = require('../config/command');
 const pipelineId = require('./pipeline').base.extract('id');
-const Compatibilities = require('Compatibilities');
+const Compatibilities = require('../config/compatibilities');
 
 const { compatibilities } = Compatibilities;
 

--- a/models/command.js
+++ b/models/command.js
@@ -4,6 +4,9 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Command = require('../config/command');
 const pipelineId = require('./pipeline').base.extract('id');
+const Compatibilities = require('Compatibilities');
+
+const { compatibilities } = Compatibilities;
 
 const MODEL = {
     id: Joi.number().integer().positive().description('Identifier of this command').example(123345),
@@ -24,7 +27,8 @@ const MODEL = {
         .example('2038-01-19T03:14:08.131Z'),
     usage: Command.usage,
     trusted: Joi.boolean().description('Mark whether command is trusted'),
-    latest: Joi.boolean().description('Whether this is latest version')
+    latest: Joi.boolean().description('Whether this is latest version'),
+    compatibilities
 };
 
 module.exports = {

--- a/models/command.js
+++ b/models/command.js
@@ -58,7 +58,7 @@ module.exports = {
         mutate(
             MODEL,
             ['id', 'namespace', 'name', 'version', 'description', 'maintainer', 'format', 'pipelineId'],
-            ['habitat', 'docker', 'binary', 'createTime', 'usage', 'trusted', 'latest']
+            ['habitat', 'docker', 'binary', 'createTime', 'usage', 'trusted', 'latest', 'compatibilities']
         )
     ).label('Get Command'),
 

--- a/models/template.js
+++ b/models/template.js
@@ -23,6 +23,10 @@ const MODEL = {
         .example('2038-01-19T03:14:08.131Z'),
     trusted: Joi.boolean().description('Mark whether template is trusted'),
     latest: Joi.boolean().description('Whether this is latest version')
+    clouds: Joi.array().items(Joi.string())
+        .description('A list of cloud that template supports')
+        .example(['aws', 'gcp', 'azure'])
+        .optional()
 };
 
 const CREATE_MODEL = { ...MODEL, config: Template.configNoDupSteps };

--- a/models/template.js
+++ b/models/template.js
@@ -23,11 +23,18 @@ const MODEL = {
         .example('2038-01-19T03:14:08.131Z'),
     trusted: Joi.boolean().description('Mark whether template is trusted'),
     latest: Joi.boolean().description('Whether this is latest version'),
-    clouds: Joi.array()
-        .items(Joi.string())
-        .description('A list of cloud that template supports')
-        .example(['aws', 'gcp', 'azure'])
-        .optional()
+    compatibilities: Joi.object({
+        clouds: Joi.array()
+            .items(Joi.string())
+            .description('A list of cloud that template supports')
+            .example(['aws', 'gcp', 'azure'])
+            .optional(),
+        architectures: Joi.array()
+            .items(Joi.string())
+            .description('A list of architectures that template supports')
+            .example(['x86', 'x86_64', 'arm64'])
+            .optional()
+    })
 };
 
 const CREATE_MODEL = { ...MODEL, config: Template.configNoDupSteps };
@@ -59,7 +66,7 @@ module.exports = {
         mutate(
             MODEL,
             ['id', 'labels', 'name', 'version', 'description', 'maintainer', 'pipelineId'],
-            ['config', 'namespace', 'images', 'createTime', 'trusted', 'latest']
+            ['config', 'namespace', 'images', 'createTime', 'trusted', 'latest', 'compatibilities']
         )
     ).label('Get Template'),
 

--- a/models/template.js
+++ b/models/template.js
@@ -4,6 +4,9 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Template = require('../config/template');
 const pipelineId = require('./pipeline').base.extract('id');
+const Compatibilities = require('Compatibilities');
+
+const { compatibilities } = Compatibilities;
 
 const MODEL = {
     id: Joi.number().integer().positive().description('Identifier of this template').example(123345),
@@ -23,18 +26,7 @@ const MODEL = {
         .example('2038-01-19T03:14:08.131Z'),
     trusted: Joi.boolean().description('Mark whether template is trusted'),
     latest: Joi.boolean().description('Whether this is latest version'),
-    compatibilities: Joi.object({
-        clouds: Joi.array()
-            .items(Joi.string())
-            .description('A list of cloud that template supports')
-            .example(['aws', 'gcp', 'azure'])
-            .optional(),
-        architectures: Joi.array()
-            .items(Joi.string())
-            .description('A list of architectures that template supports')
-            .example(['x86', 'x86_64', 'arm64'])
-            .optional()
-    })
+    compatibilities
 };
 
 const CREATE_MODEL = { ...MODEL, config: Template.configNoDupSteps };

--- a/models/template.js
+++ b/models/template.js
@@ -23,7 +23,8 @@ const MODEL = {
         .example('2038-01-19T03:14:08.131Z'),
     trusted: Joi.boolean().description('Mark whether template is trusted'),
     latest: Joi.boolean().description('Whether this is latest version'),
-    clouds: Joi.array().items(Joi.string())
+    clouds: Joi.array()
+        .items(Joi.string())
         .description('A list of cloud that template supports')
         .example(['aws', 'gcp', 'azure'])
         .optional()

--- a/models/template.js
+++ b/models/template.js
@@ -22,7 +22,7 @@ const MODEL = {
         .description('When this template was created')
         .example('2038-01-19T03:14:08.131Z'),
     trusted: Joi.boolean().description('Mark whether template is trusted'),
-    latest: Joi.boolean().description('Whether this is latest version')
+    latest: Joi.boolean().description('Whether this is latest version'),
     clouds: Joi.array().items(Joi.string())
         .description('A list of cloud that template supports')
         .example(['aws', 'gcp', 'azure'])

--- a/models/template.js
+++ b/models/template.js
@@ -4,7 +4,7 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const Template = require('../config/template');
 const pipelineId = require('./pipeline').base.extract('id');
-const Compatibilities = require('Compatibilities');
+const Compatibilities = require('../config/compatibilities');
 
 const { compatibilities } = Compatibilities;
 

--- a/test/data/command.yaml
+++ b/test/data/command.yaml
@@ -17,5 +17,6 @@ docker:
 binary:
     file: ./foobar.sh
 pipelineId: 8765
-clouds: [aws, gcp]
-architectures: [arm64]
+compatibilities:
+    clouds: [aws, gcp]
+    architectures: [arm64]

--- a/test/data/command.yaml
+++ b/test/data/command.yaml
@@ -17,3 +17,5 @@ docker:
 binary:
     file: ./foobar.sh
 pipelineId: 8765
+clouds: [aws, gcp]
+architectures: [arm64]

--- a/test/data/template.yaml
+++ b/test/data/template.yaml
@@ -22,3 +22,4 @@ config:
     FOO: bar
   secrets:
      - NPM_TOKEN
+clouds: [aws, gcp]

--- a/test/data/template.yaml
+++ b/test/data/template.yaml
@@ -22,5 +22,6 @@ config:
     FOO: bar
   secrets:
      - NPM_TOKEN
-clouds: [aws, gcp]
-architectures: [arm64]
+compatibilities:
+    clouds: [aws, gcp]
+    architectures: [arm64]

--- a/test/data/template.yaml
+++ b/test/data/template.yaml
@@ -23,4 +23,4 @@ config:
   secrets:
      - NPM_TOKEN
 clouds: [aws, gcp]
-architectures: ['arm64']
+architectures: [arm64]

--- a/test/data/template.yaml
+++ b/test/data/template.yaml
@@ -23,3 +23,4 @@ config:
   secrets:
      - NPM_TOKEN
 clouds: [aws, gcp]
+architectures: ['arm64']


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Add cloud readiness on template level, supported `clouds` field is optional
<!-- What does this PR fix? What intentional changes will this PR make? -->


<img width="736" alt="image" src="https://github.com/screwdriver-cd/data-schema/assets/15989893/2ddaed04-7209-4989-a4eb-8f1e60d0ba54">

<img width="718" alt="image" src="https://github.com/screwdriver-cd/data-schema/assets/15989893/95cba282-b574-4bfa-b291-26bbb6fc21f1">

<img width="729" alt="image" src="https://github.com/screwdriver-cd/data-schema/assets/15989893/dcad70a1-e180-424c-82d4-8daf25f59871">


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
