### PR TITLE
feat(3266): add scope and scopeId to banner models

### DIFF
--- a/migrations/20250113235218-add-scope-and-scopeId-to-banner.js
+++ b/migrations/20250113235218-add-scope-and-scopeId-to-banner.js
@@ -26,6 +26,11 @@ module.exports = {
                 },
                 { transaction }
             );
+            await queryInterface.addIndex(table, {
+                name: `${table}_scope_and_scopeId`,
+                fields: ['scope', 'scopeId'],
+                transaction
+            });
         });
     }
 };

--- a/migrations/20250113235218-add-scope-and-scopeId-to-banner.js
+++ b/migrations/20250113235218-add-scope-and-scopeId-to-banner.js
@@ -1,0 +1,29 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}banners`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                table,
+                'scope',
+                {
+                    type: Sequelize.STRING(15)
+                },
+                { transaction }
+            );
+            await queryInterface.addColumn(
+                table,
+                'scopeId',
+                {
+                    type: Sequelize.INTEGER.UNSIGNED
+                },
+                { transaction }
+            );
+        });
+    }
+};

--- a/migrations/20250113235218-add-scope-and-scopeId-to-banner.js
+++ b/migrations/20250113235218-add-scope-and-scopeId-to-banner.js
@@ -12,7 +12,9 @@ module.exports = {
                 table,
                 'scope',
                 {
-                    type: Sequelize.STRING(15)
+                    type: Sequelize.STRING(15),
+                    defaultValue: 'GLOBAL',
+                    allowNull: false
                 },
                 { transaction }
             );

--- a/models/banner.js
+++ b/models/banner.js
@@ -28,7 +28,9 @@ const MODEL = {
     scope: Joi.string()
         .valid(...SCOPES)
         .description('Scope of the banner')
-        .example('GLOBAL'),
+        .example('GLOBAL')
+        .default('GLOBAL')
+        .required(),
 
     scopeId: Joi.number()
         .integer()

--- a/models/banner.js
+++ b/models/banner.js
@@ -26,6 +26,7 @@ const MODEL = {
     type: Joi.string().valid('info', 'warn').max(32).description('Type/Severity of the banner message').example('info'),
 
     scope: Joi.string()
+        .max(16)
         .valid(...SCOPES)
         .description('Scope of the banner')
         .example('GLOBAL')

--- a/models/banner.js
+++ b/models/banner.js
@@ -3,6 +3,8 @@
 const Joi = require('joi');
 const mutate = require('../lib/mutate');
 
+const SCOPES = ['GLOBAL', 'PIPELINE', 'BUILD'];
+
 const MODEL = {
     id: Joi.number().integer().positive(),
 
@@ -21,7 +23,20 @@ const MODEL = {
 
     createdBy: Joi.string().max(128).description('Username of user creating the banner').example('batman123'),
 
-    type: Joi.string().valid('info', 'warn').max(32).description('Type/Severity of the banner message').example('info')
+    type: Joi.string().valid('info', 'warn').max(32).description('Type/Severity of the banner message').example('info'),
+
+    scope: Joi.string()
+        .valid(...SCOPES)
+        .description('Scope of the banner')
+        .example('GLOBAL'),
+
+    scopeId: Joi.number()
+        .integer()
+        .positive()
+        .description('Identifier to pipelineId for PIPELINE, buildId for BUILD, or null for GLOBAL')
+        .optional()
+        .allow(null)
+        .example(1234)
 };
 
 module.exports = {
@@ -47,9 +62,9 @@ module.exports = {
      * @property get
      * @type {Joi}
      */
-    get: Joi.object(mutate(MODEL, ['id', 'message', 'type', 'isActive', 'createdBy', 'createTime'], [])).label(
-        'Get Banner'
-    ),
+    get: Joi.object(
+        mutate(MODEL, ['id', 'message', 'type', 'isActive', 'scope', 'scopeId', 'createdBy', 'createTime'], [])
+    ).label('Get Banner'),
 
     /**
      * Properties for Banners that will be passed during a CREATE request
@@ -57,7 +72,7 @@ module.exports = {
      * @property create
      * @type {Joi}
      */
-    create: Joi.object(mutate(MODEL, ['message'], ['type', 'isActive'])).label('Create Banner'),
+    create: Joi.object(mutate(MODEL, ['message'], ['type', 'isActive', 'scope', 'scopeId'])).label('Create Banner'),
 
     /**
      * Properties for Banners that will be passed during a UPDATE request
@@ -65,14 +80,18 @@ module.exports = {
      * @property update
      * @type {Joi}
      */
-    update: Joi.object(mutate(MODEL, [], ['message', 'type', 'isActive'])).label('Update Banner'),
+    update: Joi.object(mutate(MODEL, [], ['message', 'type', 'isActive', 'scope', 'scopeId'])).label('Update Banner'),
 
     /**
      * Properties for Banners that will come back during a LIST request.
      * The LIST request will list all banners
      */
     list: Joi.array()
-        .items(Joi.object(mutate(MODEL, ['id', 'message', 'type', 'isActive', 'createdBy', 'createTime'], [])))
+        .items(
+            Joi.object(
+                mutate(MODEL, ['id', 'message', 'type', 'isActive', 'scope', 'scopeId', 'createdBy', 'createTime'], [])
+            )
+        )
         .label('List Banners'),
 
     /**

--- a/models/banner.js
+++ b/models/banner.js
@@ -36,8 +36,11 @@ const MODEL = {
         .integer()
         .positive()
         .description('Identifier to pipelineId for PIPELINE, buildId for BUILD, or null for GLOBAL')
-        .optional()
-        .allow(null)
+        .when('scope', {
+            is: Joi.valid('PIPELINE', 'BUILD'),
+            then: Joi.required(),
+            otherwise: Joi.allow(null).optional() // Explicitly states optional for other cases
+        })
         .example(1234)
 };
 

--- a/models/banner.js
+++ b/models/banner.js
@@ -128,5 +128,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['isActive'] }]
+    indexes: [{ fields: ['isActive'] }, { fields: ['scope', 'scopeId'] }]
 };

--- a/models/banner.js
+++ b/models/banner.js
@@ -37,9 +37,9 @@ const MODEL = {
         .positive()
         .description('Identifier to pipelineId for PIPELINE, buildId for BUILD, or null for GLOBAL')
         .when('scope', {
-            is: Joi.valid('PIPELINE', 'BUILD'),
-            then: Joi.required(),
-            otherwise: Joi.allow(null).optional() // Explicitly states optional for other cases
+            is: Joi.valid('GLOBAL'),
+            then: Joi.allow(null).optional(),
+            otherwise: Joi.required()
         })
         .example(1234)
 };

--- a/models/banner.js
+++ b/models/banner.js
@@ -82,7 +82,7 @@ module.exports = {
      * @property update
      * @type {Joi}
      */
-    update: Joi.object(mutate(MODEL, [], ['message', 'type', 'isActive', 'scope', 'scopeId'])).label('Update Banner'),
+    update: Joi.object(mutate(MODEL, [], ['message', 'type', 'isActive'])).label('Update Banner'),
 
     /**
      * Properties for Banners that will come back during a LIST request.

--- a/models/banner.js
+++ b/models/banner.js
@@ -102,7 +102,7 @@ module.exports = {
      * @property keys
      * @type {Array}
      */
-    keys: ['message', 'type', 'createTime'],
+    keys: ['message', 'type', 'createTime', 'scope', 'scopeId'],
 
     /**
      * List of all fields in the model

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "npx": "^3.0.0",
     "nyc": "^15.1.0",
     "pg": "^7.18.2",
-    "sequelize": "^6.25.8",
-    "sequelize-cli": "^6.5.2",
-    "sqlite3": "^5.1.2"
+    "sequelize": "^6.37.5",
+    "sequelize-cli": "^6.6.2",
+    "sqlite3": "^5.1.7"
   },
   "dependencies": {
     "cron-parser": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "cron-parser": "^4.7.0",
-    "joi": "^17.7.0"
+    "joi": "^17.13.3"
   }
 }

--- a/test/data/banner.create.invalid.yaml
+++ b/test/data/banner.create.invalid.yaml
@@ -1,0 +1,5 @@
+# Banner Create Invalid Example
+message: "Test banner example"
+type: "info"
+isActive: true
+scope: "BOOM"

--- a/test/data/banner.create.yaml
+++ b/test/data/banner.create.yaml
@@ -1,2 +1,5 @@
 # Banner Create Example
 message: "Test banner example"
+type: "info"
+isActive: true
+scope: "GLOBAL"

--- a/test/data/banner.get.yaml
+++ b/test/data/banner.get.yaml
@@ -3,5 +3,7 @@ id: 123
 message: 'Test banner example'
 type: 'info'
 isActive: true
+scope: 'GLOBAL'
+scopeId: null
 createdBy: batman123
 createTime: '2017-01-06T01:49:50.384359267Z'

--- a/test/data/banner.list.yaml
+++ b/test/data/banner.list.yaml
@@ -3,17 +3,23 @@
   message: 'Test banner example'
   type: 'info'
   isActive: true
+  scope: 'GLOBAL'
+  scopeId: null
   createdBy: batman123
   createTime: '2017-01-06T01:49:50.384359267Z'
 - id: 124
   message: 'Test banner example again'
   type: 'info'
   isActive: false
+  scope: 'PIPELINE'
+  scopeId: 123
   createdBy: batman123
   createTime: '2017-01-07T01:49:50.384359267Z'
 - id: 125
   message: 'Test banner example yet again'
   type: 'warn'
   isActive: false
+  scope: 'BUILD'
+  scopeId: 123
   createdBy: batman123
   createTime: '2017-01-08T01:49:50.384359267Z'

--- a/test/data/banner.update.invalid.yaml
+++ b/test/data/banner.update.invalid.yaml
@@ -1,0 +1,5 @@
+# Banner Create Invalid Example
+message: "Test banner example"
+type: "info"
+isActive: true
+scope: "GLOBAL"

--- a/test/data/banner.update.yaml
+++ b/test/data/banner.update.yaml
@@ -2,5 +2,3 @@
 message: 'Test banner example with update'
 type: 'warn'
 isActive: true
-scope: 'PIPELINE'
-scopeId: 123

--- a/test/data/banner.update.yaml
+++ b/test/data/banner.update.yaml
@@ -2,3 +2,5 @@
 message: 'Test banner example with update'
 type: 'warn'
 isActive: true
+scope: 'PIPELINE'
+scopeId: 123

--- a/test/data/banner.yaml
+++ b/test/data/banner.yaml
@@ -1,2 +1,3 @@
 # Banner Example
 message: "Test banner example"
+scope: "GLOBAL"

--- a/test/models/banner.test.js
+++ b/test/models/banner.test.js
@@ -19,6 +19,10 @@ describe('banner create', () => {
         it('fails the create', () => {
             assert.isNotNull(validate('empty.yaml', models.banner.create).error);
         });
+
+        it('fails the create with invalid scope', () => {
+            assert.isNotNull(validate('banner.create.invalid.yaml', models.banner.create).error);
+        });
     });
     describe('get', () => {
         it('validates the get', () => {
@@ -45,6 +49,10 @@ describe('banner create', () => {
 
         it('fails the update', () => {
             assert.isNotNull(validate('empty.yaml', models.banner.update).error);
+        });
+
+        it('fails the update with invalid config', () => {
+            assert.isNotNull(validate('banner.update.invalid.yaml', models.banner.update).error);
         });
     });
 });


### PR DESCRIPTION
## Context

The current implementation of banner schema is at the global level. 

## Objective

Sometimes banner is needed at the pipeline or build level only. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/3266

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
