### PR TITLE
fix(3103): Allow stages in pipeline template

### DIFF
--- a/config/pipelineTemplate.js
+++ b/config/pipelineTemplate.js
@@ -14,7 +14,8 @@ const SCHEMA_CONFIG = Joi.object()
         parameters: Parameters.parameters.default({}),
         annotations: Annotations.annotations,
         cache: BaseSchema.cache,
-        subscribe: BaseSchema.subscribe
+        subscribe: BaseSchema.subscribe,
+        stages: BaseSchema.stages
     })
     .unknown(false);
 

--- a/test/data/config.pipelineTemplate.yaml
+++ b/test/data/config.pipelineTemplate.yaml
@@ -63,7 +63,7 @@ config:
             build: ["target/some-artifact.zip"]
             publish-preview: ["target/some-artifact.zip"]
             test: []
-    subscribe: 
+    subscribe:
         scmUrls:
             - git@github.com:foo/bar.git#master: [~commit, ~tags, ~release]
     annotations:
@@ -71,4 +71,14 @@ config:
         bar: b
     parameters:
         color: [red, blue]
-
+    stages:
+        canary:
+            jobs:
+                - first
+                - second
+            description: "Canary jobs for testing"
+        prod:
+            jobs:
+                - deploy-west
+                - deploy-east
+            description: "Prod deploy jobs"


### PR DESCRIPTION
## Context

Would be nice if users could add stages to pipeline template.

## Objective

This PR allows `stages` field in pipeline template.
## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3103

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
