### PR TITLE
feat(3066): relax the stage trigger to allow join

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -51,8 +51,8 @@ module.exports = {
     INTERNAL_TRIGGER: /^~([\w-]+)$/,
     // Stages can only be named with A-Z,a-z,0-9,-,_
     STAGE_NAME: /^[\w-]+$/,
-    // Stage trigger like ~stage@deploy or ~stage@stageName:jobName
-    STAGE_TRIGGER: /^~stage@([\w-]+)(?::([\w-]+))?$/,
+    // Stage trigger like ~stage@deploy or ~stage@stageName:jobName or stage@deploy or stage@stageName:jobName
+    STAGE_TRIGGER: /^~?stage@([\w-]+)(?::([\w-]+))?$/,
     // Don't combine EXTERNAL_TRIGGER and EXTERNAL_TRIGGER_AND for backward compatibility
     // BlockBy does not support EXTERNAL_TRIGGER_AND
     // External trigger like ~sd@123:component (OR case)

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -461,4 +461,21 @@ describe('config regex', () => {
             assert.isFalse(config.regex.SCM_URI.test('bitbucket.org:{123}'));
         });
     });
+
+    describe('stageTrigger', () => {
+        const stageTriggerRegex = config.regex.STAGE_TRIGGER;
+
+        it('matches valid stage triggers', () => {
+            assert.isTrue(stageTriggerRegex.test('stage@build'));
+            assert.isTrue(stageTriggerRegex.test('stage@build:setup'));
+            assert.isTrue(stageTriggerRegex.test('~stage@test'));
+            assert.isTrue(stageTriggerRegex.test('~stage@test:tearDown'));
+        });
+
+        it('does not match invalid stage triggers', () => {
+            assert.isFalse(stageTriggerRegex.test('stage:'));
+            assert.isFalse(stageTriggerRegex.test('stage:build:test'));
+            assert.isFalse(stageTriggerRegex.test('build'));
+        });
+    });
 });


### PR DESCRIPTION
## Context

As the current implementation, join case is not supported for a trigger caused by stage. See below.
<img width="1711" alt="Screenshot 2024-05-30 at 10 08 25 PM" src="https://github.com/screwdriver-cd/data-schema/assets/7771180/85f7e342-9d3f-4499-89d3-0b07f88f85e6">

## Objective

Relax the regex to support join case for a stage trigger. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3066

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
