### PR TITLE
BREAKING CHANGE: Disallow unknown keys in user settings

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -50,13 +50,12 @@ const SCHEMA_USER_SETTINGS = Joi.object()
             showPRJobs: Joi.boolean()
         })
     )
-    .unknown();
-
-SCHEMA_USER_SETTINGS.append({
-    displayJobNameLength: SCHEMA_DISPLAY_JOB_NAME_LENGTH,
-    timestampFormat: SCHEMA_TIMESTAMP_FORMAT,
-    allowNotification: SCHEMA_ALLOW_NOTIFICATION
-});
+    .keys({
+        displayJobNameLength: SCHEMA_DISPLAY_JOB_NAME_LENGTH,
+        timestampFormat: SCHEMA_TIMESTAMP_FORMAT,
+        allowNotification: SCHEMA_ALLOW_NOTIFICATION
+    })
+    .unknown(false);
 
 module.exports = {
     pipelineSettings: SCHEMA_PIPELINE_SETTINGS,

--- a/test/data/user.get.invalid-settings.yaml
+++ b/test/data/user.get.invalid-settings.yaml
@@ -7,3 +7,5 @@ settings:
         showPRJobs: false
     displayJobNameLength: 50
     timestampFormat: 'LOCAL_TIMEZONE'
+    hello: world
+    this: is-allowed

--- a/test/models/user.test.js
+++ b/test/models/user.test.js
@@ -29,6 +29,10 @@ describe('model user', () => {
         it('fails the get', () => {
             assert.isNotNull(validate('empty.yaml', models.user.get).error);
         });
+
+        it('fails the get when there are unknow fields in the user settings', () => {
+            assert.isNotNull(validate('user.get.invalid-settings.yaml', models.user.get).error);
+        });
     });
 
     describe('update', () => {


### PR DESCRIPTION
## Context

The user settings schema in screwdriver-cd/data-schema (`config/settings.js`) uses .unknown(), so Joi accepts and passes through arbitrary keys—including `_proto_` and `constructor`. Validated user settings can therefore contain prototype-pollution payloads. If any consumer (e.g. screwdriver-api or UI) deep-merges this validated object into a plain object, Object.prototype can be polluted. That can lead to authorization bypass (e.g. isAdmin or similar checks inheriting a polluted value) and, in the worst case, full compromise of pipelines, secrets, and build execution. The fix is to stop allowing dangerous keys in the schema (e.g. .unknown(false) and explicit keys, or rejecting `_proto_` / `constructor` /
`prototype`).


## Objective

Disallow unknown keys in user settings.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
