### PR TITLE
fix(2952): Allow colon to be used in root directory

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -94,7 +94,7 @@ module.exports = {
         /^(?:(?:https:\/\/(?:[^@/:\s]+@)?)|git@|org-\d+@)+([^/:\s]+)(?:\/|:)([^/:\s]+)\/([^\s]+?)(?:\.git)(#[^:　\s]*　[^:　\s]*|#[^:　\s]+)?(:[^:　\s]*　[^:　\s]*|:[^:　\s]+)?$/,
     // scmUri. For example: github.com:abc-123:master or bitbucket.org:{123}:master
     // Optionally, can have rootDir. For example: github.com:abc-123:master:src/app/component
-    SCM_URI: /^([^:]+):([^:]+):([^:]+)(?::([^:]+))?$/,
+    SCM_URI: /^([^:]+):([^:]+):([^:]+)(?::(.*))?$/,
     // SCM context. For example: github:github.com, gitlab:gitlab.mycompany.com
     // First group: SCM plugin name (e.g. github)
     // Second group: SCM host name (e.g. github.com)

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -452,12 +452,12 @@ describe('config regex', () => {
         it('checks good scmUri', () => {
             assert.isTrue(config.regex.SCM_URI.test('github.com:abc-123:master'));
             assert.isTrue(config.regex.SCM_URI.test('github.com:abc-123:master:src/app/component'));
+            assert.isTrue(config.regex.SCM_URI.test('github.com:abc-123:master:a:b:c'));
             assert.isTrue(config.regex.SCM_URI.test('bitbucket.org:d2lam/{123}:master'));
         });
 
         it('fails on bad scmUri', () => {
             assert.isFalse(config.regex.SCM_URI.test('github.com:master'));
-            assert.isFalse(config.regex.SCM_URI.test('github.com:master:a:b:c'));
             assert.isFalse(config.regex.SCM_URI.test('bitbucket.org:{123}'));
         });
     });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If I try to create a pipeline with a colon in the rootDirectory, I get a validation error.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I fixe so that validation errors do not occur even when a colon is included.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/2952

PR:
https://github.com/screwdriver-cd/scm-github/pull/220
https://github.com/screwdriver-cd/scm-base/pull/96
https://github.com/screwdriver-cd/launcher/pull/469

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
