### PR TITLE
feat(2856): Add timestamp in downloaded logs [1]

### DIFF
--- a/api/loglines.js
+++ b/api/loglines.js
@@ -22,7 +22,17 @@ const SCHEMA_QUERY = Joi.object()
         type: Joi.string()
             .valid('download', 'preview')
             .default('preview')
-            .label('Flag to trigger type either to download or preview')
+            .label('Flag to trigger type either to download or preview'),
+        timestamp: Joi.boolean().optional().default(false).description('Enable timestamp in logs'),
+        timestampFormat: Joi.string()
+            .valid('full-time', 'simple-time', 'elapsed-build', 'elapsed-step')
+            .optional()
+            .default('full-time')
+            .description('Timestamp format at the head of the log'),
+        timezone: Joi.string()
+            .optional()
+            .default('UTC')
+            .description('Timezone of timestamp in logs')
     })
     .label('Query Parameters');
 

--- a/api/loglines.js
+++ b/api/loglines.js
@@ -29,10 +29,7 @@ const SCHEMA_QUERY = Joi.object()
             .optional()
             .default('full-time')
             .description('Timestamp format at the head of the log'),
-        timezone: Joi.string()
-            .optional()
-            .default('UTC')
-            .description('Timezone of timestamp in logs')
+        timezone: Joi.string().optional().default('UTC').description('Timezone of timestamp in logs')
     })
     .label('Query Parameters');
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Allows timestamps to be added to downloaded logs.
This PR by itself does not affect the existing behavior.

The releated PR
- https://github.com/screwdriver-cd/screwdriver/pull/3365
- https://github.com/screwdriver-cd/ui/pull/1436

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Allows user to select.
- Whether to include a timestamp 
- Timestamp format 
- Timestamp time zone (Only affects full-time and simple-time format)

About Timestamp format
- full-time: iso 8601 format
- simple-time: hh:mm:ss format like UI
- elapsed-build: hh:mm:ss format like UI
- elapsed-step: hh:mm:ss format like UI

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2856

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
