### PR TITLE
feat: add example to use parameters for event model

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -35,7 +35,7 @@ const MODEL = {
     meta: Joi.object()
         .default({})
         .description('Key=>Value information from the event itself')
-        .example({parameters: { nameA: 'value1', jobA: { nameB: 'value2'}}}),
+        .example({ parameters: { nameA: 'value1', jobA: { nameB: 'value2' } } }),
     pipelineId: Joi.number().integer().positive().description('Identifier of this pipeline').example(123345),
     sha: Joi.string()
         .hex()

--- a/models/event.js
+++ b/models/event.js
@@ -32,12 +32,10 @@ const MODEL = {
         .description('When this event was created')
         .example('2038-01-19T03:14:08.131Z'),
     creator: Scm.user.description('Creator of the event'),
-    meta: Joi.object().description('Key=>Value information from the event itself').example({
-        parameters: {
-            nameA: 'value1',
-            jobA: { nameB: 'value2'}
-        }
-    }),
+    meta: Joi.object()
+        .default({})
+        .description('Key=>Value information from the event itself')
+        .example({parameters: { nameA: 'value1', jobA: { nameB: 'value2'}}}),
     pipelineId: Joi.number().integer().positive().description('Identifier of this pipeline').example(123345),
     sha: Joi.string()
         .hex()

--- a/models/event.js
+++ b/models/event.js
@@ -32,7 +32,12 @@ const MODEL = {
         .description('When this event was created')
         .example('2038-01-19T03:14:08.131Z'),
     creator: Scm.user.description('Creator of the event'),
-    meta: Joi.object().default({}).description('Key=>Value information from the event itself'),
+    meta: Joi.object().description('Key=>Value information from the event itself').example({
+        parameters: {
+            nameA: 'value1',
+            jobA: { nameB: 'value2'}
+        }
+    }),
     pipelineId: Joi.number().integer().positive().description('Identifier of this pipeline').example(123345),
     sha: Joi.string()
         .hex()


### PR DESCRIPTION
## Context

A client can add parameters as payload in the meta field when creating an event via `/v4/events` POST API. But the API documentation use `{}` empty object as the default `meta` payload. 

## Objective

Provide a concise example for clients to send parameters payload when creating an event through API. 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
