### PR TITLE
feat(3171): Persist pipeline template workflowGraph in a new column

### DIFF
--- a/config/pipelineTemplate.js
+++ b/config/pipelineTemplate.js
@@ -6,7 +6,6 @@ const Annotations = require('./annotations');
 const Parameters = require('./parameters');
 const Template = require('./template');
 const Regex = require('./regex');
-const WorkflowGraph = require('./workflowGraph');
 
 const SCHEMA_CONFIG = Joi.object()
     .keys({
@@ -16,8 +15,7 @@ const SCHEMA_CONFIG = Joi.object()
         annotations: Annotations.annotations,
         cache: BaseSchema.cache,
         subscribe: BaseSchema.subscribe,
-        stages: BaseSchema.stages,
-        workflowGraph: WorkflowGraph.workflowGraph
+        stages: BaseSchema.stages
     })
     .unknown(false);
 

--- a/migrations/20240827173654-add-workflowgraph-to-pipelineTemplateVersions.js
+++ b/migrations/20240827173654-add-workflowgraph-to-pipelineTemplateVersions.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}pipelineTemplateVersions`;
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                table,
+                'workflowGraph',
+                {
+                    type: Sequelize.TEXT,
+                    defaultValue: '{"nodes": [],"edges":[]}',
+                    allowNull: false
+                },
+                { transaction }
+            );
+        });
+    }
+};

--- a/models/pipelineTemplateVersions.js
+++ b/models/pipelineTemplateVersions.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const mutate = require('../lib/mutate');
 const pipelineTemplateVersions = require('../config/pipelineTemplate');
 const JobTemplateConfig = require('../config/template');
+const WorkflowGraph = require('../config/workflowGraph');
 const templateId = require('./templateMeta').base.extract('id');
 
 const MODEL = {
@@ -17,6 +18,10 @@ const MODEL = {
         .max(32)
         .description('When this template was created')
         .example('2038-01-19T03:14:08.131Z')
+        .required(),
+    workflowGraph: WorkflowGraph.workflowGraph
+        .description('Graph representation of the workflow')
+        .default('{"nodes": [],"edges":[]}')
         .required()
 };
 
@@ -43,9 +48,9 @@ module.exports = {
      * @property get
      * @type {Joi}
      */
-    get: Joi.object(mutate(MODEL, ['id', 'templateId', 'version'], ['description', 'config', 'createTime'])).label(
-        'Get Template'
-    ),
+    get: Joi.object(
+        mutate(MODEL, ['id', 'templateId', 'version'], ['description', 'config', 'createTime', 'workflowGraph'])
+    ).label('Get Template'),
 
     /**
      * List of fields that determine a unique row

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "contributors": [
     "Dao Lam <daolam112@gmail.com>",
     "Darren Matsumoto <aeneascorrupt@gmail.com>",
+    "Dayanand Sagar <sagar1312@gmail.com>",
     "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
     "Lakshminarasimhan Parthasarathy <laky@ymail.com>",
     "Min Zhang <minzhangcmu@gmail.com>",

--- a/test/data/pipelineTemplateVersions.get.allFields.yaml
+++ b/test/data/pipelineTemplateVersions.get.allFields.yaml
@@ -21,15 +21,15 @@ config:
         user:
             value: sd-bot
             description: User running build
-    workflowGraph:
-        nodes:
-            - name: ~commit
-            - name: main
-            - name: publish
-        edges:
-            - src: ~commit
-              dest: main
-            - src: main
-              dest: publish
+workflowGraph:
+    nodes:
+        - name: ~commit
+        - name: main
+        - name: publish
+    edges:
+        - src: ~commit
+          dest: main
+        - src: main
+          dest: publish
 
 createTime: "2038-01-19T03:14:08.131Z"

--- a/test/data/pipelineTemplateVersions.yaml
+++ b/test/data/pipelineTemplateVersions.yaml
@@ -9,4 +9,15 @@ config:
             steps:
                 -   init: npm install
                 -   test: npm test
+        publish:
+            steps:
+                -   init: npm install
+                -   publish: npm publish
+workflowGraph:
+    nodes:
+        - name: main
+        - name: publish
+    edges:
+        - src: main
+          dest: publish
 createTime: "2038-01-19T03:14:08.131Z"


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config


## Context

Changes were made in https://github.com/screwdriver-cd/data-schema/pull/571 to store `workflowGraph` of pipeline template as part of the `config` 

## Objective

Move `workflowGraph` out of `config` and keep it at the same level as `config`

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
