### PR TITLE
fix(3373): Add index to events table to improve GET badge API performance

### DIFF
--- a/migrations/20250729150331-add-pipelineId-and-createTime-index-to-events.js
+++ b/migrations/20250729150331-add-pipelineId-and-createTime-index-to-events.js
@@ -6,6 +6,7 @@ const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
 const table = `${prefix}events`;
 
 module.exports = {
+    // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async transaction => {
             await queryInterface.addIndex(table, {

--- a/migrations/20250729150331-add-pipelineId-and-createTime-index-to-events.js
+++ b/migrations/20250729150331-add-pipelineId-and-createTime-index-to-events.js
@@ -1,0 +1,18 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}events`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addIndex(table, {
+                name: `${table}_pipeline_id_create_time`,
+                fields: ['pipelineId', 'createTime'],
+                transaction
+            });
+        });
+    }
+};

--- a/models/event.js
+++ b/models/event.js
@@ -183,7 +183,7 @@ module.exports = {
      * @property rangeKeys
      * @type {Array}
      */
-    rangeKeys: ['createTime', 'pipelineId', 'type', 'groupEventId', 'parentEventId'],
+    rangeKeys: ['createTime', 'pipelineId', 'type', 'groupEventId', 'parentEventId', 'pipelineId'],
 
     /**
      * Tablename to be used in the datastore

--- a/models/event.js
+++ b/models/event.js
@@ -204,6 +204,7 @@ module.exports = {
         { fields: ['pipelineId'] },
         { fields: ['type'] },
         { fields: ['groupEventId'] },
-        { fields: ['parentEventId'] }
+        { fields: ['parentEventId'] },
+        { fields: ['pipelineId', 'createTime'] }
     ]
 };

--- a/test/models/event.test.js
+++ b/test/models/event.test.js
@@ -130,7 +130,8 @@ describe('model event', () => {
                 { fields: ['pipelineId'] },
                 { fields: ['type'] },
                 { fields: ['groupEventId'] },
-                { fields: ['parentEventId'] }
+                { fields: ['parentEventId'] },
+                { fields: ['pipelineId', 'createTime'] }
             ];
             const { indexes } = models.event;
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This change is related to https://github.com/screwdriver-cd/screwdriver/issues/3373.
It addresses performance issues with the GET pipeline badge API in MySQL environments where there is a large volume of events data.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

In MySQL, [querying events for the GET pipeline badge endpoint](https://github.com/screwdriver-cd/screwdriver/blob/89d47db83d63dc527433869bb52d16902c2a7a6a/plugins/pipelines/badge.js#L40-L57) becomes highly inefficient and slow due to the use of the [index (createTime, pipeline, status)](https://github.com/screwdriver-cd/data-schema/blob/49a0cc5e999f94f3976165d49bd065a00cb40325/models/event.js#L203) during execution.

To improve query performance, we will add a new index on (pipelineId, createTime).

Please note that we are not removing the existing index (createTime, pipeline, status) at this time, as doing so may affect other operations.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3373

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
