### PR TITLE
feat(3475): Add DISABLED state and stateChanger fields to pipeline model

### DIFF
--- a/migrations/20260312000000-add-stateChanger-columns-to-pipeline.js
+++ b/migrations/20260312000000-add-stateChanger-columns-to-pipeline.js
@@ -1,0 +1,37 @@
+/* eslint-disable new-cap */
+
+'use strict';
+
+const prefix = process.env.DATASTORE_SEQUELIZE_PREFIX || '';
+const table = `${prefix}pipelines`;
+
+module.exports = {
+    up: async (queryInterface, Sequelize) => {
+        await queryInterface.sequelize.transaction(async transaction => {
+            await queryInterface.addColumn(
+                table,
+                'stateChanger',
+                {
+                    type: Sequelize.STRING(128)
+                },
+                { transaction }
+            );
+            await queryInterface.addColumn(
+                table,
+                'stateChangeTime',
+                {
+                    type: Sequelize.STRING(32)
+                },
+                { transaction }
+            );
+            await queryInterface.addColumn(
+                table,
+                'stateChangeMessage',
+                {
+                    type: Sequelize.STRING(512)
+                },
+                { transaction }
+            );
+        });
+    }
+};

--- a/models/pipeline.js
+++ b/models/pipeline.js
@@ -10,7 +10,8 @@ const WorkflowGraph = require('../config/workflowGraph');
 const Parameters = require('../config/parameters');
 const mutate = require('../lib/mutate');
 
-const STATES = ['ACTIVE', 'INACTIVE', 'DELETING'];
+const STATES = ['ACTIVE', 'INACTIVE', 'DELETING', 'DISABLED'];
+const VALID_STATES_FOR_UPDATE = ['ACTIVE', 'DISABLED'];
 const BADGE = Joi.object({
     defaultName: Joi.string()
         .max(128)
@@ -107,6 +108,15 @@ const MODEL = {
         .default('ACTIVE')
         .required(),
 
+    stateChanger: Joi.string().max(128).description('Username for who changed the state'),
+
+    stateChangeTime: Joi.string().isoDate().description('When the state of the pipeline was changed'),
+
+    stateChangeMessage: Joi.string()
+        .max(512)
+        .description('Reason why disabling or enabling pipeline')
+        .example('Disabling pipeline for maintenance'),
+
     subscribedScmUrlsWithActions: Joi.array()
         .items(
             Joi.object().keys({
@@ -132,7 +142,18 @@ const MODEL = {
         .allow(null)
 };
 
-const UPDATE_MODEL = { ...CREATE_MODEL, settings: MODEL.settings, badges: MODEL.badges };
+const UPDATE_MODEL = {
+    ...CREATE_MODEL,
+    settings: MODEL.settings,
+    badges: MODEL.badges,
+    state: Joi.string()
+        .valid(...VALID_STATES_FOR_UPDATE)
+        .max(10)
+        .description('New state of the pipeline')
+        .example('ACTIVE')
+        .optional(),
+    stateChangeMessage: MODEL.stateChangeMessage
+};
 
 module.exports = {
     /**
@@ -175,7 +196,10 @@ module.exports = {
                 'settings',
                 'badges',
                 'templateVersionId',
-                'adminUserIds'
+                'adminUserIds',
+                'stateChanger',
+                'stateChangeTime',
+                'stateChangeMessage'
             ]
         )
     ).label('Get Pipeline'),
@@ -197,7 +221,11 @@ module.exports = {
      * @type {Joi}
      */
     update: Joi.object(
-        mutate(UPDATE_MODEL, [], ['checkoutUrl', 'rootDir', 'autoKeysGeneration', 'settings', 'badges'])
+        mutate(
+            UPDATE_MODEL,
+            [],
+            ['checkoutUrl', 'rootDir', 'autoKeysGeneration', 'settings', 'badges', 'state', 'stateChangeMessage']
+        )
     ).label('Update Pipeline'),
 
     /**

--- a/test/models/pipeline.test.js
+++ b/test/models/pipeline.test.js
@@ -60,9 +60,71 @@ describe('model pipeline', () => {
             assert.isNotNull(validate('empty.yaml', models.pipeline.update).error);
         });
 
-        it('validates that state is not allowed', () => {
+        it('validates state change fields', () => {
+            assert.isNull(
+                validate('pipeline.update.yaml', models.pipeline.update, {
+                    state: 'DISABLED',
+                    stateChangeMessage: 'Disabling for maintenance'
+                }).error
+            );
+        });
+
+        it('rejects invalid stateChangeMessage that is too long', () => {
             assert.isNotNull(
-                validate('pipeline.update.yaml', models.pipeline.update, { state: models.pipeline.allStates[0] }).error
+                validate('pipeline.update.yaml', models.pipeline.update, {
+                    stateChangeMessage: 'x'.repeat(513)
+                }).error
+            );
+        });
+
+        it('rejects INACTIVE and DELETING states in update', () => {
+            assert.isNotNull(validate('pipeline.update.yaml', models.pipeline.update, { state: 'INACTIVE' }).error);
+            assert.isNotNull(validate('pipeline.update.yaml', models.pipeline.update, { state: 'DELETING' }).error);
+        });
+    });
+
+    describe('allStates', () => {
+        it('includes DISABLED state', () => {
+            assert.include(models.pipeline.allStates, 'DISABLED');
+        });
+
+        it('includes all expected states', () => {
+            assert.deepEqual(models.pipeline.allStates, ['ACTIVE', 'INACTIVE', 'DELETING', 'DISABLED']);
+        });
+    });
+
+    describe('stateChanger fields', () => {
+        it('validates get with stateChanger fields', () => {
+            assert.isNull(
+                validate('pipeline.get.yaml', models.pipeline.get, {
+                    stateChanger: 'username',
+                    stateChangeTime: '2026-03-12T00:00:00.000Z',
+                    stateChangeMessage: 'Disabling for maintenance'
+                }).error
+            );
+        });
+
+        it('validates get with DISABLED state', () => {
+            assert.isNull(
+                validate('pipeline.get.yaml', models.pipeline.get, {
+                    state: 'DISABLED'
+                }).error
+            );
+        });
+
+        it('rejects stateChanger longer than 128 characters', () => {
+            assert.isNotNull(
+                validate('pipeline.get.yaml', models.pipeline.get, {
+                    stateChanger: 'x'.repeat(129)
+                }).error
+            );
+        });
+
+        it('rejects stateChangeMessage longer than 512 characters', () => {
+            assert.isNotNull(
+                validate('pipeline.get.yaml', models.pipeline.get, {
+                    stateChangeMessage: 'x'.repeat(513)
+                }).error
             );
         });
     });


### PR DESCRIPTION
## Context
Screwdriver supports enabling and disabling individual jobs to prevent builds from being created or executed for those jobs. This is useful for temporarily pausing specific parts of a pipeline without removing them.

However, for large pipelines with many jobs, managing this at the job level becomes time-consuming and inefficient — each job must be disabled individually. There is currently no way to disable an entire pipeline in one action.

Additionally, pipelines currently only support three states: ACTIVE, INACTIVE (used for child pipelines managed by a config pipeline), and DELETING. There is no first-class concept of a user-initiated disabled state at the pipeline level.

## Objective

- Add DISABLED to pipeline states (VALID_STATES_FOR_UPDATE restricts updates to ACTIVE/DISABLED)
- Add stateChanger, stateChangeTime, stateChangeMessage fields to pipeline model
- Add migration to add new columns to pipelines table
- Add/update tests for new state and fields

## References

https://github.com/screwdriver-cd/screwdriver/issues/3475

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
