### PR TITLE
fix(3103): Add stages to config-parser schema for pipeline template

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -80,7 +80,7 @@ const SCHEMA_CONFIG_PRE_TEMPLATE_MERGE = Joi.object()
         }),
         cache: SCHEMA_CACHE,
         childPipelines: SCHEMA_CHILD_PIPELINES,
-        stages: SCHEMA_STAGES.when('template', { is: Joi.exist(), then: Joi.forbidden() }),
+        stages: SCHEMA_STAGES,
         subscribe: SCHEMA_SUBSCRIBE,
         parameters: Parameters.parameters.default({})
     })

--- a/test/data/config.base.pipelineTemplate.yaml
+++ b/test/data/config.base.pipelineTemplate.yaml
@@ -12,7 +12,7 @@ cache:
         build: ["target/some-artifact.zip"]
         publish-preview: ["target/some-artifact.zip"]
         test: []
-subscribe: 
+subscribe:
     scmUrls:
         - git@github.com:foo/bar.git#master: [~commit, ~tags, ~release]
 annotations:
@@ -25,3 +25,14 @@ childPipelines:
         - git@github.com:org/repo.git
         - https://github.com:org/repo2.git
     startAll: true
+stages:
+    canary:
+        jobs:
+            - first
+            - second
+        description: "Canary jobs for testing"
+    prod:
+        jobs:
+            - deploy-west
+            - deploy-east
+        description: "Prod deploy jobs"


### PR DESCRIPTION
## Context

Would be nice if users could config stages in pipeline template.

## Objective

This PR also relaxes schema for pipeline template in config-parser. Previous PR missed similar schema

## References

Related to https://github.com/screwdriver-cd/data-schema/pull/560, https://github.com/screwdriver-cd/data-schema/pull/563, https://github.com/screwdriver-cd/screwdriver/issues/3103
## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
