### PR TITLE
fix(3022): Rename 'screwdriver.cd/virtualTrigger' job annotation to ' screwdriver.cd/virtualJob'

### DIFF
--- a/config/annotations.js
+++ b/config/annotations.js
@@ -27,7 +27,7 @@ const RESERVED_JOB_ANNOTATIONS = [
     'screwdriver.cd/blockedBySameJob',
     'screwdriver.cd/blockedBySameJobWaitTime',
     'screwdriver.cd/jobDisabledByDefault',
-    'screwdriver.cd/virtualTrigger'
+    'screwdriver.cd/virtualJob'
 ];
 const RESERVED_PIPELINE_ANNOTATIONS = [
     'screwdriver.cd/buildCluster',


### PR DESCRIPTION
## Context
Job annotation `screwdriver.cd/virtualTrigger` was introduced in https://github.com/screwdriver-cd/data-schema/pull/552.
We need to rename it to `screwdriver.cd/virtualJob`

## Objective

Remove job annotation `screwdriver.cd/virtualTrigger`.
Add job annotation `screwdriver.cd/virtualJob`

## References

https://github.com/screwdriver-cd/screwdriver/issues/3022

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
