### PR TITLE
fix(3106): Allow user to customize job when using pipeline template

### DIFF
--- a/test/data/config.base.pipelineTemplate-customized.yaml
+++ b/test/data/config.base.pipelineTemplate-customized.yaml
@@ -6,3 +6,13 @@ shared:
     settings:
         email: foo@example.com
     requires: ~commit
+
+jobs:
+    main:
+        requires: [~commit]
+        image: node:20
+        settings:
+            email: [test@email.com, test3@email.com]
+        environment:
+            VAR3: "three"
+            VAR1: "empty"


### PR DESCRIPTION
## Context

At present, users utilizing a pipeline template are restricted from making any modifications within the job configuration.
## Objective

This PR allows users to customize image, settings, environment, and requires within `job` field when using pipeline template.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3106

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
