### PR TITLE
Add templateId and archived index to jobs table

### DIFF
--- a/migrations/20240906-add-templateId-and-archive-index-to-builds.js
+++ b/migrations/20240906-add-templateId-and-archive-index-to-builds.js
@@ -17,17 +17,5 @@ module.exports = {
                 transaction
             });
         });
-    },
-    // eslint-disable-next-line no-unused-vars
-    down: async (queryInterface, Sequelize) => {
-        await queryInterface.sequelize.transaction(async transaction => {
-            await queryInterface.removeIndex(table, `${table}_templateId_archived`, { transaction });
-
-            await queryInterface.addIndex(table, {
-                name: `${table}_templateId`,
-                fields: ['templateId'],
-                transaction
-            });
-        });
     }
 };

--- a/migrations/20240906-add-templateId-and-archive-index-to-builds.js
+++ b/migrations/20240906-add-templateId-and-archive-index-to-builds.js
@@ -1,0 +1,33 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}jobs`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.removeIndex(table, `${table}_templateId`, { transaction });
+
+            await queryInterface.addIndex(table, {
+                name: `${table}_templateId_archived`,
+                fields: ['templateId', 'archived'],
+                transaction
+            });
+        });
+    },
+    // eslint-disable-next-line no-unused-vars
+    down: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.removeIndex(table, `${table}_templateId_archived`, { transaction });
+
+            await queryInterface.addIndex(table, {
+                name: `${table}_templateId`,
+                fields: ['templateId'],
+                transaction
+            });
+        });
+    }
+};

--- a/models/job.js
+++ b/models/job.js
@@ -140,5 +140,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }, { fields: ['templateId'] }]
+    indexes: [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }, { fields: ['templateId', 'archived'] }]
 };

--- a/test/models/job.test.js
+++ b/test/models/job.test.js
@@ -86,7 +86,11 @@ describe('model job', () => {
 
     describe('indexes', () => {
         it('defines the correct indexes', () => {
-            const expected = [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }, { fields: ['templateId'] }];
+            const expected = [
+                { fields: ['pipelineId', 'state'] },
+                { fields: ['state'] },
+                { fields: ['templateId', 'archived'] }
+            ];
             const { indexes } = models.job;
 
             expected.forEach(indexName => {


### PR DESCRIPTION
## Context
related https://github.com/screwdriver-cd/screwdriver/issues/3191

https://github.com/screwdriver-cd/models/pull/612 added archived to the job table filter in the job template metrics.
However, since the only index in the job table is `templateId`, the index does not work effectively and the job template details page takes a long time to load.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Create an index for`templateId` and `archived` to speed up the loading of template detail pages


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3191

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
