### PR TITLE
feat(3022): Mark workflow node as virtual if it corresponds to a virtual job

### DIFF
--- a/config/workflowGraph.js
+++ b/config/workflowGraph.js
@@ -7,7 +7,11 @@ const SCHEMA_WORKFLOW_GRAPH = Joi.object().keys({
     nodes: Joi.array().items(
         Joi.object()
             .keys({
-                name: requiresValue
+                name: requiresValue,
+                virtual: Joi.boolean()
+                    .description('Flag to indicate if the node is a virtual job')
+                    .example(true)
+                    .optional()
             })
             .unknown()
     ),

--- a/test/data/config.workflowGraph.yaml
+++ b/test/data/config.workflowGraph.yaml
@@ -2,6 +2,14 @@ nodes:
     - name: ~commit
     - name: main
     - name: publish
+    - name: stage@integration:setup
+      stageName: integration
+      virtual: true
+    - name: ci-deploy
+      stageName: integration
+    - name: stage@integration:teardown
+      stageName: integration
+      virtual: false
     - name: sd@123:publish
     - name: sd@333:E
     - name: G
@@ -10,6 +18,12 @@ edges:
       dest: main
     - src: main
       dest: publish
+    - src: publish
+      dest: stage@integration:setup
+    - src: stage@integration:setup
+      dest: ci-deploy
+    - src: ci-deploy
+      dest: stage@integration:teardown
     - src: sd@123:publish
       dest: sd@333:E
     - src: sd@333:E


### PR DESCRIPTION
## Context

Workflow graph node (Ex: implicit setup/teardown job of a stage) for an event is identified as virtual based on the presence/value of `screwdriver.cd/virtualJob` annotation in the corresponding job definition.

Since the job definition reflects the latest configuration from `screwdriver.yaml`, referring to current annotations of the job may not be reliable to identify it as virtual for an event.
We need a way to preserve whether the job is virtual or not when event is created.

## Objective

Add a new attribute `virtual` in the workflow graph `node` to indicate whether it is virtual or not.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3022

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
