### PR TITLE
fix(2767): Stage must always have valid setup and teardown job IDs - migration script

### DIFF
--- a/migrations/20240122194105-stage_setup_teardown_required.js
+++ b/migrations/20240122194105-stage_setup_teardown_required.js
@@ -1,0 +1,32 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}stages`;
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.changeColumn(
+                table,
+                'setup',
+                {
+                    type: Sequelize.INTEGER,
+                    allowNull: false
+                },
+                { transaction }
+            );
+            await queryInterface.changeColumn(
+                table,
+                'teardown',
+                {
+                    type: Sequelize.INTEGER,
+                    allowNull: false
+                },
+                { transaction }
+            );
+        });
+    }
+};


### PR DESCRIPTION
## Context

Related to https://github.com/screwdriver-cd/data-schema/pull/547
Forgot to attach the migration file.

## Objective

Include the migration script to align with the schema

**Before (MySQL)**
![image](https://github.com/screwdriver-cd/data-schema/assets/2124590/ae261888-2b57-44a0-84dd-0c82678ce8df)

**After (MySQL)**
![image](https://github.com/screwdriver-cd/data-schema/assets/2124590/fceb309d-102a-4af1-a7f8-3e1043c0d3ed)


## References

https://github.com/screwdriver-cd/screwdriver/pull/276

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
