### PR TITLE
feat(3211): Add a new field to builds to indicate the severity of the status message

### DIFF
--- a/migrations/20241014165446-add-status-message-type-to-build.js
+++ b/migrations/20241014165446-add-status-message-type-to-build.js
@@ -1,0 +1,21 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}builds`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                table,
+                'statusMessageType',
+                {
+                    type: Sequelize.STRING(10)
+                },
+                { transaction }
+            );
+        });
+    }
+};

--- a/models/build.js
+++ b/models/build.js
@@ -22,6 +22,7 @@ const STATUSES = [
     'COLLAPSED', // when the build is collapsed
     'FROZEN' // when the build is frozen due to freeze window
 ];
+const STATUS_MESSAGE_TYPES = ['ERROR', 'WARN', 'INFO'];
 
 const MODEL = {
     id: Joi.number().integer().positive().description('Identifier of this build').example(123345),
@@ -84,6 +85,12 @@ const MODEL = {
     statusMessage: Joi.string()
         .description('Status message to describe status of the build')
         .example('Build failed due to infrastructure error'),
+
+    statusMessageType: Joi.string()
+        .valid(...STATUS_MESSAGE_TYPES)
+        .max(10)
+        .description('Severity of the status message')
+        .example('WARN'),
 
     stats: Joi.object()
         .keys({
@@ -158,6 +165,7 @@ module.exports = {
                 'eventId',
                 'environment',
                 'statusMessage',
+                'statusMessageType',
                 'stats',
                 'buildClusterName',
                 'templateId',
@@ -172,7 +180,9 @@ module.exports = {
      * @property update
      * @type {Joi}
      */
-    update: Joi.object(mutate(MODEL, [], ['status', 'meta', 'statusMessage', 'stats'])).label('Update Build'),
+    update: Joi.object(mutate(MODEL, [], ['status', 'meta', 'statusMessage', 'statusMessageType', 'stats'])).label(
+        'Update Build'
+    ),
 
     /**
      * Properties for Build that will be passed during a CREATE request
@@ -222,6 +232,14 @@ module.exports = {
      * @type {Array}
      */
     allKeys: Object.keys(MODEL),
+
+    /**
+     * All the available status message type
+     *
+     * @property allStatusMessageTypes
+     * @type {Array}
+     */
+    allStatusMessageTypes: STATUS_MESSAGE_TYPES,
 
     /**
      * Tablename to be used in the datastore

--- a/test/data/build.update.yaml
+++ b/test/data/build.update.yaml
@@ -1,6 +1,7 @@
 # Build Update Example
 status: FAILURE
 statusMessage: 'Build failed to start due to infrastructure error'
+statusMessageType: 'ERROR'
 meta:
     yes: no
 stats:

--- a/test/models/build.test.js
+++ b/test/models/build.test.js
@@ -58,6 +58,22 @@ describe('model build', () => {
         it('fails the get', () => {
             assert.isNotNull(validate('empty.yaml', models.build.get).error);
         });
+
+        // valid status message types
+        models.build.allStatusMessageTypes.forEach(messageType => {
+            it('validates the valid message types', () => {
+                assert.isNull(validate('build.get.yaml', models.build.get, { statusMessageType: messageType }).error);
+            });
+        });
+
+        // invalid status message types
+        ['', 'error', 'warn', 'info', 'some_invalid_message_type'].forEach(messageType => {
+            it('validates the invalid message types', () => {
+                assert.isNotNull(
+                    validate('build.get.yaml', models.build.get, { statusMessageType: messageType }).error
+                );
+            });
+        });
     });
 
     describe('steps', () => {


### PR DESCRIPTION
## Context

All the build status message are currently treated/visualized as warning in the UI. We need a mechanism to distinguish the messages based on severity

## Objective

Add a new field `statusMessageType` to the `build` with `ERROR`, `WARN` and `INFO` as the allowed values

## References

https://github.com/screwdriver-cd/screwdriver/issues/3211

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
