### PR TITLE
fix: Make special characters available in branch names

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -91,7 +91,7 @@ module.exports = {
     // Fifth group: root dir (e.g. :path/to/source/dir)
     // eslint-disable-next-line max-len
     CHECKOUT_URL:
-        /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#[^:\s]+)?(:[^\s]+)?$/,
+        /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#([^:\s]|(　))+)?(:[^\s]+)?$/,
     // scmUri. For example: github.com:abc-123:master or bitbucket.org:{123}:master
     // Optionally, can have rootDir. For example: github.com:abc-123:master:src/app/component
     SCM_URI: /^([^:]+):([^:]+):([^:]+)(?::([^:]+))?$/,

--- a/config/regex.js
+++ b/config/regex.js
@@ -89,9 +89,9 @@ module.exports = {
     // Third group: repo (e.g. data-schema)
     // Fourth group: branch name (e.g. #branchName)
     // Fifth group: root dir (e.g. :path/to/source/dir)
-    // eslint-disable-next-line max-len
     CHECKOUT_URL:
-        /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#([^:\s]|(　))+)?(:[^\s]+)?$/,
+        // eslint-disable-next-line no-irregular-whitespace
+        /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#[^:　\s]*　[^:　\s]*|#[^:　\s]+)?(:[^:　\s]*　[^:　\s]*|:[^:　\s]+)?$/,
     // scmUri. For example: github.com:abc-123:master or bitbucket.org:{123}:master
     // Optionally, can have rootDir. For example: github.com:abc-123:master:src/app/component
     SCM_URI: /^([^:]+):([^:]+):([^:]+)(?::([^:]+))?$/,

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -311,116 +311,140 @@ describe('config regex', () => {
         const org = 'screwdriver-cd';
         const repo = 'data-schema';
         const bitbucketRepo = 'data.schema';
-        const branchName = '#foobar';
-        const rootDir = ':path/to/source/dir';
+        const generalBranchName = '#foobar';
+        const generalRootDir = ':path/to/source/dir';
+        const specialBranchName = '#!"#$%&\'()-=|@`{;+]},<.>/　a';
+        const specialRootDir = ':!"#$%&\'()-=|@`{;+]},<.>/　b';
 
         describe('checks good checkout Url', () => {
             const githubHttps = `https://${github}/${org}/${repo}.git`;
-            const tests = [
-                {
-                    url: githubHttps,
-                    match: [githubHttps, github, org, repo, null, null]
-                },
-                {
-                    url: `${githubHttps}${branchName}`,
-                    match: [`${githubHttps}${branchName}`, github, org, repo, branchName, null]
-                },
-                {
-                    url: `${githubHttps}${branchName}${rootDir}`,
-                    match: [`${githubHttps}${branchName}${rootDir}`, github, org, repo, branchName, rootDir]
-                },
-                {
-                    url: `git@${github}:${org}/${repo}.git`,
-                    match: [`git@${github}:${org}/${repo}.git`, github, org, repo, null, null]
-                },
-                {
-                    url: `git@${github}:${org}/${repo}.git${branchName}`,
-                    match: [`git@${github}:${org}/${repo}.git${branchName}`, github, org, repo, branchName, null]
-                },
-                {
-                    url: `git@${github}:${org}/${repo}.git${branchName}${rootDir}`,
-                    match: [
-                        `git@${github}:${org}/${repo}.git${branchName}${rootDir}`,
-                        github,
-                        org,
-                        repo,
-                        branchName,
-                        rootDir
-                    ]
-                },
-                {
-                    url: `https://screwdriver-cd@${bitbucket}/${org}/${repo}.git`,
-                    match: [`https://screwdriver-cd@${bitbucket}/${org}/${repo}.git`, bitbucket, org, repo, null, null]
-                },
-                {
-                    url: `https://screwdriver-cd@${bitbucket}/${org}/${repo}.git${branchName}`,
-                    match: [
-                        `https://screwdriver-cd@${bitbucket}/${org}/${repo}.git${branchName}`,
-                        bitbucket,
-                        org,
-                        repo,
-                        branchName,
-                        null
-                    ]
-                },
-                {
-                    url: `https://user@${bitbucket}/${org}/${repo}.git${branchName}${rootDir}`,
-                    match: [
-                        `https://user@${bitbucket}/${org}/${repo}.git${branchName}${rootDir}`,
-                        bitbucket,
-                        org,
-                        repo,
-                        branchName,
-                        rootDir
-                    ]
-                },
-                {
-                    url: `git@${bitbucket}:${org}/${repo}.git`,
-                    match: [`git@${bitbucket}:${org}/${repo}.git`, bitbucket, org, repo, null, null]
-                },
-                {
-                    url: `git@${bitbucket}:${org}/${repo}.git${branchName}`,
-                    match: [`git@${bitbucket}:${org}/${repo}.git${branchName}`, bitbucket, org, repo, branchName, null]
-                },
-                {
-                    url: `git@${bitbucket}:${org}/${bitbucketRepo}.git${branchName}`,
-                    match: [
-                        `git@${bitbucket}:${org}/${bitbucketRepo}.git${branchName}`,
-                        bitbucket,
-                        org,
-                        bitbucketRepo,
-                        branchName,
-                        null
-                    ]
-                },
-                {
-                    url: `org-1234@${bitbucket}:${org}/${bitbucketRepo}.git${branchName}`,
-                    match: [
-                        `org-1234@${bitbucket}:${org}/${bitbucketRepo}.git${branchName}`,
-                        bitbucket,
-                        org,
-                        bitbucketRepo,
-                        branchName,
-                        null
-                    ]
-                }
-            ];
+            const createTests = (branchName, rootDir) => {
+                return [
+                    {
+                        url: githubHttps,
+                        match: [githubHttps, github, org, repo, null, null]
+                    },
+                    {
+                        url: `${githubHttps}${branchName}`,
+                        match: [`${githubHttps}${branchName}`, github, org, repo, branchName, null]
+                    },
+                    {
+                        url: `${githubHttps}${branchName}${rootDir}`,
+                        match: [`${githubHttps}${branchName}${rootDir}`, github, org, repo, branchName, rootDir]
+                    },
+                    {
+                        url: `git@${github}:${org}/${repo}.git`,
+                        match: [`git@${github}:${org}/${repo}.git`, github, org, repo, null, null]
+                    },
+                    {
+                        url: `git@${github}:${org}/${repo}.git${branchName}`,
+                        match: [`git@${github}:${org}/${repo}.git${branchName}`, github, org, repo, branchName, null]
+                    },
+                    {
+                        url: `git@${github}:${org}/${repo}.git${branchName}${rootDir}`,
+                        match: [
+                            `git@${github}:${org}/${repo}.git${branchName}${rootDir}`,
+                            github,
+                            org,
+                            repo,
+                            branchName,
+                            rootDir
+                        ]
+                    },
+                    {
+                        url: `https://screwdriver-cd@${bitbucket}/${org}/${repo}.git`,
+                        match: [
+                            `https://screwdriver-cd@${bitbucket}/${org}/${repo}.git`,
+                            bitbucket,
+                            org,
+                            repo,
+                            null,
+                            null
+                        ]
+                    },
+                    {
+                        url: `https://screwdriver-cd@${bitbucket}/${org}/${repo}.git${branchName}`,
+                        match: [
+                            `https://screwdriver-cd@${bitbucket}/${org}/${repo}.git${branchName}`,
+                            bitbucket,
+                            org,
+                            repo,
+                            branchName,
+                            null
+                        ]
+                    },
+                    {
+                        url: `https://user@${bitbucket}/${org}/${repo}.git${branchName}${rootDir}`,
+                        match: [
+                            `https://user@${bitbucket}/${org}/${repo}.git${branchName}${rootDir}`,
+                            bitbucket,
+                            org,
+                            repo,
+                            branchName,
+                            rootDir
+                        ]
+                    },
+                    {
+                        url: `git@${bitbucket}:${org}/${repo}.git`,
+                        match: [`git@${bitbucket}:${org}/${repo}.git`, bitbucket, org, repo, null, null]
+                    },
+                    {
+                        url: `git@${bitbucket}:${org}/${repo}.git${branchName}`,
+                        match: [
+                            `git@${bitbucket}:${org}/${repo}.git${branchName}`,
+                            bitbucket,
+                            org,
+                            repo,
+                            branchName,
+                            null
+                        ]
+                    },
+                    {
+                        url: `git@${bitbucket}:${org}/${bitbucketRepo}.git${branchName}`,
+                        match: [
+                            `git@${bitbucket}:${org}/${bitbucketRepo}.git${branchName}`,
+                            bitbucket,
+                            org,
+                            bitbucketRepo,
+                            branchName,
+                            null
+                        ]
+                    },
+                    {
+                        url: `org-1234@${bitbucket}:${org}/${bitbucketRepo}.git${branchName}`,
+                        match: [
+                            `org-1234@${bitbucket}:${org}/${bitbucketRepo}.git${branchName}`,
+                            bitbucket,
+                            org,
+                            bitbucketRepo,
+                            branchName,
+                            null
+                        ]
+                    }
+                ];
+            };
 
-            tests.forEach(test => {
-                it(`correctly validates ${test.url}`, () => {
-                    assert.deepEqual(
-                        JSON.stringify(config.regex.CHECKOUT_URL.exec(test.url), null, 4),
-                        JSON.stringify(test.match, null, 4)
-                    );
-                });
-            });
+            [createTests(generalBranchName, generalRootDir), createTests(specialBranchName, specialRootDir)].forEach(
+                tests => {
+                    tests.forEach(test => {
+                        it(`correctly validates ${test.url}`, () => {
+                            assert.deepEqual(
+                                JSON.stringify(config.regex.CHECKOUT_URL.exec(test.url), null, 4),
+                                JSON.stringify(test.match, null, 4)
+                            );
+                        });
+                    });
+                }
+            );
         });
 
         it('fails on bad checkout Url', () => {
             assert.isFalse(config.regex.CHECKOUT_URL.test('https://github.com/screwdriver-cd/'));
             assert.isFalse(config.regex.CHECKOUT_URL.test(`git@${org}/${repo}.git`));
-            assert.isFalse(config.regex.CHECKOUT_URL.test(`git@${org}/${repo}.git#${rootDir}`));
-            assert.isFalse(config.regex.CHECKOUT_URL.test(`git@${org}/${repo}.git${branchName}:`));
+            assert.isFalse(config.regex.CHECKOUT_URL.test(`git@${org}/${repo}.git#${generalRootDir}`));
+            assert.isFalse(config.regex.CHECKOUT_URL.test(`git@${org}/${repo}.git${generalBranchName}:`));
+            assert.isFalse(config.regex.CHECKOUT_URL.test(`git@${org}/${repo}.git#${specialRootDir}`));
+            assert.isFalse(config.regex.CHECKOUT_URL.test(`git@${org}/${repo}.git${specialBranchName}:`));
         });
     });
 


### PR DESCRIPTION
## Context
<!-- Why do we need this PR? What was the reason that led you to make this change? -->
On GitHub, it was possible to use full-width space of Japanese in branch names, but these characters were not available in SD.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
Allows pipelines to be created and built with branch names that contain special characters and full-width space of Japanese.
For example, the following branch names are available.
```
a!"#$%&'()-=|@`{;+]},<.>/　a
```

The following two PRs are associated with this PR.
- https://github.com/screwdriver-cd/scm-github/pull/218
- https://github.com/screwdriver-cd/ui/pull/963

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
