### PR TITLE
fix: Add pipelineId and archived index to jobs

### DIFF
--- a/migrations/20250318145743-add-pipelineId-and-archived-index-to-jobs.js
+++ b/migrations/20250318145743-add-pipelineId-and-archived-index-to-jobs.js
@@ -1,0 +1,19 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}jobs`;
+
+module.exports = {
+    // eslint-disable-next-line no-unused-vars
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addIndex(table, {
+                name: `${table}_pipelineId_archived`,
+                fields: ['pipelineId', 'archived'],
+                transaction
+            });
+        });
+    }
+};

--- a/models/job.js
+++ b/models/job.js
@@ -140,5 +140,10 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }, { fields: ['templateId', 'archived'] }, { fields: ['pipelineId', 'archived'] }]
+    indexes: [
+        { fields: ['pipelineId', 'state'] },
+        { fields: ['state'] },
+        { fields: ['templateId', 'archived'] },
+        { fields: ['pipelineId', 'archived'] }
+    ]
 };

--- a/models/job.js
+++ b/models/job.js
@@ -140,5 +140,5 @@ module.exports = {
      * @property indexes
      * @type {Array}
      */
-    indexes: [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }, { fields: ['templateId', 'archived'] }]
+    indexes: [{ fields: ['pipelineId', 'state'] }, { fields: ['state'] }, { fields: ['templateId', 'archived'] }, { fields: ['pipelineId', 'archived'] }]
 };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Queries to find jobs in the pipeline with large numbers of archived jobs can be slow.

Location of the call where the slow query was actually detected.
https://github.com/screwdriver-cd/models/blob/3c515d63a2d7e52a25684e2ae93b552e204c90c2/lib/pipeline.js#L1456

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add pipelineId and archived index to job table.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
