### PR TITLE
fix: pipeline schema for executor start

### DIFF
--- a/plugins/executor.js
+++ b/plugins/executor.js
@@ -20,7 +20,7 @@ const SCHEMA_PIPELINE = Joi.object()
         id: pipelineId.required(),
         name: models.pipeline.base.extract('name').optional(),
         scmContext: models.pipeline.base.extract('scmContext').required(),
-        configPipelineId: models.pipeline.base.extract('configPipelineId').required()
+        configPipelineId: models.pipeline.base.extract('configPipelineId').optional().allow(null)
     })
     .unknown();
 const SCHEMA_TEMPLATE = Joi.object()


### PR DESCRIPTION
## Context

configPipelineId does not always exist

## Objective

This PR makes configPipelineId optional for executor start.

## References

Related to https://github.com/screwdriver-cd/data-schema/pull/536/files#diff-a1eeedbd9535815be45f09a81926ba437ac5e131adbc27069dba042dc9262cdeR23

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
