### PR TITLE
feat(3146): Allow to pass scmRepo argument to scm plugins methods [1]

### DIFF
--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -26,6 +26,7 @@ const ADD_WEBHOOK = Joi.object()
     .keys({
         scmUri,
         token,
+        scmRepo,
         actions: Joi.array().items(Joi.string()),
         webhookUrl: Joi.string().uri({
             scheme: ['http', 'https']
@@ -127,6 +128,7 @@ const UPDATE_COMMIT_STATUS = Joi.object()
     .keys({
         scmUri,
         token,
+        scmRepo,
         sha,
         buildStatus: Joi.string()
             .required()
@@ -156,6 +158,7 @@ const GET_CHANGED_FILES_INPUT = Joi.object()
         type,
         webhookConfig: Joi.object().allow(null).required(),
         token,
+        scmRepo,
         scmContext,
         scmUri: scmUri.optional(),
         prNum
@@ -180,6 +183,7 @@ const DECORATE_COMMIT = Joi.object()
         scmUri,
         sha,
         token,
+        scmRepo,
         scmContext
     })
     .required();
@@ -205,6 +209,7 @@ const GET_BRANCH_LIST = Joi.object()
     .keys({
         scmUri,
         token,
+        scmRepo,
         scmContext
     })
     .required();

--- a/plugins/scm.js
+++ b/plugins/scm.js
@@ -109,6 +109,7 @@ const ADD_PR_COMMENT = Joi.object()
     .keys({
         scmUri,
         token,
+        scmRepo,
         prNum: core.scm.hook.extract('prNum').required(),
         comments: Joi.array()
             .items(

--- a/test/data/scm.addPrCommentWithScmRepo.yaml
+++ b/test/data/scm.addPrCommentWithScmRepo.yaml
@@ -1,0 +1,11 @@
+scmUri: github.com:12345678:master
+token: 'thisisatokenthingy'
+prNum: 5
+scmContext: github:github.com
+comments: [ { text: 'my, what a fine PR' } ]
+jobName: 'main'
+pipelineId: '123456'
+scmRepo:
+    branch: master
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/data/scm.addWebhookWithScmRepo.yaml
+++ b/test/data/scm.addWebhookWithScmRepo.yaml
@@ -1,0 +1,10 @@
+---
+scmUri: github.com:126987453:master
+token: thisisashinytoken
+webhookUrl: https://screwdriver.cd/v4/some-endpoint
+scmContext: github:github.com
+actions: [commit, tags, release]
+scmRepo:
+    branch: master
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/data/scm.decorateCommitWithScmRepo.yaml
+++ b/test/data/scm.decorateCommitWithScmRepo.yaml
@@ -1,0 +1,8 @@
+scmUri: github.com:12345678:master
+sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
+token: 'thisisatokenthingy'
+scmContext: github:github.com
+scmRepo:
+    branch: master
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/data/scm.getBranchListWithScmRepo.yaml
+++ b/test/data/scm.getBranchListWithScmRepo.yaml
@@ -1,0 +1,7 @@
+---
+scmUri: github.com:126987453:master
+token: thisisashinytoken
+scmRepo:
+    branch: master
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/data/scm.getChangedFilesInputWithScmRepo.yaml
+++ b/test/data/scm.getChangedFilesInputWithScmRepo.yaml
@@ -1,0 +1,12 @@
+webhookConfig:
+    ref: 'refs/heads/master'
+    before: '9049f1265b7d61be4a8904a9a27120d2064dab3b'
+    after: '0d1a26e67d8f5eaf1f6ba5c57fc3c7d91ac0fd1c'
+type: pr
+token: 'thisisatoken'
+scmContext: github:github.com
+scmUri: github.com:12345678:master
+scmRepo:
+    branch: master
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/data/scm.updateCommitStatusWithScmRepo.yaml
+++ b/test/data/scm.updateCommitStatusWithScmRepo.yaml
@@ -1,0 +1,12 @@
+scmUri: github.com:12345678:master
+token: thisisatokenthingy
+sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
+buildStatus: SUCCESS
+jobName: main
+url: https://foo.bar
+pipelineId: 123
+scmContext: github:github.com
+scmRepo:
+    branch: master
+    url: https://github.com/org/name/tree/master
+    name: org/name

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -58,6 +58,10 @@ describe('scm test', () => {
             assert.isNull(validate('scm.addPrComment.yaml', scm.addPrComment).error);
         });
 
+        it('validates with optional scmRepo', () => {
+            assert.isNull(validate('scm.addPrCommentWithScmRepo.yaml', scm.addPrComment).error);
+        });
+
         it('fails', () => {
             assert.isNotNull(validate('empty.yaml', scm.addPrComment).error);
         });

--- a/test/plugins/scm.test.js
+++ b/test/plugins/scm.test.js
@@ -68,6 +68,10 @@ describe('scm test', () => {
             assert.isNull(validate('scm.updateCommitStatus.yaml', scm.updateCommitStatus).error);
         });
 
+        it('validates with optional scmRepo', () => {
+            assert.isNull(validate('scm.updateCommitStatusWithScmRepo.yaml', scm.updateCommitStatus).error);
+        });
+
         it('validates with extra optional params (context and description)', () => {
             assert.isNull(validate('scm.updateCommitStatusFull.yaml', scm.updateCommitStatus).error);
         });
@@ -94,6 +98,10 @@ describe('scm test', () => {
     describe('getChangedFiles', () => {
         it('validates input', () => {
             assert.isNull(validate('scm.getChangedFilesInput.yaml', scm.getChangedFilesInput).error);
+        });
+
+        it('validates with optional scmRepo', () => {
+            assert.isNull(validate('scm.getChangedFilesInputWithScmRepo.yaml', scm.getChangedFilesInput).error);
         });
 
         it('fails empty input', () => {
@@ -130,6 +138,10 @@ describe('scm test', () => {
     describe('decorateCommit', () => {
         it('validates', () => {
             assert.isNull(validate('scm.decorateCommit.yaml', scm.decorateCommit).error);
+        });
+
+        it('validates with optional scmRepo', () => {
+            assert.isNull(validate('scm.decorateCommitWithScmRepo.yaml', scm.decorateCommit).error);
         });
 
         it('fails', () => {
@@ -184,6 +196,10 @@ describe('scm test', () => {
             assert.isNull(validate('scm.addWebhook.yaml', scm.addWebhook).error);
         });
 
+        it('validates with optional scmRepo', () => {
+            assert.isNull(validate('scm.addWebhookWithScmRepo.yaml', scm.addWebhook).error);
+        });
+
         it('fails', () => {
             assert.isNotNull(validate('empty.yaml', scm.addWebhook).error);
         });
@@ -202,6 +218,10 @@ describe('scm test', () => {
     describe('getBranchList', () => {
         it('validates', () => {
             assert.isNull(validate('scm.getBranchList.yaml', scm.getBranchList).error);
+        });
+
+        it('validates with optional scmRepo', () => {
+            assert.isNull(validate('scm.getBranchListWithScmRepo.yaml', scm.getBranchList).error);
         });
 
         it('fails', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

I would like to skip GitHub access if `scmRepo` is available. But some methods in the scm plugin do not allow to pass `scmRepo` argument.

https://github.com/screwdriver-cd/screwdriver/issues/3146

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Allow to pass `scmRepo` argument into methods that using `lookupScmUri` method inside.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3146

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
