### PR TITLE
fix: Add template info and prNum to executor start [0]

### DIFF
--- a/config/template.js
+++ b/config/template.js
@@ -21,6 +21,12 @@ const TEMPLATE_NAME = Joi.alternatives()
     .description('Name of the Template')
     .example('node/npm-install');
 
+const TEMPLATE_FULL_NAME = Joi.string()
+    .regex(Regex.TEMPLATE_NAME_ALLOW_SLASH)
+    .max(64)
+    .description('Full name including namespace of the Template')
+    .example('node/npm-install');
+
 const TEMPLATE_TAG_NAME = Joi.string()
     .regex(Regex.TEMPLATE_TAG_NAME)
     .max(30)
@@ -75,6 +81,7 @@ module.exports = {
     template: SCHEMA_TEMPLATE,
     namespace: TEMPLATE_NAMESPACE,
     name: TEMPLATE_NAME,
+    fullName: TEMPLATE_FULL_NAME,
     templateTag: TEMPLATE_TAG_NAME,
     version: TEMPLATE_VERSION,
     exactVersion: TEMPLATE_EXACT_VERSION,

--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const Annotations = require('../config/annotations');
 const Job = require('../config/job');
 const Provider = require('../config/provider');
+const Template = require('../config/template');
 const models = require('../models');
 const buildId = models.build.base.extract('id').required();
 const eventId = models.event.base.extract('id');
@@ -12,14 +13,25 @@ const jobId = models.job.base.extract('id');
 const jobName = models.job.base.extract('name');
 const jobState = models.job.base.extract('state');
 const jobArchived = models.job.base.extract('archived');
+const pipelineId = models.pipeline.base.extract('id');
 
 const SCHEMA_PIPELINE = Joi.object()
     .keys({
-        id: models.pipeline.base.extract('id').required(),
-        scmContext: models.pipeline.base.extract('scmContext').required()
+        id: pipelineId.required(),
+        name: models.pipeline.base.extract('name').optional(),
+        scmContext: models.pipeline.base.extract('scmContext').required(),
+        configPipelineId: models.pipeline.base.extract('configPipelineId').required()
     })
     .unknown();
-const pipelineId = models.pipeline.base.extract('id');
+const SCHEMA_TEMPLATE = Joi.object()
+    .keys({
+        id: models.template.base.extract('id'),
+        fullName: Template.fullName,
+        name: models.template.base.extract('name'),
+        namespace: models.template.base.extract('namespace'),
+        version: models.template.base.extract('version')
+    })
+    .unknown();
 const buildSchemaObj = {
     build: Joi.object(),
     causeMessage,
@@ -36,12 +48,14 @@ const buildSchemaObj = {
     tokenGen: Joi.func(),
     pipeline: SCHEMA_PIPELINE,
     pipelineId,
+    template: SCHEMA_TEMPLATE,
     buildClusterName: models.buildCluster.base.extract('name'),
     container: models.build.base.extract('container').required(),
     apiUri: Joi.string().uri().required().label('API URI'),
     token: Joi.string().required().label('Build JWT'),
     enqueueTime: Joi.date().iso(),
     isPR: Joi.boolean().optional().default(true),
+    prNum: models.event.base.extract('prNum'),
     prParentJobId: jobId.optional()
 };
 const SCHEMA_START = Joi.object()

--- a/test/data/executor.start.yaml
+++ b/test/data/executor.start.yaml
@@ -32,5 +32,13 @@ pipeline:
     scmContext: http://mock
     admin: admin
     token: asdf
+    name: d2lam/test
+template:
+    id: 888
+    name: docker
+    namespace: sd
+    fullName: sd/docker
+    version: '1.0.0'
 isPR: true
+prNum: 567
 prParentJobId: 457


### PR DESCRIPTION
## Context

Sometimes pods need more information.

## Objective

This PR adds template info and prNum to executor start config.

## References
NA

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
