### PR TITLE
fix: remove commit column from build

### DIFF
--- a/migrations/20240306-remove_column_commit_from_build.js
+++ b/migrations/20240306-remove_column_commit_from_build.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}builds`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.removeColumn(table, 'commit', { transaction });
+        });
+    }
+};

--- a/models/build.js
+++ b/models/build.js
@@ -2,7 +2,6 @@
 
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
-const Scm = require('../core/scm');
 const Regex = require('../config/regex');
 const Job = require('../config/job');
 const Step = require('./step');
@@ -66,8 +65,6 @@ const MODEL = {
         .hex()
         .description('SHA this project was built on')
         .example('ccc49349d3cffbd12ea9e3d41521480b4aa5de5f'),
-
-    commit: Scm.commit,
 
     createTime: Joi.string().isoDate().max(32).description('When this build was created'),
 

--- a/test/data/build.yaml
+++ b/test/data/build.yaml
@@ -8,14 +8,6 @@ cause: Because I clicked it
 environment:
     DOCKER_REPO: screwdrivercd/screwdriver
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
-commit:
-    message: Fixing a bug with signing
-    author:
-        url: https://github.com/stjohnjohnson
-        name: St. John Johnson
-        username: stjohnjohnson
-        avatar: https://avatars.githubusercontent.com/u/622065?v=3
-    url: https://github.com/scredriver-cd/screwdriver/commit/46f1a0bd5592a2f9244ca321b129902a06b53e03
 createTime: "2038-01-19T03:14:08.131Z"
 startTime: "2038-01-19T03:15:08.131Z"
 endTime: "2038-01-19T03:16:10.131Z"


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
https://github.com/screwdriver-cd/data-schema/pull/555 breaks `GET /v4/builds/{id}` because api still try to return `commit`
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
remove `commit` column since it was obsolete in current implementation, commit information was stored in `meta` and `commit` was not being used
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
