### PR TITLE
fix: Adhere to removeIndex signature

### DIFF
--- a/migrations/20250912140626-remove-pipelineId-and-createTime-index-from-events.js
+++ b/migrations/20250912140626-remove-pipelineId-and-createTime-index-from-events.js
@@ -9,8 +9,7 @@ module.exports = {
     // eslint-disable-next-line no-unused-vars
     up: async (queryInterface, Sequelize) => {
         await queryInterface.sequelize.transaction(async transaction => {
-            await queryInterface.removeIndex(table, {
-                name: `${table}_pipeline_id_create_time`,
+            await queryInterface.removeIndex(table, `${table}_pipeline_id_create_time`, {
                 transaction
             });
         });


### PR DESCRIPTION
## Context
The `removeIndex` signature is of the following format:
```javascript
public async removeIndex(tableName: string, indexNameOrAttributes: string | string[], options: object): Promise
```
https://sequelize.org/api/v6/class/src/dialects/abstract/query-interface.js~queryinterface#instance-method-removeIndex

The current migration fails due to the following error:
```
 ERROR: TypeError: indexNameOrAttributes.join is not a function
``` 

## Objective
Fixes the `removeIndex` migration to use the expected function signature

## References
#608

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
