### PR TITLE
fix(3106): Allow shared.requires for pipeline template yaml

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -74,7 +74,8 @@ const SCHEMA_CONFIG_PRE_TEMPLATE_MERGE = Joi.object()
             then: Joi.object().keys({
                 image: Job.image,
                 environment: Job.environment,
-                settings: Job.settings
+                settings: Job.settings,
+                requires: Job.requires
             }),
             otherwise: SCHEMA_SHARED
         }),

--- a/test/config/base.test.js
+++ b/test/config/base.test.js
@@ -50,9 +50,15 @@ describe('config base', () => {
             assert.isNull(validate('config.base.pipelineTemplate.yaml', config.base.configBeforeMergingTemplate).error);
         });
 
-        it('if template is provided then unsupported fields are foridden', () => {
+        it('if template is provided then unsupported fields are forbidden', () => {
             assert.isNotNull(
                 validate('config.base.pipelineTemplate-forbidden.yaml', config.base.configBeforeMergingTemplate).error
+            );
+        });
+
+        it('if template is provided then allow user yaml to customize image, settings, environment, and requires', () => {
+            assert.isNull(
+                validate('config.base.pipelineTemplate-customized.yaml', config.base.configBeforeMergingTemplate).error
             );
         });
 

--- a/test/data/config.base.pipelineTemplate-customized.yaml
+++ b/test/data/config.base.pipelineTemplate-customized.yaml
@@ -1,0 +1,8 @@
+template: foo/bar@1.0.0
+shared:
+    image: node:20
+    environment:
+        FOO: user overwrite
+    settings:
+        email: foo@example.com
+    requires: ~commit

--- a/test/data/config.base.pipelineTemplate.yaml
+++ b/test/data/config.base.pipelineTemplate.yaml
@@ -5,6 +5,7 @@ shared:
         FOO: user overwrite
     settings:
         email: foo@example.com
+    requires: ~commit
 cache:
     pipeline: ["node_modules/", "~/.sbt"]
     event: ["target/generated-intermediate-resouce/*"]


### PR DESCRIPTION
## Context

It would be nice if users could customize the image, settings, environment, and requires within the job configuration of pipelines that are using a template.

## Objective

This PR allows `requires` in shared settings for pipeline template yaml.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3106

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
