### PR TITLE
fix: Allow workflowGraph for pipeline template versions model

### DIFF
--- a/config/pipelineTemplate.js
+++ b/config/pipelineTemplate.js
@@ -6,6 +6,7 @@ const Annotations = require('./annotations');
 const Parameters = require('./parameters');
 const Template = require('./template');
 const Regex = require('./regex');
+const WorkflowGraph = require('./workflowGraph');
 
 const SCHEMA_CONFIG = Joi.object()
     .keys({
@@ -15,7 +16,8 @@ const SCHEMA_CONFIG = Joi.object()
         annotations: Annotations.annotations,
         cache: BaseSchema.cache,
         subscribe: BaseSchema.subscribe,
-        stages: BaseSchema.stages
+        stages: BaseSchema.stages,
+        workflowGraph: WorkflowGraph.workflowGraph
     })
     .unknown(false);
 

--- a/test/data/pipelineTemplateVersions.get.allFields.yaml
+++ b/test/data/pipelineTemplateVersions.get.allFields.yaml
@@ -9,6 +9,9 @@ config:
             steps:
                 -   init: npm install
                 -   test: npm test
+        publish:
+            steps:
+                -   publish: npm publish
 
     shared:
         environment:
@@ -18,5 +21,15 @@ config:
         user:
             value: sd-bot
             description: User running build
+    workflowGraph:
+        nodes:
+            - name: ~commit
+            - name: main
+            - name: publish
+        edges:
+            - src: ~commit
+              dest: main
+            - src: main
+              dest: publish
 
 createTime: "2038-01-19T03:14:08.131Z"


### PR DESCRIPTION
## Context

Would be nice if we could see workflowGraph when we get pipeline template versions in pipeline template page.

## Objective

This PR adds workflowGraph to pipeline template config schema.

## References

NA

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
