### PR TITLE
fix(3491): Enable the UI to determine which start method is used [1]

### DIFF
--- a/models/event.js
+++ b/models/event.js
@@ -21,17 +21,20 @@ const STATUSES = [
 ];
 
 const START_ACTIONS = [
-    'start', // Start a new event from specific job
-    'restart' // Restart event from specific job
-    // If you need to identify whether to start from the `~commit` or from a specific job, please uncomment this line and use it.
-    // 'FULL_START', // Start a new event from "~commit"
+    'START_FROM_LATEST_COMMIT', // Start a new event from latest commit (e.g., Start from "~commit")
+    // Case of using parentEventId (e.g., Workflow graph tooltip)
+    'START_FROM_PARENT_EVENT', // Start a new event from specific parent event
+    'RESTART_FROM_PARENT_EVENT', // Restart a new event from specific parent event
+    // Case of using parentBuildId (e.g., Job list view and build log page)
+    'START_FROM_PARENT_BUILD', // Start a new event from specific parent build
+    'RESTART_FROM_PARENT_BUILD' // Restart a new event from specific parent build
 ];
 
 const startAction = Joi.string()
     .valid(...START_ACTIONS)
     .max(10)
     .description('Start method of the event')
-    .example('START');
+    .example('START_FROM_PARENT_EVENT');
 
 const MODEL = {
     id: Joi.number().integer().positive().description('Identifier of this event').example(123345),

--- a/models/event.js
+++ b/models/event.js
@@ -21,7 +21,7 @@ const STATUSES = [
 ];
 
 const START_ACTIONS = [
-    'START_FROM_LATEST_COMMIT', // Start a new event from latest commit (e.g., Start from "~commit")
+    'START_FROM_LATEST_COMMIT', // Start a new event from latest commit (e.g., Start from "~commit", Start by buildPeriodically annotation)
     // Case of using parentEventId (e.g., v2 UI workflow graph tooltip)
     'START_FROM_EVENT', // Start a new event from specific parent event
     'RESTART_FROM_EVENT', // Restart a new event from specific parent event

--- a/models/event.js
+++ b/models/event.js
@@ -22,11 +22,10 @@ const STATUSES = [
 
 const START_ACTIONS = [
     'START_FROM_LATEST_COMMIT', // Start a new event from latest commit (e.g., Start from "~commit")
-    // Case of using parentEventId (e.g., Workflow graph tooltip)
+    // Case of using parentEventId (e.g., v2 UI workflow graph tooltip)
     'START_FROM_EVENT', // Start a new event from specific parent event
     'RESTART_FROM_EVENT', // Restart a new event from specific parent event
-    // Case of using parentBuildId (e.g., Job list view and build log page)
-    'START_FROM_BUILD', // Start a new event from specific parent build
+    // Case of using buildId (e.g., Job list view, v1 UI workflow graph tooltip, and build log page)
     'RESTART_FROM_BUILD' // Restart a new event from specific parent build
 ];
 

--- a/models/event.js
+++ b/models/event.js
@@ -23,11 +23,11 @@ const STATUSES = [
 const START_ACTIONS = [
     'START_FROM_LATEST_COMMIT', // Start a new event from latest commit (e.g., Start from "~commit")
     // Case of using parentEventId (e.g., Workflow graph tooltip)
-    'START_FROM_PARENT_EVENT', // Start a new event from specific parent event
-    'RESTART_FROM_PARENT_EVENT', // Restart a new event from specific parent event
+    'START_FROM_EVENT', // Start a new event from specific parent event
+    'RESTART_FROM_EVENT', // Restart a new event from specific parent event
     // Case of using parentBuildId (e.g., Job list view and build log page)
-    'START_FROM_PARENT_BUILD', // Start a new event from specific parent build
-    'RESTART_FROM_PARENT_BUILD' // Restart a new event from specific parent build
+    'START_FROM_BUILD', // Start a new event from specific parent build
+    'RESTART_FROM_BUILD' // Restart a new event from specific parent build
 ];
 
 const startAction = Joi.string()

--- a/models/event.js
+++ b/models/event.js
@@ -20,6 +20,19 @@ const STATUSES = [
     'SUCCESS'
 ];
 
+const START_ACTIONS = [
+    'start', // Start a new event from specific job
+    'restart' // Restart event from specific job
+    // If you need to identify whether to start from the `~commit` or from a specific job, please uncomment this line and use it.
+    // 'FULL_START', // Start a new event from "~commit"
+];
+
+const startAction = Joi.string()
+    .valid(...START_ACTIONS)
+    .max(10)
+    .description('Start method of the event')
+    .example('START');
+
 const MODEL = {
     id: Joi.number().integer().positive().description('Identifier of this event').example(123345),
     parentEventId: Joi.number()
@@ -80,7 +93,7 @@ const MODEL = {
         .required()
 };
 
-const CREATE_MODEL = { ...MODEL, buildId, parentBuildId, parentBuilds, prNum };
+const CREATE_MODEL = { ...MODEL, startAction, buildId, parentBuildId, parentBuilds, prNum };
 
 module.exports = {
     /**
@@ -152,6 +165,7 @@ module.exports = {
             [
                 'pipelineId',
                 'startFrom',
+                'startAction',
                 'buildId',
                 'causeMessage',
                 'parentBuildId',

--- a/models/event.js
+++ b/models/event.js
@@ -31,7 +31,7 @@ const START_ACTIONS = [
 
 const startAction = Joi.string()
     .valid(...START_ACTIONS)
-    .max(10)
+    .max(24)
     .description('Start method of the event')
     .example('START_FROM_PARENT_EVENT');
 

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -1,6 +1,6 @@
 # Event Create Example
 startFrom: main
-startAction: "START"
+startAction: "START_FROM_BUILD"
 parentBuildId: 123
 parentEventId: 123456
 groupEventId: 123456

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -1,5 +1,6 @@
 # Event Create Example
 startFrom: main
+startAction: "START"
 parentBuildId: 123
 parentEventId: 123456
 groupEventId: 123456

--- a/test/data/event.create.full.yaml
+++ b/test/data/event.create.full.yaml
@@ -1,6 +1,6 @@
 # Event Create Example
 startFrom: main
-startAction: "START_FROM_BUILD"
+startAction: "START_FROM_LATEST_COMMIT"
 parentBuildId: 123
 parentEventId: 123456
 groupEventId: 123456


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

If you start a new event based on an event triggered by a branch-specific trigger, the branch is not properly inherited.
This is because `parentEventId` is not passed at the start.

However, if you simply pass `parentEventId` along, it will no longer be distinguishable from a restart, and the metadata will be carried over as well.
As a temporary fix for this issue, we can pass the `baseBranch` information from the UI on the payload.
However, I hesitate to implement this solution without following points:

Currently, the only way to determine which start method was used from the UI is by checking whether a specific property is included in the payload (e.g., buildId, parentEventId).
In this issues, the fundamental issue is that the start or restart method is determined based on the existence of specific properties.
In general, the methods for initiating actions from the UI are limited to a finite number of types that can be expressed using enumerations, such as STATUS.

Therefore, it should be possible to clearly distinguish the start method in the API by including the start method in the payload sent from the UI.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Make it possible to check which start method was used from the UI.
Furthermore, we will ensure that this information can be accepted as the payload in a POST request.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/3491

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
