### PR TITLE
feat(3022): Add annotation to mark implicitly created stage setup/teardown jobs are virtual

### DIFF
--- a/config/annotations.js
+++ b/config/annotations.js
@@ -26,7 +26,8 @@ const RESERVED_JOB_ANNOTATIONS = [
     'screwdriver.cd/manualStartEnabled',
     'screwdriver.cd/blockedBySameJob',
     'screwdriver.cd/blockedBySameJobWaitTime',
-    'screwdriver.cd/jobDisabledByDefault'
+    'screwdriver.cd/jobDisabledByDefault',
+    'screwdriver.cd/virtual'
 ];
 const RESERVED_PIPELINE_ANNOTATIONS = [
     'screwdriver.cd/buildCluster',

--- a/config/annotations.js
+++ b/config/annotations.js
@@ -27,7 +27,7 @@ const RESERVED_JOB_ANNOTATIONS = [
     'screwdriver.cd/blockedBySameJob',
     'screwdriver.cd/blockedBySameJobWaitTime',
     'screwdriver.cd/jobDisabledByDefault',
-    'screwdriver.cd/virtual'
+    'screwdriver.cd/virtualTrigger'
 ];
 const RESERVED_PIPELINE_ANNOTATIONS = [
     'screwdriver.cd/buildCluster',


### PR DESCRIPTION
## Context
`setup` / `teardown` job for a `stage` are implicitly created if it is not configured in the `screwdriver.yaml`.
We need a mechanism to identify these implicitly created `setup` / `teardown` jobs to take necessary actions.
Ex: skip execution, hide it from workflow graph in the UI, etc

## Objective

This PR adds a new annotation to job annotations: `screwdriver.cd/virtual`.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3022

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
