### PR TITLE
feat(3328): Increase the size of status column value in events table

### DIFF
--- a/migrations/20250513162834-update-status-length-in-event.js
+++ b/migrations/20250513162834-update-status-length-in-event.js
@@ -1,0 +1,23 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}events`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.changeColumn(
+                table,
+                'status',
+                {
+                    type: Sequelize.STRING(15),
+                    defaultValue: 'UNKNOWN',
+                    allowNull: false
+                },
+                { transaction }
+            );
+        });
+    }
+};

--- a/models/event.js
+++ b/models/event.js
@@ -73,7 +73,7 @@ const MODEL = {
     baseBranch: Joi.string().description('build base branch').example('develop'),
     status: Joi.string()
         .valid(...STATUSES)
-        .max(10)
+        .max(15)
         .description('Current status of the event')
         .example('SUCCESS')
         .default('UNKNOWN')


### PR DESCRIPTION
## Context

PR https://github.com/screwdriver-cd/data-schema/pull/599 added a new column `status` (Max length = 10) column to `events` table.
There are statuses (Ex: `IN_PROGRESS`) exceeding the declared max length. 

## Objective

Increase the max length to 15.

## References

https://github.com/screwdriver-cd/screwdriver/issues/3328

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
