### PR TITLE
fix(3271): Disable setting sourcePaths for a stage teardown job

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -37,13 +37,14 @@ const SCHEMA_CHILD_PIPELINES = Joi.object()
         startAll: Joi.boolean()
     })
     .unknown(false);
-const SCHEMA_SETUP_TEARDOWN_JOB = Job.job.keys({ requires: Joi.forbidden() });
+const SCHEMA_SETUP_JOB = Job.job.keys({ requires: Joi.forbidden() });
+const SCHEMA_TEARDOWN_JOB = Job.job.keys({ requires: Joi.forbidden(), sourcePaths: Joi.forbidden() });
 const SCHEMA_STAGE = Joi.object()
     .keys({
         description: Joi.string(),
         jobs: Joi.array().items(Job.jobName).min(0),
-        setup: SCHEMA_SETUP_TEARDOWN_JOB,
-        teardown: SCHEMA_SETUP_TEARDOWN_JOB,
+        setup: SCHEMA_SETUP_JOB,
+        teardown: SCHEMA_TEARDOWN_JOB,
         requires: Job.requires,
         sourcePaths: Job.sourcePaths
     })
@@ -123,7 +124,8 @@ module.exports = {
     childPipelines: SCHEMA_CHILD_PIPELINES,
     configBeforeMergingTemplate: SCHEMA_CONFIG_PRE_TEMPLATE_MERGE,
     configAfterMergingTemplate: SCHEMA_CONFIG_POST_TEMPLATE_MERGE,
-    stageSetupTeardownJob: SCHEMA_SETUP_TEARDOWN_JOB,
+    stageSetupJob: SCHEMA_SETUP_JOB,
+    stageTeardownJob: SCHEMA_TEARDOWN_JOB,
     stage: SCHEMA_STAGE,
     stages: SCHEMA_STAGES,
     subscribe: SCHEMA_SUBSCRIBE


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I am now modifying it so that sourcePaths can be used in stage.
- https://github.com/screwdriver-cd/data-schema/pull/591
- https://github.com/screwdriver-cd/config-parser/pull/178

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Disable setting sourcePaths for stage teardown jobs.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3271

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
