### PR TITLE
fix(2767): Stage setup and teardown should be number

### DIFF
--- a/models/stage.js
+++ b/models/stage.js
@@ -11,13 +11,9 @@ const MODEL = {
 
     name: Joi.string().regex(Regex.STAGE_NAME).max(110).description('Name of the Stage').example('deploy'),
 
-    setup: Joi.array()
-        .items(Joi.number().integer().positive().description('Identifier for this job').example(123345))
-        .description('Job IDs in this Stage'),
+    setup: Joi.number().integer().positive().description('Job ID for Stage setup').example(123345),
 
-    teardown: Joi.array()
-        .items(Joi.number().integer().positive().description('Identifier for this job').example(123345))
-        .description('Job IDs in this Stage'),
+    teardown: Joi.number().integer().positive().description('Job ID for Stage teardown').example(123345),
 
     jobIds: Joi.array()
         .items(Joi.number().integer().positive().description('Identifier for this job').example(123345))

--- a/test/data/stage.yaml
+++ b/test/data/stage.yaml
@@ -4,5 +4,5 @@ pipelineId: 123345
 name: deploy
 jobIds: [1, 2, 3, 4]
 description: 'Deploys canary jobs'
-setup: [222]
-teardown: [333]
+setup: 222
+teardown: 333


### PR DESCRIPTION
## Context

Stage get is failing at setup/teardown schema validation.

## Objective

This PR changes setup/teardown for stage to number. We can change to array in the future if we feel it is needed.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2767

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
