### PR TITLE
feat(3143): Add regex for stage setup or teardown job names

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -45,6 +45,8 @@ module.exports = {
     JOB_NAME: /^(([\w-]+)|(?:stage@([\w-]+):(setup|teardown)))$/,
     // PR JOB Name can only be PR-1 or PR-1:main, group1: PR-prNum, group2: jobName
     PR_JOB_NAME: /^(PR-\d+)(?::([\w-]+))?$/,
+    // Stage setup pattern. Can be stage@stage-name:setup or stage@stage-name:teardown
+    STAGE_SETUP_TEARDOWN_JOB_NAME: /^stage@([\w-]+):(setup|teardown)$/,
     // Match all possible job name
     ALL_JOB_NAME: /^(PR-[0-9]+:)?[\w-@:]+$/,
     // Internal trigger like ~component or ~main
@@ -121,7 +123,5 @@ module.exports = {
     // Provider Role. Can be arn:aws:iam::xxxxxx:role/some-role
     ROLE_ARN: /^arn:aws:iam::\d{12}:role\/.+/,
     // Stage setup pattern. Can be stage@stage-name:setup
-    STAGE_SETUP_PATTERN: /^stage@([\w-]+):setup$/,
-    // Stage setup pattern. Can be stage@stage-name:setup or stage@stage-name:teardown
-    STAGE_SETUP_TEARDOWN_PATTERN: /^stage@([\w-]+):(setup|teardown)$/
+    STAGE_SETUP_PATTERN: /^stage@([\w-]+):setup$/
 };

--- a/config/regex.js
+++ b/config/regex.js
@@ -45,7 +45,7 @@ module.exports = {
     JOB_NAME: /^(([\w-]+)|(?:stage@([\w-]+):(setup|teardown)))$/,
     // PR JOB Name can only be PR-1 or PR-1:main, group1: PR-prNum, group2: jobName
     PR_JOB_NAME: /^(PR-\d+)(?::([\w-]+))?$/,
-    // Stage setup pattern. Can be stage@stage-name:setup or stage@stage-name:teardown
+    // Stage setup or teardown job name. Can be stage@stage-name:setup or stage@stage-name:teardown
     STAGE_SETUP_TEARDOWN_JOB_NAME: /^stage@([\w-]+):(setup|teardown)$/,
     // Match all possible job name
     ALL_JOB_NAME: /^(PR-[0-9]+:)?[\w-@:]+$/,

--- a/config/regex.js
+++ b/config/regex.js
@@ -121,5 +121,7 @@ module.exports = {
     // Provider Role. Can be arn:aws:iam::xxxxxx:role/some-role
     ROLE_ARN: /^arn:aws:iam::\d{12}:role\/.+/,
     // Stage setup pattern. Can be stage@stage-name:setup
-    STAGE_SETUP_PATTERN: /^stage@([\w-]+):setup$/
+    STAGE_SETUP_PATTERN: /^stage@([\w-]+):setup$/,
+    // Stage setup pattern. Can be stage@stage-name:setup or stage@stage-name:teardown
+    STAGE_SETUP_TEARDOWN_PATTERN: /^stage@([\w-]+):(setup|teardown)$/
 };

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -526,7 +526,7 @@ describe('config regex', () => {
     });
 
     describe('stageSetupTeardown', () => {
-        const stageSetupTeardownRegex = config.regex.STAGE_SETUP_TEARDOWN_PATTERN;
+        const stageSetupTeardownRegex = config.regex.STAGE_SETUP_TEARDOWN_JOB_NAME;
 
         it('matches valid stage setup or teardown jobs', () => {
             ['stage@alpha:setup', 'stage@alpha:teardown'].forEach(trigger => {
@@ -535,7 +535,16 @@ describe('config regex', () => {
         });
 
         it('does not match invalid stage setup or teardown jobs', () => {
-            ['stage@alpha', 'alpha-deploy', 'alpha:setup', 'stage@setup'].forEach(trigger => {
+            [
+                'stage@alpha',
+                'alpha-deploy',
+                'alpha:setup',
+                'stage@setup',
+                'stage@alpha:deploy',
+                'stage@teardown',
+                'sd@1234:stage@alpha:setup',
+                'sd@1234:stage@alpha:teardown'
+            ].forEach(trigger => {
                 assert.isFalse(stageSetupTeardownRegex.test(trigger));
             });
         });

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -524,4 +524,20 @@ describe('config regex', () => {
             });
         });
     });
+
+    describe('stageSetupTeardown', () => {
+        const stageSetupTeardownRegex = config.regex.STAGE_SETUP_TEARDOWN_PATTERN;
+
+        it('matches valid stage setup or teardown jobs', () => {
+            ['stage@alpha:setup', 'stage@alpha:teardown'].forEach(trigger => {
+                assert.isTrue(stageSetupTeardownRegex.test(trigger));
+            });
+        });
+
+        it('does not match invalid stage setup or teardown jobs', () => {
+            ['stage@alpha', 'alpha-deploy', 'alpha:setup', 'stage@setup'].forEach(trigger => {
+                assert.isFalse(stageSetupTeardownRegex.test(trigger));
+            });
+        });
+    });
 });


### PR DESCRIPTION
## Context

No regex exists to check if a job is one of stage setup or teardown

## Objective

Add regex to check if a job is a stage setup or teardown

## References

https://github.com/screwdriver-cd/screwdriver/issues/3143

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
