### PR TITLE
fix: add badges to UPDATE_MODEL of pipeline

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -107,7 +107,7 @@ const MODEL = {
         .optional()
 };
 
-const UPDATE_MODEL = { ...CREATE_MODEL, settings: MODEL.settings };
+const UPDATE_MODEL = { ...CREATE_MODEL, settings: MODEL.settings, badges: MODEL.badges };
 
 module.exports = {
     /**


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Pipeline model is a little complex, we have CREATE_MODEL, UPDATE_MODEL, and the previous PR https://github.com/screwdriver-cd/data-schema/pull/533/ forgot to include `badges` definition to `UPDATE_MODEL`

This PR fixes that, when API calls `PUT`, with `badges: {}` in the payload, payload will pass the hapi validate 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
