### PR TITLE
fix(2767): Relax job name Regex to allow stage setup/teardown jobs

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -41,7 +41,8 @@ module.exports = {
     // Steps can only be named with A-Z,a-z,0-9,-,_
     STEP_NAME: /^[\w-]+$/,
     // Jobs can only be named with A-Z,a-z,0-9,-,_
-    JOB_NAME: /^[\w-]+$/,
+    // Also allow stage setup/teardown like stage@stage-name:setup
+    JOB_NAME: /^(([\w-]+)|(stage@[\w-]+:(setup|teardown)))$/,
     // PR JOB Name can only be PR-1 or PR-1:main, group1: PR-prNum, group2: jobName
     PR_JOB_NAME: /^(PR-\d+)(?::([\w-]+))?$/,
     // Match all possible job name

--- a/config/regex.js
+++ b/config/regex.js
@@ -42,7 +42,7 @@ module.exports = {
     STEP_NAME: /^[\w-]+$/,
     // Jobs can only be named with A-Z,a-z,0-9,-,_
     // Also allow stage setup/teardown like stage@stage-name:setup
-    JOB_NAME: /^(([\w-]+)|(stage@[\w-]+:(setup|teardown)))$/,
+    JOB_NAME: /^(([\w-]+)|(?:stage@([\w-]+):(setup|teardown)))$/,
     // PR JOB Name can only be PR-1 or PR-1:main, group1: PR-prNum, group2: jobName
     PR_JOB_NAME: /^(PR-\d+)(?::([\w-]+))?$/,
     // Match all possible job name

--- a/models/job.js
+++ b/models/job.js
@@ -9,7 +9,7 @@ const MODEL = {
     id: Joi.number().integer().positive().description('Identifier of this Job').example(123345),
 
     name: Joi.string()
-        .regex(/^(PR-[0-9]+:)?(([\w-]+)|(stage@[\w-]+:(setup|teardown)))$/)
+        .regex(/^(PR-[0-9]+:)?(([\w-]+)|(?:stage@([\w-]+):(setup|teardown)))$/)
         .max(110)
         .description('Name of the Job')
         .example('main'),

--- a/models/job.js
+++ b/models/job.js
@@ -9,7 +9,7 @@ const MODEL = {
     id: Joi.number().integer().positive().description('Identifier of this Job').example(123345),
 
     name: Joi.string()
-        .regex(/^(PR-[0-9]+:)?[\w-]+$/)
+        .regex(/^(PR-[0-9]+:)?(([\w-]+)|(stage@[\w-]+:(setup|teardown)))$/)
         .max(110)
         .description('Name of the Job')
         .example('main'),

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -261,10 +261,15 @@ describe('config regex', () => {
     describe('jobs', () => {
         it('checks good job names', () => {
             assert.isTrue(config.regex.JOB_NAME.test('foo-BAR_15'));
+            assert.isTrue(config.regex.JOB_NAME.test('stage@integration:setup'));
+            assert.isTrue(config.regex.JOB_NAME.test('stage@production-blue:teardown'));
         });
 
         it('fails on bad job names', () => {
             assert.isFalse(config.regex.JOB_NAME.test('run all the things'));
+            assert.isFalse(config.regex.JOB_NAME.test('stage@integration'));
+            assert.isFalse(config.regex.JOB_NAME.test('stage@integration:deploy'));
+            assert.isFalse(config.regex.JOB_NAME.test('integration:deploy'));
         });
 
         it('checks good PR job names', () => {


### PR DESCRIPTION
## Context
Regex associated with `job` name is strict and does not allow setup and teardown jobs created by the backend for a stage which follows the pattern like `stage@<STAGE_NAME>:setup` or `stage@<STAGE_NAME>:teardown`
Ex: `stage@production:setup`

This results in below issues:

1. Validator fails to permit the pipeline configuration which has one or more stages defined
![image](https://github.com/screwdriver-cd/data-schema/assets/2124590/173fe930-d358-44c2-b6e8-7296948464ac)

2. Validation of the API response for the endpoint `/v4/pipelines/<PIPELINE_ID>/jobs` fails when stage setup/teardown jobs exist. 
![image](https://github.com/screwdriver-cd/data-schema/assets/2124590/34b64efb-8824-421b-9a00-1e890d54e17d)


## Objective

Relaxing the job name Regex to allow stage setup/teardown jobs

## References

https://github.com/screwdriver-cd/screwdriver/issues/2767

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
