### PR TITLE
fix: add templateVersionId to validator output

### DIFF
--- a/api/validator.js
+++ b/api/validator.js
@@ -7,6 +7,7 @@ const Job = require('../config/job');
 const Parameters = require('../config/parameters');
 const Regex = require('../config/regex');
 const WorkflowGraph = require('../config/workflowGraph');
+const Pipeline = require('../models/pipeline');
 
 const SCHEMA_JOB_COMMAND = Joi.object()
     .keys({
@@ -65,7 +66,8 @@ const SCHEMA_OUTPUT = Joi.object()
         parameters: Parameters.parameters.default({}),
         warnMessages: Joi.array().optional(),
         stages: Base.stages.optional(),
-        subscribe: Base.subscribe
+        subscribe: Base.subscribe,
+        templateVersionId: Pipeline.fields.templateVersionId
     })
     .label('Execution information');
 

--- a/test/data/validator.output.yaml
+++ b/test/data/validator.output.yaml
@@ -65,3 +65,4 @@ jobs:
     environment: {}
     secrets:
       - NPM_TOKEN
+templateVersionId: 123


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
api throws 500 error when validating yaml with pipeline template
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
add templateVersionId to validator output
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
