### PR TITLE
fix: Add new inverse field to datastore search

### DIFF
--- a/plugins/datastore.js
+++ b/plugins/datastore.js
@@ -31,7 +31,8 @@ const SCHEMA_SCAN = Joi.object().keys({
     }),
     search: Joi.object().keys({
         field: Joi.alternatives().try(Joi.array().items(SCHEMA_SEARCH_FIELD), SCHEMA_SEARCH_FIELD),
-        keyword: Joi.alternatives().try(Joi.array().items(SCHEMA_SEARCH_KEYWORD), SCHEMA_SEARCH_KEYWORD)
+        keyword: Joi.alternatives().try(Joi.array().items(SCHEMA_SEARCH_KEYWORD), SCHEMA_SEARCH_KEYWORD),
+        inverse: Joi.boolean().default(false).optional()
     }),
     sort: Joi.string().lowercase().valid('ascending', 'descending').default('descending'),
     sortBy: Joi.string().max(100),


### PR DESCRIPTION
## Context

Currently a lot of calls are being made on the PR tab page in the UI to: 
- `GET /pipelines/:id/events?count=1&page=1&prNum=prNum`
- `GET /jobs/:id/builds?count=10&page=1`
- `GET /events/:id/builds`

It would be nice if we could simplify these calls to get only latest builds in a PR and make fewer calls to the API.

## Objective

This PR adds `inverse` field to datastore search.

## References
Related to https://github.com/screwdriver-cd/screwdriver/pull/3078, https://github.com/screwdriver-cd/datastore-sequelize/pull/93

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
