### PR TITLE
fix: add defaultName and defaultUri for sonar system auto population [1]

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -12,11 +12,16 @@ const mutate = require('../lib/mutate');
 
 const STATES = ['ACTIVE', 'INACTIVE'];
 const BADGE = Joi.object({
-    name: Joi.string().max(128).description('The dashboard name for a badge').example('screwdriver/ui'),
+    defaultName: Joi.string().max(128).description('Auto populated dashboard name for a badge').example('screwdriver/ui'),
+    defaultUri: Joi.string()
+        .max(500)
+        .description('Auto populated url for the badge application dashboard')
+        .example('https://sonar.screwdriver.cd/dashboard?id=112233')
+    name: Joi.string().max(128).description('The dashboard name for a badge').example('my-screwdriver/ui'),
     uri: Joi.string()
         .max(500)
-        .description('Unique identifier for the badge application dashboard')
-        .example('https://sonar.screwdriver.cd/dashboard?id=112233')
+        .description('The url the badge application dashboard')
+        .example('https://my-sonar.screwdriver.cd/dashboard?id=112233')
 });
 
 const CREATE_MODEL = {

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -12,7 +12,10 @@ const mutate = require('../lib/mutate');
 
 const STATES = ['ACTIVE', 'INACTIVE'];
 const BADGE = Joi.object({
-    defaultName: Joi.string().max(128).description('Auto populated dashboard name for a badge').example('screwdriver/ui'),
+    defaultName: Joi.string()
+        .max(128)
+        .description('Auto populated dashboard name for a badge')
+        .example('screwdriver/ui'),
     defaultUri: Joi.string()
         .max(500)
         .description('Auto populated url for the badge application dashboard')

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -16,7 +16,7 @@ const BADGE = Joi.object({
     defaultUri: Joi.string()
         .max(500)
         .description('Auto populated url for the badge application dashboard')
-        .example('https://sonar.screwdriver.cd/dashboard?id=112233')
+        .example('https://sonar.screwdriver.cd/dashboard?id=112233'),
     name: Joi.string().max(128).description('The dashboard name for a badge').example('my-screwdriver/ui'),
     uri: Joi.string()
         .max(500)

--- a/test/data/pipeline.yaml
+++ b/test/data/pipeline.yaml
@@ -12,6 +12,6 @@ badges:
     sonar: 
         name: my-screwdriver-cd/screwdriver
         uri:  https://beta.sonar.screwdriver.cd/dashboard?id=123123
-        defeaultName: screwdriver-cd/screwdriver
+        defaultName: screwdriver-cd/screwdriver
         defaultUri:  https://sonar.screwdriver.cd/dashboard?id=123123
         

--- a/test/data/pipeline.yaml
+++ b/test/data/pipeline.yaml
@@ -10,5 +10,8 @@ scmRepo:
 state: ACTIVE
 badges: 
     sonar: 
-        name: screwdriver-cd/screwdriver
-        uri:  https://sonar.screwdriver.cd/dashboard?id=123123
+        name: my-screwdriver-cd/screwdriver
+        uri:  https://beta.sonar.screwdriver.cd/dashboard?id=123123
+        defeaultName: screwdriver-cd/screwdriver
+        defaultUri:  https://sonar.screwdriver.cd/dashboard?id=123123
+        


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

Add `defaultName` and `defaultUri` to `badge` object to accommodate populating default values and allow user override.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/coverage-sonar/pull/73
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
