### PR TITLE
fix(2862): Filter 'builds' by templates and creation time performance degrade

### DIFF
--- a/migrations/20231106181001-add-template-and-date-index-to-builds.js
+++ b/migrations/20231106181001-add-template-and-date-index-to-builds.js
@@ -1,0 +1,21 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}builds`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.removeIndex(table, `${table}_template_id`, { transaction });
+
+            await queryInterface.addIndex(table, {
+                name: `${table}_templateId_startTime_endTime`,
+                fields: ['templateId', { attribute: 'startTime', length: 32 }, { attribute: 'endTime', length: 32 }],
+                transaction
+            });
+        });
+    }
+};

--- a/migrations/20231106181001-add-templateId-and-createTime-index-to-builds.js
+++ b/migrations/20231106181001-add-templateId-and-createTime-index-to-builds.js
@@ -9,11 +9,11 @@ module.exports = {
     // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async transaction => {
-            await queryInterface.removeIndex(table, `${table}_template_id`, { transaction });
+            await queryInterface.removeIndex(table, `${table}_template_Id`, { transaction });
 
             await queryInterface.addIndex(table, {
-                name: `${table}_templateId_startTime_endTime`,
-                fields: ['templateId', { attribute: 'startTime', length: 32 }, { attribute: 'endTime', length: 32 }],
+                name: `${table}_templateId_createTime`,
+                fields: ['templateId', 'createTime'],
                 transaction
             });
         });

--- a/models/build.js
+++ b/models/build.js
@@ -246,6 +246,6 @@ module.exports = {
         { fields: ['eventId', 'createTime'] },
         { fields: ['jobId'] },
         { fields: [{ attribute: 'parentBuildId', length: 32 }] },
-        { fields: ['templateId'] }
+        { fields: ['templateId', { name: 'startTime', length: 32 }, { name: 'endTime', length: 32 }] }
     ]
 };

--- a/models/build.js
+++ b/models/build.js
@@ -246,6 +246,6 @@ module.exports = {
         { fields: ['eventId', 'createTime'] },
         { fields: ['jobId'] },
         { fields: [{ attribute: 'parentBuildId', length: 32 }] },
-        { fields: ['templateId', { name: 'startTime', length: 32 }, { name: 'endTime', length: 32 }] }
+        { fields: ['templateId', 'createTime'] }
     ]
 };

--- a/test/models/build.test.js
+++ b/test/models/build.test.js
@@ -84,7 +84,7 @@ describe('model build', () => {
                 { fields: ['eventId', 'createTime'] },
                 { fields: ['jobId'] },
                 { fields: [{ attribute: 'parentBuildId', length: 32 }] },
-                { fields: ['templateId', { name: 'startTime', length: 32 }, { name: 'endTime', length: 32 }] }
+                { fields: ['templateId', 'createTime'] }
             ];
             const { indexes } = models.build;
 

--- a/test/models/build.test.js
+++ b/test/models/build.test.js
@@ -84,7 +84,7 @@ describe('model build', () => {
                 { fields: ['eventId', 'createTime'] },
                 { fields: ['jobId'] },
                 { fields: [{ attribute: 'parentBuildId', length: 32 }] },
-                { fields: ['templateId'] }
+                { fields: ['templateId', { name: 'startTime', length: 32 }, { name: 'endTime', length: 32 }] }
             ];
             const { indexes } = models.build;
 


### PR DESCRIPTION
## Context
https://github.com/screwdriver-cd/screwdriver/issues/2862#issuecomment-1786509652

## Objective

Update the index to include `createTime`

## References

https://github.com/screwdriver-cd/screwdriver/issues/2862

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
