### PR TITLE
feat(3328): Add status column to events table

### DIFF
--- a/migrations/20250425162418-add-status-to-event.js
+++ b/migrations/20250425162418-add-status-to-event.js
@@ -1,0 +1,31 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}events`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                table,
+                'status',
+                {
+                    type: Sequelize.STRING(10),
+                    defaultValue: 'UNKNOWN',
+                    allowNull: false
+                },
+                { transaction }
+            );
+
+            await queryInterface.removeIndex(table, `${table}_create_time_pipeline_id`, { transaction });
+
+            await queryInterface.addIndex(table, {
+                name: `${table}_create_time_pipeline_id_status`,
+                fields: ['createTime', 'pipelineId', 'status'],
+                transaction
+            });
+        });
+    }
+};

--- a/test/data/event.get.full.yaml
+++ b/test/data/event.get.full.yaml
@@ -32,3 +32,4 @@ workflowGraph:
           dest: main
         - src: main
           dest: publish
+status: SUCCESS

--- a/test/data/event.get.pr.yaml
+++ b/test/data/event.get.pr.yaml
@@ -21,3 +21,4 @@ pr:
     url: https://github.com/scredriver-cd/screwdriver/pull/25
     title: pr_test
 prNum: 25
+status: SUCCESS

--- a/test/data/event.get.yaml
+++ b/test/data/event.get.yaml
@@ -17,3 +17,4 @@ creator:
 pipelineId: 354675231876
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
 type: pipeline
+status: SUCCESS

--- a/test/data/event.yaml
+++ b/test/data/event.yaml
@@ -18,3 +18,4 @@ creator:
 pipelineId: 978668
 sha: 46f1a0bd5592a2f9244ca321b129902a06b53e03
 type: pipeline
+status: IN_PROGRESS

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -79,6 +79,22 @@ describe('model event', () => {
         it('fails the get', () => {
             assert.isNotNull(validate('empty.yaml', models.event.get).error);
         });
+
+        describe('test status', () => {
+            // valid statuses
+            models.event.allStatuses.forEach(validStatus => {
+                it('validates the valid statuses', () => {
+                    assert.isNull(validate('event.get.yaml', models.event.get, { status: validStatus }).error);
+                });
+            });
+
+            // invalid statuses
+            [null, '', 'some_invalid_state', 'success'].forEach(validState => {
+                it('validates the invalid statuses', () => {
+                    assert.isNotNull(validate('event.get.yaml', models.event.get, { status: validState }).error);
+                });
+            });
+        });
     });
 
     describe('keys', () => {
@@ -110,7 +126,7 @@ describe('model event', () => {
     describe('indexes', () => {
         it('defines the correct indexes', () => {
             const expected = [
-                { fields: ['createTime', 'pipelineId'] },
+                { fields: ['createTime', 'pipelineId', 'status'] },
                 { fields: ['pipelineId'] },
                 { fields: ['type'] },
                 { fields: ['groupEventId'] },


### PR DESCRIPTION
## Context
Overall execution status of the event is being determined by UI based on individual build statuses.
We need to determine the status in the backend and persist in DB.

## Objective

Add a new column `status` to `events` table

## References

https://github.com/screwdriver-cd/screwdriver/issues/3328

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
