### PR TITLE
fix: Relax pipeline adminUserIds restriction

### DIFF
--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -71,8 +71,8 @@ const MODEL = {
     adminUserIds: Joi.array()
         .items(Joi.number().integer().positive().description('Identifier of the user').example(12345))
         .description('IDs of the users who have admin privileges for this pipeline')
-        .default([])
-        .required(),
+        .example('[12345, 6789]')
+        .default([]),
 
     workflowGraph: WorkflowGraph.workflowGraph.description('Graph representation of the workflow'),
 
@@ -160,7 +160,7 @@ module.exports = {
     get: Joi.object(
         mutate(
             MODEL,
-            ['id', 'scmUri', 'scmContext', 'createTime', 'admins', 'adminUserIds', 'state'],
+            ['id', 'scmUri', 'scmContext', 'createTime', 'admins', 'state'],
             [
                 'workflowGraph',
                 'scmRepo',
@@ -174,7 +174,8 @@ module.exports = {
                 'subscribedScmUrlsWithActions',
                 'settings',
                 'badges',
-                'templateVersionId'
+                'templateVersionId',
+                'adminUserIds'
             ]
         )
     ).label('Get Pipeline'),


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
If screwdriver using mysql 5.X, default value cannot be set in TEXT field.
Because of that, old pipelines have null adminUserIds column.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Relax pipeline adminUserIds restriction for mysql backward compatibility.
- remove required restriction for null value.
- move adminUserIds from requiredFileds to optionalFields.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/pull/3325

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
