### PR TITLE
fix(3310): Consistently extract external job name

### DIFF
--- a/config/regex.js
+++ b/config/regex.js
@@ -67,7 +67,7 @@ module.exports = {
     EXTERNAL_TRIGGER_AND: /^sd@(\d+):(?:([\w-]+)|(stage@([\w-]+):setup))$/,
     // External trigger (OR and AND case)
     // Can be ~sd@123:component or sd@123:component
-    EXTERNAL_TRIGGER_ALL: /^~?sd@(\d+):(?:([\w-]+)|(stage@([\w-]+):setup))$/,
+    EXTERNAL_TRIGGER_ALL: /^~?sd@(\d+):(([\w-]+)|(stage@([\w-]+):setup))$/,
 
     // Can be ~pr, ~commit, ~release, ~tag or ~commit:branchName, or ~sd@123:component
     // Note: if you modify this regex, you must modify `sdJoi` definition in the `config/job.js`

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -549,4 +549,53 @@ describe('config regex', () => {
             });
         });
     });
+
+    describe.only('extract downstream job name', () => {
+        const externalTriggerRegex = config.regex.EXTERNAL_TRIGGER_ALL;
+
+        it('matches valid external jobs', () => {
+            ['sd@26:hello', '~sd@26:hello', 'sd@26:stage@alpha:setup', '~sd@26:stage@alpha:setup'].forEach(trigger => {
+                assert.isTrue(externalTriggerRegex.test(trigger));
+            });
+        });
+
+        it('does not match invalid downstream job name', () => {
+            [
+                'sd@26',
+                '~sd@26',
+                'sd@26:stage@alpha',
+                'sd@26:stage@alpha:deploy',
+                '~sd@26:stage@alpha:deploy',
+                'sd@26:stage@alpha:teardown',
+                '~sd@26:stage@alpha:teardown'
+            ].forEach(trigger => {
+                assert.isFalse(externalTriggerRegex.test(trigger));
+            });
+        });
+
+        it('consistently extracts downstream job name', () => {
+            [
+                {
+                    externalTrigger: 'sd@26:hello',
+                    expectedJobName: 'hello'
+                },
+                {
+                    externalTrigger: '~sd@26:hello',
+                    expectedJobName: 'hello'
+                },
+                {
+                    externalTrigger: 'sd@26:stage@alpha:setup',
+                    expectedJobName: 'stage@alpha:setup'
+                },
+                {
+                    externalTrigger: '~sd@26:stage@alpha:setup',
+                    expectedJobName: 'stage@alpha:setup'
+                }
+            ].forEach(e => {
+                const [, , actualJobName] = externalTriggerRegex.exec(e.externalTrigger);
+
+                assert.equal(actualJobName, e.expectedJobName);
+            });
+        });
+    });
 });

--- a/test/config/regex.test.js
+++ b/test/config/regex.test.js
@@ -550,7 +550,7 @@ describe('config regex', () => {
         });
     });
 
-    describe.only('extract downstream job name', () => {
+    describe('extract downstream job name', () => {
         const externalTriggerRegex = config.regex.EXTERNAL_TRIGGER_ALL;
 
         it('matches valid external jobs', () => {


### PR DESCRIPTION
## Context
The regex `^~?sd@(\d+):(?:([\w-]+)|(stage@([\w-]+):setup))$` does not consistently return the matching group to get the job name 

<img width="892" alt="image" src="https://github.com/user-attachments/assets/adfbc9e8-279e-4b6f-ba6e-976f2fba04d1" />




## Objective

Fix the regex to consistently retrieve the job name as the second group.

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/5f4326e4-34aa-4dcd-9836-210660e1b3d7" />



## References

https://github.com/screwdriver-cd/screwdriver/issues/3310

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
