### PR TITLE
fix(2767): Stage must always have valid setup and teardown job IDs

### DIFF
--- a/models/stage.js
+++ b/models/stage.js
@@ -11,12 +11,13 @@ const MODEL = {
 
     name: Joi.string().regex(Regex.STAGE_NAME).max(110).description('Name of the Stage').example('deploy'),
 
-    setup: Joi.number().integer().positive().description('Job ID for Stage setup').example(123345),
+    setup: Joi.number().integer().positive().required().description('Job ID for Stage setup').example(123345),
 
-    teardown: Joi.number().integer().positive().description('Job ID for Stage teardown').example(123345),
+    teardown: Joi.number().integer().positive().required().description('Job ID for Stage teardown').example(123345),
 
     jobIds: Joi.array()
         .items(Joi.number().integer().positive().description('Identifier for this job').example(123345))
+        .min(1)
         .description('Job IDs in this Stage'),
 
     description: Joi.string().max(256).description('Description of the Stage').example('Deploys canary jobs'),

--- a/test/models/stage.test.js
+++ b/test/models/stage.test.js
@@ -9,6 +9,36 @@ describe('model stage', () => {
         it('validates the base', () => {
             assert.isNull(validate('stage.yaml', models.stage.base).error);
         });
+
+        describe('validates setup and teardown', () => {
+            ['setup', 'teardown'].forEach(fieldName => {
+                [null, 0, -1].forEach(validType => {
+                    it(`validates the invalid ${fieldName} job id`, () => {
+                        assert.isNotNull(validate('stage.yaml', models.stage.base, { [fieldName]: validType }).error);
+                    });
+                });
+
+                [22, 33].forEach(validType => {
+                    it(`validates the valid ${fieldName} job id`, () => {
+                        assert.isNull(validate('stage.yaml', models.stage.base, { [fieldName]: validType }).error);
+                    });
+                });
+            });
+        });
+
+        describe('validates jobIds', () => {
+            [null, [], [0], [-1], [1, -1]].forEach(validType => {
+                it(`validates the invalid jobIds`, () => {
+                    assert.isNotNull(validate('stage.yaml', models.stage.base, { jobIds: validType }).error);
+                });
+            });
+
+            [[1], [1, 2]].forEach(validType => {
+                it(`validates the valid jobIds`, () => {
+                    assert.isNull(validate('stage.yaml', models.stage.base, { jobIds: validType }).error);
+                });
+            });
+        });
     });
 
     describe('keys', () => {


### PR DESCRIPTION
## Context

`setup` and `teardown` should always exist for a stage.
A stage must have at least one job.

## Objective

Update model and DB schema
- `setup` and `teardown` are non nullable
- `jobIds` should not be empty

## References

https://github.com/screwdriver-cd/screwdriver/issues/276

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
