### PR TITLE
feat: add new admin annotation to update job build cluster

### DIFF
--- a/config/annotations.js
+++ b/config/annotations.js
@@ -27,7 +27,8 @@ const RESERVED_JOB_ANNOTATIONS = [
     'screwdriver.cd/blockedBySameJob',
     'screwdriver.cd/blockedBySameJobWaitTime',
     'screwdriver.cd/jobDisabledByDefault',
-    'screwdriver.cd/virtualJob'
+    'screwdriver.cd/virtualJob',
+    'screwdriver.cd/sdAdminBuildClusterOverride'
 ];
 const RESERVED_PIPELINE_ANNOTATIONS = [
     'screwdriver.cd/buildCluster',


### PR DESCRIPTION
## Context

Build Cluster annotation on a job is currently only derived from pipeline or from screwdriver config.
Screwdriver Admin should have a way to override the behavior to move jobs to some cluster

## Objective

This PR adds a new annotation to support Screwdriver admin level override for build cluster

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
